### PR TITLE
Fix disable_analysis setting in rengo games

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -531,8 +531,7 @@ export class GoEngine extends TypedEventEmitter<Events> {
                 typeof window !== "undefined" &&
                 typeof (window as any)["user"] !== "undefined" &&
                 (window as any)["user"] &&
-                ((window as any)["user"].id as number) !== this.players.black.id &&
-                ((window as any)["user"].id as number) !== this.players.white.id
+                !this.isParticipant((window as any)["user"].id)
             ) {
                 this.disable_analysis = false;
                 this.config.disable_analysis = false;


### PR DESCRIPTION
Fixes https://github.com/online-go/online-go.com/issues/2016

Changes: don't enable analysis if the player is a rengo participant