### PR TITLE
Generate a UMD module with webpack.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,7 +77,11 @@ module.exports = (env, argv) => {
 
             output: {
                 path: __dirname + '/lib',
-                filename: production ? '[name].min.js' : '[name].js'
+                filename: production ? '[name].min.js' : '[name].js',
+                library: {
+                    name: "goban",
+                    type: "umd",
+                },
             },
 
             module: {


### PR DESCRIPTION
I'm not sure if this is the correct solution (I'm kind of getting my feet wet with webpack), but I'll try to explain the problem and proposed solution below.

## Problem

When I try to instantiate a `Goban` in tests, I get the following error:

```
goban_1.Goban is not a constructor
```

When I log the value of `Goban`, I get `undefined`, and if I try to log the `goban` module itself, it is an empty object.

The reason this happens is that webpack is configured by default to be "imported" via the `script` tag.  However, jest doesn't have an html file where we can load scripts.

## Solution

This PR has webpack build the module as [UMD](https://github.com/umdjs/umd).  That means that it can be imported as `CommonJS` in addition to the `script` way.

### Possible concerns

- Does this mess with any existing deployment flows?
- Overhead (if I'm reading the webpack output correctly, overhead is negligible)
- AFAIK, [UMD does not support ES6 imports](https://stackoverflow.com/questions/54774822/is-webpack-librarytarget-umd-supposed-to-work-with-es6-modules), but I don't think this is aproblem since TS is transpiling the imports anyway.

## Benefit

Tests like these:

```
import { Goban } from "goban";

    ...

test("does not display undo button if current user is not a participant.", () => {
    const goban = new Goban({ game_id: 1234 });
    data.set("user", TEST_USER);

    render(<PlayControls goban={goban} {...PLAY_CONTROLS_DEFAULTS} user_is_player={false} />);

    expect(screen.queryByText("Undo")).toBeNull();
});
```

See https://github.com/online-go/online-go.com/pull/1840 for a full demonstration (the tests only pass if `goban` has this change).