### PR TITLE
Tell clients who played a move that was clicked on

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -521,6 +521,9 @@ export class GoEngine extends TypedEventEmitter<Events> {
                             this.cur_move.player_update = mv.player_update;
                             this.updatePlayers(mv.player_update);
                         }
+                        if (mv.played_by) {
+                            this.cur_move.played_by = mv.played_by;
+                        }
                     } catch (e) {
                         if (this.throw_all_errors) {
                             throw e;

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -3132,6 +3132,18 @@ export class GobanCanvas extends GobanCore {
                         this.syncReviewMove();
                         this.redraw();
                     }
+                    if (this.engine.cur_move.played_by) {
+                        // note that getRelativeEventPosition handles various
+                        // nasty looking things to do with Touch etc, so using it here
+                        // gets around that kind of thing, even though in theory it
+                        // might be nicer to sent the client absolute coods, maybe.
+                        const rpos = getRelativeEventPosition(event);
+                        this.emit("played-by-click", {
+                            player_id: this.engine.cur_move.played_by,
+                            x: rpos.x,
+                            y: rpos.y,
+                        });
+                    }
                 }
             } catch (e) {
                 console.error(e);

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -219,6 +219,11 @@ export interface Events {
     "chat-remove": { chat_ids: Array<string> };
     "move-made": never;
     "player-update": JGOFPlayerSummary;
+    "played-by-click": {
+        player_id: number;
+        x: number;
+        y: number;
+    };
     "review.sync-to-current-move": never;
     "review.updated": never;
     "review.load-start": never;
@@ -1120,6 +1125,10 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
                         //console.log("`move` got player update:", the_move.player_update);
                         this.engine.cur_move.player_update = the_move.player_update;
                         this.engine.updatePlayers(the_move.player_update);
+                    }
+
+                    if (the_move.played_by) {
+                        this.engine.cur_move.played_by = the_move.played_by;
                     }
 
                     this.setLastOfficialMove();

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -103,6 +103,7 @@ export class MoveTree {
     public state: GoEngineState;
     public pen_marks: MoveTreePenMarks = [];
     public player_update: JGOFPlayerSummary | undefined;
+    public played_by: number | undefined;
 
     /* public for use by renderer */
     public active_path_number: number = 0;


### PR DESCRIPTION
The server sends played_by for rengo moves.

This change takes advantage of that to emit a played-by-clicked event when a person clicks on a move with this information in the move tree.

Which in turn lets clients tell the user who played that move.
