### PR TITLE
Removed ko check that is likely unnecessary

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1000,9 +1000,7 @@ export class GoEngine {
                     }
                 }
 
-                if (checkForKo && !this.allow_ko &&
-                    (this.cur_move.move_number > 2 ||
-                     (this.goban_callback && this.goban_callback.mode === 'puzzle'))) {
+                if (checkForKo && !this.allow_ko) {
                     let current_state = this.getState();
                     if (!this.cur_move.edited && this.boardStatesAreTheSame(current_state, this.cur_move.index(-1).state)) {
                         throw new GobanMoveError(


### PR DESCRIPTION
See discussion here: https://forums.online-go.com/t/illegal-ko-move/32389/4

Text copied from post:

> From testing it out it doesn't seem like anything goes wrong (or explodes), but I haven't tried too many edge cases (not sure what they would be). This logic seems do the "correct" thing (return false) when evaluated on the first move (i.e. there is no previous move): `this.boardStatesAreTheSame(current_state, this.cur_move.index(-1).state)`
> 
> However, this doesn't fully solve the forked game issue. As we check for ko by determining if the previous board state is the same, a game without an earlier move tree will never find a ko on the first move even though this is possible in a forked game (e.g. forking this game: https://beta.online-go.com/game/9717).
> 
> If we copied move history, then removing `move_number > 2` should be enough to solve the problem. Seems like adding captures/history is blocked on an API change though, so not something I can push through on the client side: https://github.com/online-go/online-go.com/issues/508
> 
> Still, even though this isn't fully solved the behavior is better with `move_number > 2` removed since it will now detect if a ko occurs on the second or third move which it wouldn't before (and also it simplifies the code). I've published a PR, but we might want to test on beta for a bit before pushing live (or feel free to send me more test cases and I'll be happy to try them out on dev).