### PR TITLE
Handle reviews properly in setScoringMode

### DIFF
--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -3031,7 +3031,11 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
             this.redraw(true);
             this.emit("update");
         } else {
-            this.setMode("play");
+            if (this.game_id) {
+                this.setMode("play");
+            } else {
+                this.setMode("analyze", true);
+            }
             this.redraw(true);
         }
 


### PR DESCRIPTION
When score estimation mode is exited during a review the mode is now set to "analyze" and the board is reset to the current move (as opposed to the original empty board position, which is the "last official move" when in a review).

This diff will have no user facing impact until the PR which adds score estimation in reviews to `online-go.com` is merged: https://github.com/online-go/online-go.com/pull/1272

**Side question for the developers**: Why does "Back to Game" in score estimation (for a real game, not a review) return to the last official move as opposed to the board position that the score was estimating (e.g. if the player had moved back in the move tree and then run score estimation)? I can change this behavior so that `esc` and "Back to Game" return to "current move" as opposed to "last official move" in this PR for games (not just reviews) if that seems reasonable to others, otherwise I'll leave as-is.