### PR TITLE
Show '?' on latest move if there is an undo request for it.

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -1644,16 +1644,30 @@ export class GobanCanvas extends GobanCore  {
                         draw_last_move = false;
                     }
                     else {
-                        ctx.beginPath();
-                        ctx.strokeStyle = color;
-                        ctx.lineWidth = this.square_size * 0.075;
-                        let r = this.square_size * 0.25;
-                        if (this.submit_move) {
-                            //ctx.globalAlpha = 0.6;
-                            r = this.square_size * 0.30;
+                        if (this.engine.undo_requested && this.visual_undo_request_indicator && this.engine.undo_requested === this.engine.cur_move.move_number) {
+                            const letter = '?';
+                            ctx.save();
+                            ctx.fillStyle = color;
+                            let metrics = ctx.measureText(letter);
+                            let xx = cx - metrics.width / 2;
+                            let yy = cy + (/WebKit|Trident/.test(navigator.userAgent) ? this.square_size * -0.03 : 1); /* middle centering is different on firefox */
+                            ctx.textBaseline = "middle";
+                            ctx.fillText(letter, xx, yy);
+                            draw_last_move = false;
+                            ctx.restore();
                         }
-                        ctx.arc(cx, cy, r, 0, 2 * Math.PI, false);
-                        ctx.stroke();
+                        else {
+                            ctx.beginPath();
+                            ctx.strokeStyle = color;
+                            ctx.lineWidth = this.square_size * 0.075;
+                            let r = this.square_size * 0.25;
+                            if (this.submit_move) {
+                                //ctx.globalAlpha = 0.6;
+                                r = this.square_size * 0.30;
+                            }
+                            ctx.arc(cx, cy, r, 0, 2 * Math.PI, false);
+                            ctx.stroke();
+                        }
                     }
                 }
 

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -120,6 +120,7 @@ export interface GobanConfig extends GoEngineConfig, PuzzleConfig {
     one_click_submit?: boolean;
     double_click_submit?: boolean;
     variation_stone_transparency?: number;
+    visual_undo_request_indicator?: boolean;
 
     //
     auth?:string;
@@ -299,6 +300,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
     public draw_left_labels:boolean;
     public draw_right_labels:boolean;
     public draw_top_labels:boolean;
+    public visual_undo_request_indicator: boolean;
     public abstract engine: GoEngine;
     public height:number;
     public last_clock?:AdHocClock;
@@ -476,6 +478,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         this.one_click_submit = "one_click_submit" in config ? !!config.one_click_submit : false;
         this.double_click_submit = "double_click_submit" in config ? !!config.double_click_submit : true;
         this.variation_stone_transparency = typeof config.variation_stone_transparency !== 'undefined' ? config.variation_stone_transparency : 0.6;
+        this.visual_undo_request_indicator = "visual_undo_request_indicator" in config ? !!config.visual_undo_request_indicator : false;
         this.original_square_size = config.square_size || "auto";
         //this.square_size = config["square_size"] || "auto";
         this.interactive = !!config.interactive;
@@ -915,7 +918,9 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
                 this.engine.undo_requested = parseInt(move_number);
                 this.emit("update");
                 this.emit('audio-undo-requested');
-
+                if (this.visual_undo_request_indicator) {
+                    this.redraw(true);  // need to update the mark on the last move
+                }
             });
             this._socket_on(prefix + "undo_accepted", ():void => {
                 if (this.disconnectedFromGame) { return; }


### PR DESCRIPTION
Some people would like [a visual indication if they have received an undo request](https://forums.online-go.com/t/wish-better-noticeable-undo-requests/964/70?u=eugene).

This change provides a preference setting to indicate that this is desired, and puts a '?' on the latest move if there is an undo request on it.

It does _not_ try to colour the '?' red as some requested, because that is an absolute can of worms - the 'standard' black stone has a white highlight on it, which causes a red question mark to look bad-contrast.    Not to mention what happens with themes.

This implementation assumes that the colour that has been selected for other marks to be drawn on the stones is the right one.
