### PR TITLE
Added start-time and end-time to GoEngineConfig declaration

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -109,6 +109,9 @@ export interface GoEngineConfig {
     score?:Score;
     outcome?:string;
 
+    start_time?:number;
+    end_time?:number;
+
     allow_self_capture?:boolean;
     automatic_stone_removal?:boolean;
     allow_ko?:boolean;


### PR DESCRIPTION
start-time and end-time are in the GoEngineConfig we get from the server, so declaration needed