### PR TITLE
Show a pass as a '.' in the "move number" in the move tree

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -2643,7 +2643,6 @@ export class GobanCanvas extends GobanCore  {
         }
 
         if (!viewport || (node.layout_cx >= viewport.minx && node.layout_cx <= viewport.maxx && node.layout_cy >= viewport.miny && node.layout_cy <= viewport.maxy)) {
-            console.log("Stone:", node);
             this.move_tree_drawStone(ctx, node, active_path_number, viewport);
         }
     }

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -2585,7 +2585,12 @@ export class GobanCanvas extends GobanCore  {
 
             case "move-number":
             default:
-                label = String(node.move_number);
+                if (node.pretty_coordinates === 'pass') {
+                    label = String('.');
+                }
+                else {
+                    label = String(node.move_number);
+                }
                 break;
         }
 
@@ -2638,6 +2643,7 @@ export class GobanCanvas extends GobanCore  {
         }
 
         if (!viewport || (node.layout_cx >= viewport.minx && node.layout_cx <= viewport.maxx && node.layout_cy >= viewport.miny && node.layout_cy <= viewport.maxy)) {
+            console.log("Stone:", node);
             this.move_tree_drawStone(ctx, node, active_path_number, viewport);
         }
     }


### PR DESCRIPTION
As a moderator, I need this all the time, so that when I get called to "timewasting" reports I can see at a glance where the reporter first passed, instead of trawling through the game to see where timewasting started.

I'd thought to dim the stone which is a pass, but that's a much deeper change (requiring modification to placeBlackStone, placeWhiteStone, so I went with this lightweight version.

<img width="1316" alt="Screen Shot 2020-03-25 at 2 02 26 pm (2)" src="https://user-images.githubusercontent.com/61894/77499376-d7f26b00-6ea1-11ea-9b77-d6c29fa44cd5.png">
