### PR TITLE
Rotate board feature

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1081,7 +1081,15 @@ export class GoEngine {
     }
     public rotateBoard():void {
         // rotates this.board by 90 degrees anti-clockwise
-        const N = 19; // board size
+        if (!this.config.width) {
+            console.log('rotateBoard: this.config.width is not defined. Aborting.');
+            return;
+        }
+        if (this.config.width !== this.config.height) {
+            console.log('rotateBoard: board size not square, aborting rotateBoard...');
+            return;
+        }
+        const N = this.config.width; // board size (width must be equal to height)
         for (let x = 0; x < Math.floor(N/2); x++) {
             for (let y = x; y < N-x-1; y++) {
                 let temp = this.board[x][y];

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1079,6 +1079,19 @@ export class GoEngine {
         }
         return false;
     }
+    public rotateBoard():void {
+        // rotates this.board by 90 degrees anti-clockwise
+        const N = 19; // board size
+        for (let x = 0; x < Math.floor(N/2); x++) {
+            for (let y = x; y < N-x-1; y++) {
+                let temp = this.board[x][y];
+                this.board[x][y] = this.board[y][N-1-x];
+                this.board[y][N-1-x] = this.board[N-1-x][N-1-y];
+                this.board[N-1-x][N-1-y] = this.board[N-1-y][x];
+                this.board[N-1-y][x] = temp;
+            }
+        }
+    }
     public editPlace(x:number, y:number, color:JGOFNumericPlayerColor, isTrunkMove?:boolean):void {
         let player = this.playerByColor(color);
 

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -637,6 +637,11 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         }
     }
 
+    public rotateBoard():void {
+        this.engine.rotateBoard();    
+        this.redraw();
+    }
+
     protected getClockDrift():number {
         if (GobanCore.hooks.getClockDrift) {
             return GobanCore.hooks.getClockDrift();

--- a/src/test.tsx
+++ b/src/test.tsx
@@ -213,6 +213,11 @@ function Main():JSX.Element {
                     }} />
             </div>
         </div>
+        <div className='inline-block'>
+            <div className='setting'>
+                <button onClick={() => fiddler.emit('rotateBoard')}>Rotate Board</button>
+            </div>
+        </div>
     </div>
 
 
@@ -249,6 +254,10 @@ function ReactGoban<GobanClass extends GobanCore>(ctor:{new(x:GobanCanvasConfig)
             goban.setSquareSize(ss)
             const end = Date.now();
             console.log("SSS time: ", end - start);
+        });
+
+        fiddler.on('rotateBoard', () => {
+            goban.rotateBoard();
         });
 
         fiddler.on('redraw', () => {


### PR DESCRIPTION
This is my attempt at implementing the rotate board feature as requested here: https://github.com/online-go/online-go.com/issues/819. 

Note this is a work in progress. I will be adding more commits later. Feel free to make changes/make suggestions.

This adds a `rotateBoard` method in `GoEngine.ts` and `GobanCore.ts`, which effectively rotates the internal 2D array `this.board` state. 

I've also added a a 'rotate board' button for testing purposes, which we can view by navigating to `http://0.0.0.0:9000/webpack-dev-server/` after running `npm run dev`.

TODO:

- [ ] Currently it only rotates the board for the current move number. Make it update the board for all moves in the move tree.
- [ ] Add functionality to rotate non-square board sizes as well.
- [ ] Integrate with the main online-go.com repository.

