### PR TITLE
add setCoordinates function that triggers a rerender

### DIFF
--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -64,6 +64,13 @@ export const MARK_TYPES: Array<keyof MarkInterface> = [
     "black",
     "white",
 ];
+export type LabelPosition =
+    | "all"
+    | "none"
+    | "top-left"
+    | "top-right"
+    | "bottom-right"
+    | "bottom-left";
 
 let last_goban_id = 0;
 
@@ -1914,6 +1921,15 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         }
 
         this.setSquareSize(Math.floor(this.display_width / n_squares));
+    }
+
+    public setCoordinates(label_position: LabelPosition) {
+        this.draw_top_labels = label_position === "all" || label_position.indexOf("top") >= 0;
+        this.draw_left_labels = label_position === "all" || label_position.indexOf("left") >= 0;
+        this.draw_right_labels = label_position === "all" || label_position.indexOf("right") >= 0;
+        this.draw_bottom_labels = label_position === "all" || label_position.indexOf("bottom") >= 0;
+        this.setSquareSizeBasedOnDisplayWidth(Number(this.display_width));
+        this.redraw(true);
     }
 
     public setStrictSekiMode(tf: boolean): void {


### PR DESCRIPTION
There are two problems with the current way of toggling coordinates:

1) top, bottom, left, and right must be set even though the caller usually wants to set "bottom-right", "all", "top-left" etc.
2) Square sizes are not recalculated and a rerender is not triggered by setting any of the coordinate labels.

The call-site (in the React repo) will change in the following way:

```diff
- goban.current.draw_top_labels =
-     label_position === "all" || label_position.indexOf("top") >= 0;
- goban.current.draw_left_labels =
-     label_position === "all" || label_position.indexOf("left") >= 0;
- goban.current.draw_right_labels =
-     label_position === "all" || label_position.indexOf("right") >= 0;
- goban.current.draw_bottom_labels =
-     label_position === "all" || label_position.indexOf("bottom") >= 0;
- goban.current.redraw(true);
- onResize();  // calls setSquareSizeBasedOnDisplayWidth() with a calculated display width
+ goban.current.setCoordinates(label_position);
```

