### PR TITLE
Fix stop estimating score

### DIFF
--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -3038,9 +3038,12 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
             this.redraw(true);
             this.emit("update");
         } else {
-            let dont_jump_to_official_move = (this.previous_mode === 'analyze' ||
-                                              this.previous_mode === 'conditional');
-            this.setToPreviousMode(dont_jump_to_official_move);
+            if (this.previous_mode === "analyze" ||
+                this.previous_mode === "conditional") {
+                this.setToPreviousMode(true);
+            } else {
+                this.setMode("play");
+            }
             this.redraw(true);
         }
 

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -2079,7 +2079,8 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         setTimeout(() => { this.setMode(mode); }, 1);
     }
     public setMode(mode:GobanModes, dont_jump_to_official_move?:boolean):boolean {
-        if (mode === "conditional" && this.player_id === this.engine.playerToMove()) {
+        if (mode === "conditional" && this.player_id === this.engine.playerToMove() &&
+            this.mode !== "score estimation") {
             /* this shouldn't ever get called, but incase we screw up.. */
             swal("Can't enter conditional move planning when it's your turn");
             return false;
@@ -3037,7 +3038,9 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
             this.redraw(true);
             this.emit("update");
         } else {
-            this.setToPreviousMode(true);
+            let dont_jump_to_official_move = (this.previous_mode === 'analyze' ||
+                                              this.previous_mode === 'conditional');
+            this.setToPreviousMode(dont_jump_to_official_move);
             this.redraw(true);
         }
 


### PR DESCRIPTION
Fixes these issues (will need to manually close these since they're in the `online-go` repo):
https://github.com/online-go/online-go.com/issues/1290
https://github.com/online-go/online-go.com/issues/1291

This fixes the bugs by doing two things:
1. Return to `play` mode and jump to official move unless we were previously in `analyze` or `conditional` mode (i.e. only allow this "feature" where we think it's safe, rather than allowing for exposing latent bugs when returning to different modes which was the cause of the above issues). This should fix the "staged submit move" by just jumping back to the official move.
2. Allow conditional mode even if it's the current players turn if we were previously in estimate score mode.