### PR TITLE
make handicap adjustment apply under Japanese rules with the (basic) score estimator, since it uses area counting

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -2644,9 +2644,9 @@ export class GoEngine extends TypedEventEmitter<Events> {
     }
     /* Returns the amount of points that should be given to white for any
      * handicap stones in the game. */
-    public getHandicapPointAdjustmentForWhite(): number {
+    public getHandicapPointAdjustmentForWhite(assume_area_counting: boolean = false): number {
         let ret = 0;
-        if (this.score_handicap) {
+        if (this.score_handicap || (assume_area_counting && !this.score_stones)) {
             if (this.aga_handicap_scoring && this.handicap > 0) {
                 ret = this.handicap - 1;
             } else {

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -478,7 +478,7 @@ export class ScoreEstimator {
             trials,
             tolerance,
         );
-        estimated_score -= this.engine.getHandicapPointAdjustmentForWhite();
+        estimated_score -= this.engine.getHandicapPointAdjustmentForWhite(true);
         const ownership = GoMath.makeMatrix(this.width, this.height, 0);
         i = 0;
         for (let y = 0; y < this.height; ++y) {


### PR DESCRIPTION
This should fix the issue with wrong Japanese scoring:

https://github.com/online-go/online-go.com/issues/1610

We should test a variety of combinations of rules and handicaps before releasing this change!