### PR TITLE
Fix sgf dead stones

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -29,6 +29,9 @@ import { AdHocPackedMove } from './AdHocFormat';
 import {_} from "./translate";
 
 
+declare const CLIENT:boolean;
+declare const SERVER:boolean;
+
 export const AUTOSCORE_TRIALS = 1000;
 export const AUTOSCORE_TOLERANCE = 0.30;
 
@@ -500,7 +503,8 @@ export class GoEngine {
         if (config.removed) {
             removed = this.decodeMoves(config.removed);
         }
-        if (!this.territory_included_in_sgf &&
+        if (CLIENT &&
+            !this.territory_included_in_sgf &&
             typeof(config.removed) === "undefined" &&
             config.original_sgf &&
             (/[0-9.]+/.test(self.outcome))) {

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -499,8 +499,10 @@ export class GoEngine {
         if (config.removed) {
             removed = this.decodeMoves(config.removed);
         }
-        if (typeof(config.removed) === "undefined" && config.original_sgf &&
-            config.outcome !== "Resignation") {
+        if (typeof(config.removed) === "undefined" &&
+            config.original_sgf &&
+            typeof(config.outcome) !== "undefined" &&
+            (/[0-9.]+/.test(config.outcome))) {
             // 2021-01-05: Game data for SGF uploaded games currently don't include
             // removed stones, so we use score estimator to find probably dead stones to get a
             // closer approximation of what territories should be marked in the final board

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -506,8 +506,9 @@ export class GoEngine {
             // closer approximation of what territories should be marked in the final board
             // position.
             //
-            // NOTE: Some Go clients do include dead stones in their SGFs, so this is something
-            // we may be able to support in the future.
+            // NOTE: Some Go clients do include dead stones in their SGFs, however we ignore them,
+            // so this is something we may be able to support in the future with a server side
+            // change so we wouldn't require this hack.
             let se = new ScoreEstimator(this.goban_callback, this, AUTOSCORE_TRIALS, AUTOSCORE_TOLERANCE);
             removed = this.decodeMoves(se.getProbablyDead());
         }

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -501,8 +501,8 @@ export class GoEngine {
         }
         if (typeof(config.removed) === "undefined" &&
             config.original_sgf &&
-            typeof(config.outcome) !== "undefined" &&
-            (/[0-9.]+/.test(config.outcome))) {
+            typeof(self.outcome) !== "undefined" &&
+            (/[0-9.]+/.test(self.outcome))) {
             // 2021-01-05: Game data for SGF uploaded games currently don't include
             // removed stones, so we use score estimator to find probably dead stones to get a
             // closer approximation of what territories should be marked in the final board

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -499,7 +499,8 @@ export class GoEngine {
         if (config.removed) {
             removed = this.decodeMoves(config.removed);
         }
-        if (typeof(config.removed) === "undefined" && config.original_sgf) {
+        if (typeof(config.removed) === "undefined" && config.original_sgf &&
+            config.outcome !== "Resignation") {
             // 2021-01-05: Game data for SGF uploaded games currently don't include
             // removed stones, so we use score estimator to find probably dead stones to get a
             // closer approximation of what territories should be marked in the final board
@@ -1506,6 +1507,11 @@ export class GoEngine {
         }
         if ("ladder" in config) {
             delete config["ladder"];
+        }
+
+        if (config.outcome === "resign") {
+            // SGF games have this non-standard outcome, so we correct it.
+            config.outcome = "Resignation";
         }
 
         if (config.black_player_id || config.white_player_id) {

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -15,6 +15,8 @@
  */
 
 import {
+    AUTOSCORE_TRIALS,
+    AUTOSCORE_TOLERANCE,
     GoEngine,
     GoEngineConfig,
     GoEnginePhase,
@@ -50,8 +52,6 @@ export const GOBAN_FONT =  "Verdana,Arial,sans-serif";
 
 export const SCORE_ESTIMATION_TRIALS = 1000;
 export const SCORE_ESTIMATION_TOLERANCE = 0.30;
-export const AUTOSCORE_TRIALS = 1000;
-export const AUTOSCORE_TOLERANCE = 0.30;
 export const MARK_TYPES:Array<keyof MarkInterface> = ["letter", "circle", "square", "triangle", "sub_triangle", "cross", "black", "white"];
 
 let last_goban_id = 0;


### PR DESCRIPTION
Fixes #27 

This change uses the score estimator to find dead stones in SGF uploaded games, since they don't include `gamedata.removed` (even if the SGF did include dead stones). This makes the final territory marking more accurate.

In the resignation case, there was just a small bug where `outcome: resign` instead of `outcome: Resignation` in the game data, causing it to improperly render marks on the board for SGF games that resulted in resignation.

Both of these changes should now make SGF final board state rendering much closer to their native OGS game counterparts.

Before (when game ends in resignation):
![image](https://user-images.githubusercontent.com/4645409/103693254-da641400-4f4d-11eb-9f82-1b2421f6ec71.png)

After (when game ends in resignation):
![image](https://user-images.githubusercontent.com/4645409/103693102-9bce5980-4f4d-11eb-8bf5-6fadc8f86eab.png)

Before (when game ends with score):
![image](https://user-images.githubusercontent.com/4645409/103692001-fff01e00-4f4b-11eb-8c3c-d7130d89b829.png)

After (when game ends with score):
![image](https://user-images.githubusercontent.com/4645409/103691898-d33c0680-4f4b-11eb-86ee-843d6b7fb744.png)

Once OGS server-side supports parsing dead stones from SGFs the `gamedata.removed` string will be set in the game payload, and then this logic won't trigger and we'll properly use that instead. (EDIT: this statement may not be out of date since I added TW/TB support to `parseSGF`).

EDIT: I added `TW`/`TB` parsing support, so if those properties are present we'll defer to that rather than the score estimator.