### PR TITLE
Fixed Goban error message on mobile and puzzle ko bug

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1000,7 +1000,9 @@ export class GoEngine {
                     }
                 }
 
-                if (checkForKo && !this.allow_ko && this.cur_move.move_number > 2) {
+                if (checkForKo && !this.allow_ko &&
+                    (this.cur_move.move_number > 2 ||
+                     (this.goban_callback && this.goban_callback.mode === 'puzzle'))) {
                     let current_state = this.getState();
                     if (!this.cur_move.edited && this.boardStatesAreTheSame(current_state, this.cur_move.index(-1).state)) {
                         throw new GobanMoveError(

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -2164,34 +2164,36 @@ export class GobanCanvas extends GobanCore  {
     public message(msg:string, timeout:number = 5000):void {
         this.clearMessage();
 
-        this.message_div = document.createElement('div');
-        this.message_div.className = "GobanMessage";
-        this.message_td = document.createElement("td");
-        let table = document.createElement("table");
-        let tr = document.createElement("tr");
-        tr.appendChild(this.message_td);
-        table.appendChild(tr);
-        this.message_div.appendChild(table);
-        this.message_text = document.createElement("div");
-        this.message_text.innerHTML = msg;
-        this.message_td.appendChild(this.message_text);
-        this.parent.appendChild(this.message_div);
+        window.setTimeout(() => {
+            this.message_div = document.createElement('div');
+            this.message_div.className = "GobanMessage";
+            this.message_td = document.createElement("td");
+            let table = document.createElement("table");
+            let tr = document.createElement("tr");
+            tr.appendChild(this.message_td);
+            table.appendChild(tr);
+            this.message_div.appendChild(table);
+            this.message_text = document.createElement("div");
+            this.message_text.innerHTML = msg;
+            this.message_td.appendChild(this.message_text);
+            this.parent.appendChild(this.message_div);
 
-        this.message_div.addEventListener("click", () => {
-            if (timeout > 0) {
-                this.clearMessage();
+            this.message_div.addEventListener("click", () => {
+                if (timeout > 0) {
+                    this.clearMessage();
+                }
+            });
+
+            if (!timeout) {
+                timeout = 5000;
             }
-        });
 
-        if (!timeout) {
-            timeout = 5000;
-        }
-
-        if (timeout > 0) {
-            this.message_timeout = window.setTimeout(() => {
-                this.clearMessage();
-            }, timeout);
-        }
+            if (timeout > 0) {
+                this.message_timeout = window.setTimeout(() => {
+                    this.clearMessage();
+                }, timeout);
+            }
+        }, 100);
     }
     public clearMessage():void {
         if (this.message_div) {


### PR DESCRIPTION
Fixes the following bugs:
- Ko's were not respected in puzzles if they occured within the first 3 moves. This is because pre-placed stones in the puzzle do not count towards the move count, which means Ko's can occur within the first 3 moves of the puzzle which is impossible in real games/reviews. Fixed this by ignoring the `this.cur_move.move_number > 2` check if we are in puzzle mode.
- Fixed Goban error message disappearing as soon as it appears on mobile due to "phantom click". Prevented this by delaying the message from rendering by 100ms, allowing the "phantom click" to occur before the `click` event handler has been registered for the message.

This screen capture shows both bugs that were fixed in this PR: https://streamable.com/x3qwqf