### PR TITLE
Goban 2021.10.10 issue #1491 on online-go.com - Unreadable AI evaluation text when using dark theme boards #1491

### DIFF
--- a/src/themes/board_plain.ts
+++ b/src/themes/board_plain.ts
@@ -70,7 +70,7 @@ export default function(GoThemes:GoThemesInterface) {
         getFadedLineColor():string { return "#333333"; }
         getStarColor():string { return "#555555"; }
         getFadedStarColor():string { return "#333333"; }
-        getBlankTextColor():string { return "#777777"; }
+        getBlankTextColor():string { return "#ffffff"; }
         getLabelTextColor():string { return "#555555"; }
     }
 
@@ -94,7 +94,7 @@ export default function(GoThemes:GoThemesInterface) {
         getFadedLineColor():string { return "#00AFBF"; }
         getStarColor():string { return HNG.C; }
         getFadedStarColor():string { return "#00AFBF"; }
-        getBlankTextColor():string { return HNG.C2; }
+        getBlankTextColor():string { return "#000000"; }
         getLabelTextColor():string { return HNG.C2; }
     }
 
@@ -117,7 +117,7 @@ export default function(GoThemes:GoThemesInterface) {
         getFadedLineColor():string { return "#4481B5"; }
         getStarColor():string { return HNGNight.C; }
         getFadedStarColor():string { return "#4481B5"; }
-        getBlankTextColor():string { return "#3591DE"; }
+        getBlankTextColor():string { return "#ffffff"; }
         getLabelTextColor():string { return "#4481B5"; }
     }
 

--- a/src/themes/board_woods.ts
+++ b/src/themes/board_woods.ts
@@ -128,7 +128,7 @@ export default function(GoThemes:GoThemesInterface) {
         getFadedLineColor():string { return "#888888"; }
         getStarColor():string { return "#cccccc"; }
         getFadedStarColor():string { return "#888888"; }
-        getBlankTextColor():string { return "#cccccc"; }
+        getBlankTextColor():string { return "#ffffff"; }
         getLabelTextColor():string { return "#cccccc"; }
     }
 


### PR DESCRIPTION
### Summary
[Issue was the AI evaluation text was difficult to read on dark boards](https://github.com/online-go/online-go.com/issues/1491). The fix was:
* Granite board: white AI evaluation text.
* Night board: white AI evaluation text.
* HNE night: white AI evaluation text.
* HNE: black AI evaluation text (white looks slightly worse with the bright light blue board, black stands out better in the blue circle thingy).

### Images
See changes below:
<img width="960" alt="granite_board_white_color" src="https://user-images.githubusercontent.com/47124313/136690065-6469bc19-8e83-4423-a85f-5e7518ea65d4.png">
<img width="960" alt="Night_board_white_color" src="https://user-images.githubusercontent.com/47124313/136690078-2a2b80ca-c0d9-486b-92bd-a5edb0c9be78.png">
<img width="960" alt="HNE_Night_board_white_color" src="https://user-images.githubusercontent.com/47124313/136690064-b2668354-16b2-4b4c-b116-1988a6e2d399.png">
<img width="960" alt="HNE_board_black_color" src="https://user-images.githubusercontent.com/47124313/136690071-9161609d-da9c-48bc-8825-a734da5b364c.png">


