### PR TITLE
Added variation stone transparency support to Goban

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -1251,6 +1251,7 @@ export class GobanCanvas extends GobanCore  {
             ) {
                 //let color = stone_color ? stone_color : (this.move_selected ? this.engine.otherPlayer() : this.engine.player);
                 let transparent = false;
+                let stoneAlphaTransparencyValue = 0.6;
                 let color;
                 if (this.scoring_mode
                     && this.score_estimate
@@ -1303,6 +1304,7 @@ export class GobanCanvas extends GobanCore  {
                 else if (pos.black || pos.white) {
                     color = pos.black ? 1 : 2;
                     transparent = true;
+                    stoneAlphaTransparencyValue = this.variation_stone_transparency;
                 }
                 else {
                     color = this.engine.player;
@@ -1330,7 +1332,7 @@ export class GobanCanvas extends GobanCore  {
                     ctx.save();
                     let shadow_ctx:CanvasRenderingContext2D | null | undefined = this.shadow_ctx;
                     if (!stone_color || transparent) {
-                        ctx.globalAlpha = 0.6;
+                        ctx.globalAlpha = stoneAlphaTransparencyValue;
                         shadow_ctx = null;
                     }
                     if (shadow_ctx === undefined) {

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -119,6 +119,7 @@ export interface GobanConfig extends GoEngineConfig, PuzzleConfig {
     dont_draw_last_move?: boolean;
     one_click_submit?: boolean;
     double_click_submit?: boolean;
+    variation_stone_transparency?: number;
 
     //
     auth?:string;
@@ -293,6 +294,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
     //public black_pause_text: string;
     public conditional_tree:GoConditionalMove = new GoConditionalMove(null);
     public double_click_submit: boolean;
+    public variation_stone_transparency: number;
     public draw_bottom_labels:boolean;
     public draw_left_labels:boolean;
     public draw_right_labels:boolean;
@@ -474,6 +476,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         this.game_type = config.game_type || "";
         this.one_click_submit = "one_click_submit" in config ? !!config.one_click_submit : false;
         this.double_click_submit = "double_click_submit" in config ? !!config.double_click_submit : true;
+        this.variation_stone_transparency = typeof config.variation_stone_transparency !== 'undefined' ? config.variation_stone_transparency : 0.6;
         this.original_square_size = config.square_size || "auto";
         //this.square_size = config["square_size"] || "auto";
         this.interactive = !!config.interactive;


### PR DESCRIPTION
This change allows for a custom variation stone transparency level. It will have no effect until the corresponding OGS PR merges: https://github.com/online-go/online-go.com/pull/1317