### PR TITLE
AIReview updates

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -15,7 +15,7 @@
  */
 
 import { GobanMoveError } from "./GobanError";
-import { MoveTree, MoveTreeJson, MarkInterface } from "./MoveTree";
+import { MoveTree, MoveTreeJson } from "./MoveTree";
 import {
     GoMath,
     Move,
@@ -183,7 +183,7 @@ export interface ReviewMessage {
     "undo"?:boolean; /* offical undo [reviewing live game] */
     "t"?:string;   /* text */
     "t+"?:string;  /* text append */
-    "k"?:MarkInterface;   /* marks */
+    "k"?:{[mark: string] : string};   /* marks */
     "pp"?:[number, number];  /* pen point */
     "pen"?: string; /* pen color / pen start */
     "chat"?: {

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -2331,9 +2331,9 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         });
     }
 
-    public setMarks(marks:MarkInterface, dont_draw?:boolean):void {
+    public setMarks(marks: { [mark: string]: string }, dont_draw?:boolean):void {
         for (let key in marks) {
-            let locations = this.engine.decodeMoves(marks[key] as string);
+            let locations = this.engine.decodeMoves(marks[key]);
             for (let i = 0; i < locations.length; ++i) {
                 let pt = locations[i];
                 this.setMark(pt.x, pt.y, key, dont_draw);
@@ -3014,7 +3014,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
             let msg:ReviewMessage;
 
             if (!msg_override) {
-                let marks:MarkInterface = {};
+                let marks: {[mark:string]: string} = {};
                 for (let y = 0; y < this.height; ++y) {
                     for (let x = 0; x < this.width; ++x) {
                         let pos = this.getMarks(x, y);

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -36,8 +36,8 @@ export interface MarkInterface {
     stone_removed?    : boolean;
     mark_x?           : boolean;
     hint?             : boolean;
-    black?            : boolean;
-    white?            : boolean;
+    black?            : boolean | string;
+    white?            : boolean | string;
     color?            : string;
 
     [label: string]: string | boolean | undefined;

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -36,8 +36,8 @@ export interface MarkInterface {
     stone_removed?    : boolean;
     mark_x?           : boolean;
     hint?             : boolean;
-    black?            : boolean | string;
-    white?            : boolean | string;
+    black?            : boolean;
+    white?            : boolean;
     color?            : string;
 
     [label: string]: string | boolean | undefined;


### PR DESCRIPTION
- Add ability to use score as the metric for "Key Moves"
    - I did it with an additional parameter to allow for score instead of win rate.  Perhaps that puts too much onus on the API clients?  Let me know if I should move more logic into this function.
- Change type definition for SetMarks (I don't think it's actually meant to handle a MarkInterface proper)