### PR TITLE
Fixed unrecognized resignation outcome string

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1515,8 +1515,8 @@ export class GoEngine {
             delete config["ladder"];
         }
 
-        if (config.outcome === "resign") {
-            // SGF games have this non-standard outcome, so we correct it.
+        if (config.outcome === "resign" || config.outcome === "r") {
+            // SGF games sometimes have these non-standard outcomes, so we correct it.
             config.outcome = "Resignation";
         }
 


### PR DESCRIPTION
Game data has `outcome: 'r'` for these SGF uploaded games which I've never seen before, leading to incorrectly marking territory:
https://online-go.com/game/30411889
https://online-go.com/game/28824220

The SGFs seem to be properly formatted, so not sure what's going wrong in the server side parser. @anoek Did something recently change? I've never seen `r` before as an outcome.

This fixes the issue by handling the new outcome and correcting it to a recognized outcome type so that territory isn't marked.

Before (1):
![Screenshot 2021-01-30 085812](https://user-images.githubusercontent.com/4645409/106362955-85ac8280-62da-11eb-85f5-e09a7814d5a9.jpg)

After (1):
![image](https://user-images.githubusercontent.com/4645409/106362980-9d840680-62da-11eb-827d-837ebee3541d.png)

Before (2):
![Screenshot 2021-01-30 085850](https://user-images.githubusercontent.com/4645409/106362960-89d8a000-62da-11eb-8cbc-30a1dad4468b.jpg)

After (2):
![image](https://user-images.githubusercontent.com/4645409/106363005-b7254e00-62da-11eb-81eb-f27331220208.png)