### PR TITLE
External goban image 

### DIFF
--- a/src/GoTheme.ts
+++ b/src/GoTheme.ts
@@ -19,11 +19,13 @@
 export interface GoThemeBackgroundCSS {
     'background-color'?: string;
     'background-image'?: string;
+	'background-size'?: string;
 }
 
 export interface GoThemeBackgroundReactStyles {
     'backgroundColor'?: string;
     'backgroundImage'?: string;
+	'backgroundSize'?: string;
 }
 
 export class GoTheme {

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -270,7 +270,8 @@ export interface GobanHooks {
     discWhiteStoneColor?: () => string;
     discWhiteTextColor?: () => string;
     plainBoardColor?: () => string;
-    plainBoardLineColor?: () => string;
+	plainBoardLineColor?: () => string;
+	plainBoardUrl?: () => string;
 
     addCoordinatesToChatInput?: (coordinates:string) => void;
     updateScoreEstimation?: (est_winning_color:"black"|"white", number_of_points:number) => void;

--- a/src/themes/board_plain.ts
+++ b/src/themes/board_plain.ts
@@ -39,7 +39,8 @@ export default function(GoThemes:GoThemesInterface) {
         getBackgroundCSS():GoThemeBackgroundCSS {
             return {
                 "background-color": GobanCore.hooks.plainBoardColor ? GobanCore.hooks.plainBoardColor() : '#DCB35C',
-                "background-image": ""
+                "background-image": GobanCore.hooks.plainBoardUrl ? "url('" + GobanCore.hooks.plainBoardUrl() + "')" : '',
+				"background-size": "cover"
             };
         }
         getLineColor():string { return GobanCore.hooks.plainBoardLineColor ? GobanCore.hooks.plainBoardLineColor() : '#000000'; }


### PR DESCRIPTION
**WARNING: This PR is co-dependant with [this one](https://github.com/online-go/online-go.com/pull/1179) on online-go.com**

---

The basic idea is to allow users to style their goban with a custom image in the form of supplying a link to an external picture. 

- I have changed the look of the plain board preview in the selector, to more intuitively represent the cutomizable nature
![Screenshot_2020-06-21 OGS](https://user-images.githubusercontent.com/27279102/85224143-68204d80-b3c8-11ea-836a-0e14b57aa6ea.png)

- Upon selecting the custom option an input form appears together with the color selectors, once the text is replaced with an image link, it will automatically update the board background. 
![Screenshot_2020-06-21 OGS(1)](https://user-images.githubusercontent.com/27279102/85224183-cc431180-b3c8-11ea-86cb-4a2ab8d242b6.png)

- in the future I was thinking of creating a similar option for the stones, together with two buttons allowing for playing one-color-go and blind-go easily. Let me know what you think about that.

---

Please note, this is my first barbecue with React. I mostly wanted to have a look around with a simple/fun project. If the code is not up to par, or if you think it was a stupid idea to begin with, don't be afraid to tell me to shove it :) 