### PR TITLE
Use MA instead of XX for SGF exports.

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -2459,7 +2459,8 @@ export class GoEngine extends TypedEventEmitter<Events> {
                     case "TR":
                     case "CR":
                     case "SQ":
-                    case "XX":
+                    case "XX": // Legacy
+                    case "MA":
                         {
                             instructions.push(() => {
                                 try {
@@ -2482,7 +2483,8 @@ export class GoEngine extends TypedEventEmitter<Events> {
                                         case "SQ":
                                             marks.square = true;
                                             break;
-                                        case "XX":
+                                        case "XX": // Legacy - Old OGS SGF used XX to denote an X
+                                        case "MA":
                                             marks.cross = true;
                                             break;
                                     }

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -603,7 +603,7 @@ export class MoveTree {
                             ret += "SQ[" + pos + "]";
                         }
                         if (m.cross) {
-                            ret += "XX[" + pos + "]";
+                            ret += "MA[" + pos + "]";
                         }
                         if (m.circle) {
                             ret += "CR[" + pos + "]";


### PR DESCRIPTION
MA is the officially supported property for marking points with an X: https://www.red-bean.com/sgf/properties.html#MA

This pull request aims to maintain backwards compatibility.  Newly exported SGFs will use the MA field, but the XX field will still be recognized when reading a "legacy" SGF in.

## Additional Context

https://forums.online-go.com/t/ogs-seems-to-not-respect-the-sgf-standard-with-the-x-marking/43361/2