### PR TITLE
Take out TSLint rules that look like they do formatting.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -19,28 +19,16 @@
         "no-angle-bracket-type-assertion": true,
         "no-arg": true,
         "no-conditional-assignment": true,
-        "no-consecutive-blank-lines": [
-            true,
-            3
-        ],
         "no-construct": true,
         "no-debugger": true,
         "no-eval": true,
         "no-floating-promises": true,
         "no-internal-module": true,
-        "no-trailing-whitespace": true,
         "no-unnecessary-initializer": true,
         "no-unsafe-finally": true,
         "no-invalid-this": [true, "check-function-in-method"],
         "no-var-keyword": true,
         "no-var-requires": true,
-        "one-line": [
-            true,
-            "check-catch",
-            "check-finally",
-            "check-open-brace",
-            "check-whitespace"
-        ],
         "one-variable-per-declaration": [
             true,
             "ignore-for-loop"
@@ -50,41 +38,15 @@
             "allow-declarations",
             "allow-named-functions"
         ],
-        "semicolon": [
-            true,
-            "always"
-        ],
-        "space-before-function-paren": [
-            true,
-            "never"
-        ],
         "triple-equals": [
             true,
             "allow-null-check",
             "allow-undefined-check"
         ],
-        "typedef-whitespace": [
-            true,
-            {
-                "call-signature": "nospace",
-                "index-signature": "nospace",
-                "parameter": "nospace",
-                "property-decl  aration": "nospace",
-                "variable-declaration": "nospace"
-            }
-        ],
         "use-isnan": true,
         "variable-name": [
             true,
             "ban-keywords"
-        ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-preblock"
         ]
     }
 }


### PR DESCRIPTION
I don't know if this is all of them, but this is a quick fix for some prettier conflicts @GreenAsJade bumped into.

Long-term plan is to nix TSLint in favor of ESLint, hence why not a more thorough investigation of prettier compatibility.