### PR TITLE
Parsed outcome from SGF on load if missing

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -2115,6 +2115,45 @@ export class GoEngine {
                                 if (val[0].toLowerCase() === "w") {
                                     self.winner = "white";
                                 }
+
+                                if (self.outcome === "") {
+                                    let result;
+                                    let match = val.match(/[BW]\+(.*)/);
+                                    if (match === null) {
+                                        result = val;
+                                    } else {
+                                        result = match[1];
+                                    }
+
+                                    if (match !== null && !isNaN(result as any)) {
+                                        // There's a numeric score.
+                                        self.outcome = result;
+                                    } else {
+                                        switch (result[0].toUpperCase()) {
+                                            case "0": // Draw.
+                                            case "D": // Draw.
+                                                self.outcome = "0";
+                                                break;
+                                            case "R": // Resignation.
+                                                self.outcome = "Resignation";
+                                                break;
+                                            case "T": // Timeout.
+                                                self.outcome = "Timeout";
+                                                break;
+                                            case "F": // Forfeit.
+                                                // Disqualification seems the closest to forfeit.
+                                                self.outcome = "Disqualification";
+                                                break;
+                                            case "V": // Void.
+                                            case "?": // Unknown.
+                                                self.outcome = "";
+                                                break;
+                                            default:
+                                                self.outcome = "";
+                                                console.warn(`Unknown result: ${result}`);
+                                        }
+                                    }
+                                }
                             });
                         }
                         break;

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -2125,7 +2125,7 @@ export class GoEngine {
                                         result = match[1];
                                     }
 
-                                    if (match !== null && !isNaN(result as any)) {
+                                    if (match !== null && /[0-9.]+/.test(result)) {
                                         // There's a numeric score.
                                         self.outcome = result;
                                     } else {


### PR DESCRIPTION
Fixes #26

Before:
![image](https://user-images.githubusercontent.com/4645409/103802336-d5fa3280-5003-11eb-81ea-c7e917be62bb.png)

After:
![image](https://user-images.githubusercontent.com/4645409/103802118-8582d500-5003-11eb-81b6-e89885acde38.png)

Another benefit that you can see from the screenshot is that we properly recognize that territory shouldn't be scored since it's a "timeout".

Opened new issue to track the server side change still required to fix the SGF library page showing "?" (which actually looks like this should fix as well, so hopefully a noop after deploy): https://github.com/online-go/online-go.com/issues/1348