### PR TITLE
Don't issue error messages on "stone_already_placed_here" exception

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -904,9 +904,12 @@ export class GobanCanvas extends GobanCore  {
 
         } catch (e) {
             delete this.move_selected;
-            console.info(e);
-            this.errorHandler(e);
-            this.emit("error");
+            // stone already placed is just to be ignored, it's not really an error.
+            if (e.message_id !== "stone_already_placed_here") {
+                console.info(e);
+                this.errorHandler(e);
+                this.emit("error");
+            }
             this.emit("update");
         }
     }


### PR DESCRIPTION
Sentry keeps getting "stone_already_placed_here" reports, and they appear in the console.

I don't think there's any reason for this: the goban raises this exception to bomb out of onClick processing, but it's not really an error.

this.errorHandler() already has a check to ignore this exception, but unfortunately at the level that this.errorHandler() is called there is another place (console.info(e) that is causing it to be reported.  Hence the need for this, I think.
