### PR TITLE
Fix sgf escaping & minor refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,23 @@ lrwxrwxrwx 1 root root 11 Oct  4 13:10 node_modules/goban -> ../../goban
 $ make
 ```
 
+
+# Running & Writing tests
+Is easy.
+
+## Deps
+Just install `jest` package (might need `sudo`):
+
+```
+$ npm install --save-dev jest
+```
+
+## Running and writing tests
+Tests live in `src/__tests__` directory, check it out & add Your own!
+To run tests:
+```
+# from root directory
+$ cd goban 
+$ npm test
+```
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
+
 # Current state
 
 *Warning* This code base has been extracted from the online-go.com source code
@@ -8,6 +9,14 @@ some moderinization of the rest of the site. Until v 1.0 is released of this
 library, it is not recommended to make use of it as much overhaul is happening
 to improve usability on sites other than online-go.com.
 
+
+# Before PR
+
+- be sure you are able to replicate / test what you are fixing :-)
+- write tests for your code if possible, see the test section below
+- be ready for CI check on PR:
+	- run tests `npm test`
+	- run prettify `npm prettier`
 
 # Dev setup
 
@@ -70,4 +79,5 @@ To run tests:
 $ cd goban 
 $ npm test
 ```
+
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to improve usability on sites other than online-go.com.
 - write tests for your code if possible, see the test section below
 - be ready for CI check on PR:
 	- run tests `npm test`
-	- run prettify `npm prettier`
+	- run prettify `npm run prettier`
 
 # Dev setup
 
@@ -40,9 +40,9 @@ You need to compile goban:
 ```
 $ cd goban
 
-# dependencies (your mileage may vary based on what you have, or have not installed already)
+# dependencies
 $ sudo npm install --global yarn
-$ yarn add webpack-cli --dev
+$ yarn install
 
 # build the goban module
 $ make

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -283,7 +283,7 @@ export class GoMath {
                     if (mv instanceof Array && typeof mv[0] === "number") {
                         ret.push(decodeSingleMoveArray(mv as [number, number, number, number]));
                     } else {
-                        console.error("mv: ", mv);
+                        //console.error("mv: ", mv);
                         throw new Error(`Unrecognized move format: ${mv}`);
                     }
                 }

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -224,7 +224,7 @@ export class GoMath {
     public static readonly PRETTY_COOR_SEQ = "abcdefghjklmnopqrstuvwxyz";
 
     public static pretty_coor_ch2num(ch: string): number {
-        return GoMath.PRETTY_COOR_SEQ.indexOf(ch.toLowerCase());
+        return GoMath.PRETTY_COOR_SEQ.indexOf(ch?.toLowerCase());
     }
 
     public static pretty_coor_num2ch(coor: number): string {

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -211,9 +211,29 @@ export class GoMath {
         }
         return ret;
     }
+    public static readonly COOR_SEQ = "abcdefghijklmnopqrstuvwxyz";
+
+    public static coor_ch2num(ch: string): number {
+        return GoMath.COOR_SEQ.indexOf(ch?.toLowerCase());
+    }
+
+    public static coor_num2ch(coor: number): string {
+        return GoMath.COOR_SEQ[coor];
+    }
+
+    public static readonly PRETTY_COOR_SEQ = "abcdefghjklmnopqrstuvwxyz";
+
+    public static pretty_coor_ch2num(ch: string): number {
+        return GoMath.PRETTY_COOR_SEQ.indexOf(ch.toLowerCase());
+    }
+
+    public static pretty_coor_num2ch(coor: number): string {
+        return GoMath.PRETTY_COOR_SEQ[coor];
+    }
+
     public static prettyCoords(x: number, y: number, board_height: number): string {
         if (x >= 0) {
-            return "ABCDEFGHJKLMNOPQRSTUVWXYZ"[x] + ("" + (board_height - y));
+            return GoMath.pretty_coor_num2ch(x)?.toUpperCase() + ("" + (board_height - y));
         }
         return "pass";
     }
@@ -222,7 +242,7 @@ export class GoMath {
             return { x: -1, y: -1 };
         }
         let y = height - parseInt(move.substr(1));
-        const x = "ABCDEFGHJKLMNOPQRSTUVWXYZ".indexOf(move[0].toUpperCase());
+        const x = GoMath.pretty_coor_ch2num(move[0]);
         if (x === -1) {
             y = -1;
         }
@@ -364,19 +384,19 @@ export class GoMath {
         if (ch === ".") {
             return -1;
         }
-        return "abcdefghijklmnopqrstuvwxyz".indexOf(ch);
+        return GoMath.coor_ch2num(ch);
     }
     private static pretty_char2num(ch: string): number {
         if (ch === ".") {
             return -1;
         }
-        return "abcdefghjklmnopqrstuvwxyz".indexOf(ch.toLowerCase());
+        return GoMath.pretty_coor_ch2num(ch);
     }
     public static num2char(num: number): string {
         if (num === -1) {
             return ".";
         }
-        return "abcdefghijklmnopqrstuvwxyz"[num];
+        return GoMath.coor_num2ch(num);
     }
     public static encodeMove(x: number | Move, y?: number): string {
         if (typeof x === "number") {

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -303,7 +303,6 @@ export class GoMath {
                     if (mv instanceof Array && typeof mv[0] === "number") {
                         ret.push(decodeSingleMoveArray(mv as [number, number, number, number]));
                     } else {
-                        //console.error("mv: ", mv);
                         throw new Error(`Unrecognized move format: ${mv}`);
                     }
                 }

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -221,10 +221,10 @@ export class GoMath {
         return GoMath.COOR_SEQ[coor];
     }
 
-    public static readonly PRETTY_COOR_SEQ = "abcdefghjklmnopqrstuvwxyz";
+    public static readonly PRETTY_COOR_SEQ = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
 
     public static pretty_coor_ch2num(ch: string): number {
-        return GoMath.PRETTY_COOR_SEQ.indexOf(ch?.toLowerCase());
+        return GoMath.PRETTY_COOR_SEQ.indexOf(ch?.toUpperCase());
     }
 
     public static pretty_coor_num2ch(coor: number): string {
@@ -233,7 +233,7 @@ export class GoMath {
 
     public static prettyCoords(x: number, y: number, board_height: number): string {
         if (x >= 0) {
-            return GoMath.pretty_coor_num2ch(x)?.toUpperCase() + ("" + (board_height - y));
+            return GoMath.pretty_coor_num2ch(x) + ("" + (board_height - y));
         }
         return "pass";
     }

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -2644,7 +2644,7 @@ export class GobanCanvas extends GobanCore {
                                 this.square_size +
                             this.square_size / 2;
                         const y = j * this.square_size + this.square_size / 2;
-                        place(GoMath.pretty_coor_num2ch(c)?.toUpperCase(), x, y);
+                        place(GoMath.pretty_coor_num2ch(c), x, y);
                     }
                     break;
                 case "1-1":

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -2644,7 +2644,7 @@ export class GobanCanvas extends GobanCore {
                                 this.square_size +
                             this.square_size / 2;
                         const y = j * this.square_size + this.square_size / 2;
-                        place("ABCDEFGHJKLMNOPQRSTUVWXYZ"[c], x, y);
+                        place(GoMath.pretty_coor_num2ch(c)?.toUpperCase(), x, y);
                     }
                     break;
                 case "1-1":

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-export function escapeSGFText(txt: string): string{
+export function escapeSGFText(txt: string): string {
     // escape slashes first
     // 'blah\blah' -> 'blah\\blah'
     txt = txt.replace(/\\/g, "\\\\");

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -14,7 +14,23 @@
  * limitations under the License.
  */
 
-export function escapeSGFText(txt: string): string {
+/*
+ * SPEC: https://www.red-bean.com/sgf/sgf4.html#text
+ *
+ * in sgf (as per spec):
+ * - slash is an escape char
+ * - closing bracket is a special symbol
+ * - whitespaces other than space & newline should be converted to space
+ * - in compose data type, we should also escape ':'
+ *   (but that is only used in special SGFproperties)
+ *
+ * so we gotta:
+ * - escape (double) all slashes in the text (so that they do not have the special meaning)
+ * - escape any closing brackets ] (as it closes e.g. the comment section)
+ * - replace whitespace
+ * - [opt] handle colon
+ */
+export function escapeSGFText(txt: string, escapeColon: boolean = false): string {
     // escape slashes first
     // 'blah\blah' -> 'blah\\blah'
     txt = txt.replace(/\\/g, "\\\\");
@@ -28,5 +44,12 @@ export function escapeSGFText(txt: string): string {
     //   ^ after it finds the first [, it is only looking for the closing bracket
     // parsing SGF properties, so the remaining [ are safely treated as text
     //txt = txt.replace(/[/g, "\\[");
+
+    // escape whitespace except newline & carriage return by space
+    txt = txt.replace(/[^\S\r\n]/g, " ");
+
+    if (escapeColon) {
+        txt = txt.replace(/:/g, "\\:");
+    }
     return txt;
 }

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2012-2022 Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function escapeSGFText(txt: string): string{
+    // escape slashes first
+    // 'blah\blah' -> 'blah\\blah'
+    txt = txt.replace(/\\/g, "\\\\");
+
+    // escape closing square bracket ]
+    // 'hideki[9dan]' -> 'hideki[9dan\]'
+    txt = txt.replace(/]/g, "\\]");
+
+    // no need to escape opening bracket, SGF grammar handles that
+    // 'C[[[[[[blabla]'
+    //   ^ after it finds the first [, it is only looking for the closing bracket
+    // parsing SGF properties, so the remaining [ are safely treated as text
+    //txt = txt.replace(/[/g, "\\[");
+    return txt;
+}

--- a/src/Misc.ts
+++ b/src/Misc.ts
@@ -45,11 +45,16 @@ export function escapeSGFText(txt: string, escapeColon: boolean = false): string
     // parsing SGF properties, so the remaining [ are safely treated as text
     //txt = txt.replace(/[/g, "\\[");
 
-    // escape whitespace except newline & carriage return by space
+    // sub whitespace except newline & carriage return by space
     txt = txt.replace(/[^\S\r\n]/g, " ");
 
     if (escapeColon) {
         txt = txt.replace(/:/g, "\\:");
     }
     return txt;
+}
+
+// in SGF simple text, we also need to get rid of the newlines
+export function newline2space(txt: string): string {
+    return txt.replace(/[\r\n]/g, " ");
 }

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -570,10 +570,10 @@ export class MoveTree {
         return str;
     }
     toSGF(): string {
-        let ret = [];
+        const ret = [];
 
         try {
-            let txt = [];
+            const txt = [];
             if (this.parent != null) {
                 ret.push(";");
                 if (this.edited) {
@@ -598,11 +598,7 @@ export class MoveTree {
                 txt.push("\n");
                 for (let i = 0; i < this.chatlog.length; ++i) {
                     txt.push(MoveTree.fmtUsername(this.chatlog[i].username));
-                    txt.push(MoveTree.markupSGFChatMessage(
-                            this.chatlog[i].body,
-                            this.engine.width,
-                            this.engine.height,
-                        ));
+                    txt.push(MoveTree.markupSGFChatMessage(this.chatlog[i].body, this.engine.width, this.engine.height));
                     txt.push("\n");
                 }
             }
@@ -973,9 +969,8 @@ export class MoveTree {
 
         return `${message}`;
     }
-    static fmtUsername(
-        username: string,
-    ): string {
+
+    static fmtUsername(username: string): string {
         return username ? username + ": " : "";
     }
     static escapedSGFChat(
@@ -984,7 +979,7 @@ export class MoveTree {
         width: number,
         height: number,
     ): string {
-        var txt = MoveTree.fmtUsername(username) + MoveTree.markupSGFChatMessage(message, width, height);
+        let txt = MoveTree.fmtUsername(username) + MoveTree.markupSGFChatMessage(message, width, height);
         return escapeSGFText(txt);
     }
     static markupSGFChat(

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -19,7 +19,7 @@ import { GoEngine, GoEngineState } from "./GoEngine";
 import { encodeMove } from "./GoEngine";
 import { AdHocPackedMove } from "./AdHocFormat";
 import { JGOFNumericPlayerColor, JGOFPlayerSummary } from "./JGOF";
-import { escapeSGFText } from "./Misc";
+import { escapeSGFText, newline2space } from "./Misc";
 
 export interface MarkInterface {
     triangle?: boolean;
@@ -626,7 +626,9 @@ export class MoveTree {
                             ret.push("CR[" + pos + "]");
                         }
                         if (m.letter) {
-                            ret.push("LB[" + pos + ":" + escapeSGFText(m.letter) + "]");
+                            // https://www.red-bean.com/sgf/properties.html
+                            // LB is composed type of simple text (== no newlines, escaped colon)
+                            ret.push("LB[" + pos + ":" + newline2space(escapeSGFText(m.letter, true)) + "]");
                         }
                     }
                 }

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -568,6 +568,12 @@ export class MoveTree {
         }
         return str;
     }
+	/*
+	 * sgf serialization
+	 *
+	 * this is probably currently unused, as the closed-source backend does
+	 * its own serialization, so only 
+	 */
     toSGF(): string {
         const ret = [];
 
@@ -628,14 +634,15 @@ export class MoveTree {
                         if (m.letter) {
                             // https://www.red-bean.com/sgf/properties.html
                             // LB is composed type of simple text (== no newlines, escaped colon)
-                            ret.push("LB[" + pos + ":" + newline2space(escapeSGFText(m.letter, true)) + "]");
+                            const body = newline2space(escapeSGFText(m.letter, true));
+                            ret.push("LB[" + pos + ":" + body + "]");
                         }
                     }
                 }
             }
             const comment = txt.join("");
             if (comment !== "") {
-                ret.push("C[" + escapeSGFText(comment) + "]\n");
+                ret.push("C[" + escapeSGFText(comment) + "]");
             }
             ret.push("\n");
 
@@ -999,6 +1006,9 @@ export class MoveTree {
     ): string {
         return "C[" + MoveTree.escapedSGFChat(username, message, width, height) + "]\n";
     }
+	/*
+	 * this is used on backend to serialize chat line
+	 */
     static markupSGFChatWithoutNode(
         username: string,
         message: MoveTreeChatLineBody | string,

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -568,12 +568,6 @@ export class MoveTree {
         }
         return str;
     }
-	/*
-	 * sgf serialization
-	 *
-	 * this is probably currently unused, as the closed-source backend does
-	 * its own serialization, so only 
-	 */
     toSGF(): string {
         const ret = [];
 
@@ -1006,9 +1000,9 @@ export class MoveTree {
     ): string {
         return "C[" + MoveTree.escapedSGFChat(username, message, width, height) + "]\n";
     }
-	/*
-	 * this is used on backend to serialize chat line
-	 */
+    /*
+     * this is used on backend to serialize chat line
+     */
     static markupSGFChatWithoutNode(
         username: string,
         message: MoveTreeChatLineBody | string,

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -76,7 +76,6 @@ let __move_tree_id = 0;
 let __isobranches_state_hash: { [hash: string]: Array<MoveTree> } =
     {}; /* used while finding isobranches */
 
-
 /* TODO: If we're on the server side, we shouldn't be doing anything with marks */
 export class MoveTree {
     public static readonly stone_radius = 11;
@@ -598,7 +597,13 @@ export class MoveTree {
                 txt.push("\n");
                 for (let i = 0; i < this.chatlog.length; ++i) {
                     txt.push(MoveTree.fmtUsername(this.chatlog[i].username));
-                    txt.push(MoveTree.markupSGFChatMessage(this.chatlog[i].body, this.engine.width, this.engine.height));
+                    txt.push(
+                        MoveTree.markupSGFChatMessage(
+                            this.chatlog[i].body,
+                            this.engine.width,
+                            this.engine.height,
+                        ),
+                    );
                     txt.push("\n");
                 }
             }
@@ -628,7 +633,7 @@ export class MoveTree {
             }
 
             if (txt.length > 0) {
-                ret.push("C[" + escapeSGFText(txt.join('')) + "]\n");
+                ret.push("C[" + escapeSGFText(txt.join("")) + "]\n");
             }
             ret.push("\n");
 
@@ -979,7 +984,8 @@ export class MoveTree {
         width: number,
         height: number,
     ): string {
-        let txt = MoveTree.fmtUsername(username) + MoveTree.markupSGFChatMessage(message, width, height);
+        const txt =
+            MoveTree.fmtUsername(username) + MoveTree.markupSGFChatMessage(message, width, height);
         return escapeSGFText(txt);
     }
     static markupSGFChat(

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -585,8 +585,8 @@ export class MoveTree {
                 if (this.x === -1) {
                     ret.push("");
                 } else {
-                    ret.push("abcdefghijklmnopqrstuvwxyz"[this.x]);
-                    ret.push("abcdefghijklmnopqrstuvwxyz"[this.y]);
+                    ret.push(GoMath.coor_num2ch(this.x));
+                    ret.push(GoMath.coor_num2ch(this.y));
                 }
                 ret.push("]");
                 txt.push(this.text);
@@ -611,8 +611,7 @@ export class MoveTree {
                 for (let y = 0; y < this.marks.length; ++y) {
                     for (let x = 0; x < this.marks[0].length; ++x) {
                         const m = this.marks[y][x];
-                        const pos =
-                            "abcdefghijklmnopqrstuvwxyz"[x] + "abcdefghijklmnopqrstuvwxyz"[y];
+                        const pos = GoMath.coor_num2ch(x) + GoMath.coor_num2ch(y);
                         if (m.triangle) {
                             ret.push("TR[" + pos + "]");
                         }

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -19,6 +19,7 @@ import { GoEngine, GoEngineState } from "./GoEngine";
 import { encodeMove } from "./GoEngine";
 import { AdHocPackedMove } from "./AdHocFormat";
 import { JGOFNumericPlayerColor, JGOFPlayerSummary } from "./JGOF";
+import { escapeSGFText } from "./Misc";
 
 export interface MarkInterface {
     triangle?: boolean;
@@ -624,25 +625,14 @@ export class MoveTree {
                             ret += "CR[" + pos + "]";
                         }
                         if (m.letter) {
-                            ret +=
-                                "LB[" +
-                                pos +
-                                ":" +
-                                m.letter
-                                    .replace(/[\\]/, "\\\\")
-                                    .replace(/\]/g, "\\]")
-                                    .replace(/[[]/g, "\\[") +
-                                "]";
+                            ret += "LB[" + pos + ":" + escapeSGFText(m.letter) + "]";
                         }
                     }
                 }
             }
 
             if (txt !== "") {
-                ret +=
-                    "C[" +
-                    txt.replace(/[\\]/, "\\\\").replace(/\]/g, "\\]").replace(/[[]/g, "\\[") +
-                    "\n]\n";
+                ret += "C[" + escapeSGFText(txt) + "]\n";
             }
             ret += "\n";
 
@@ -979,23 +969,22 @@ export class MoveTree {
 
         return `${message}`;
     }
+    static escapedSGFChat(
+        username: string,
+        message: MoveTreeChatLineBody | string,
+        width: number,
+        height: number,
+    ): string {
+        var txt = (username ? username + ": " : "") + MoveTree.markupSGFChatMessage(message, width, height);
+        return escapeSGFText(txt);
+    }
     static markupSGFChat(
         username: string,
         message: MoveTreeChatLineBody | string,
         width: number,
         height: number,
     ): string {
-        return (
-            "C[" +
-            (
-                (username ? username + ": " : "") +
-                MoveTree.markupSGFChatMessage(message, width, height)
-            )
-                .replace(/[\\]/, "\\\\")
-                .replace(/\]/g, "\\]")
-                .replace(/[[]/g, "\\[") +
-            "\n]\n"
-        );
+        return "C[" + escapedSGFChat(username, message, width, height) + "]\n";
     }
     static markupSGFChatWithoutNode(
         username: string,
@@ -1003,14 +992,6 @@ export class MoveTree {
         width: number,
         height: number,
     ): string {
-        return (
-            (
-                (username ? username + ": " : "") +
-                MoveTree.markupSGFChatMessage(message, width, height)
-            )
-                .replace(/[\\]/, "\\\\")
-                .replace(/\]/g, "\\]")
-                .replace(/[[]/g, "\\[") + "\n"
-        );
+        return escapedSGFChat(username, message, width, height) + "\n";
     }
 }

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -631,9 +631,9 @@ export class MoveTree {
                     }
                 }
             }
-
-            if (txt.length > 0) {
-                ret.push("C[" + escapeSGFText(txt.join("")) + "]\n");
+            const comment = txt.join("");
+            if (comment != "") {
+                ret.push("C[" + escapeSGFText(comment) + "]\n");
             }
             ret.push("\n");
 
@@ -972,6 +972,7 @@ export class MoveTree {
             console.log(e);
         }
 
+        // TODO FIXME: here lives https://github.com/online-go/online-go.com/issues/1518
         return `${message}`;
     }
 

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -632,7 +632,7 @@ export class MoveTree {
                 }
             }
             const comment = txt.join("");
-            if (comment != "") {
+            if (comment !== "") {
                 ret.push("C[" + escapeSGFText(comment) + "]\n");
             }
             ret.push("\n");

--- a/src/__tests__/GoEngine_sgf.test.ts
+++ b/src/__tests__/GoEngine_sgf.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// ^^ jsdom environment is because getLocation() returns window.location.pathname
+// Same about CLIENT.
+//
+// TODO: move this into a setup-jest.ts file
+
+(global as any).CLIENT = true;
+
+import { TestGoban } from "../TestGoban";
+
+const SGF_TEMPLATES = {
+    unicode:
+        "(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2] RU[Japanese]SZ[19]KM[0.00]PW[White]PB[Black]_MOVES_)",
+    honinbo:
+        "(;FF[4]GM[1]SZ[19]AP[]US[]EV[74th Honinbo challenger decision match]PC[]PB[Shibano Toramaru]BR[7d]PW[Kono Rin]WR[9d]KM[6.5]RE[W+1.5]DT[2019-04-10]TM[0]_MOVES_)",
+};
+
+const SGF_MOVES = {
+    unicode: ";W[aa]C[příliš žluťoučký kůň úpěl ďábelské ódy];W[pd]",
+    honinbo: ";B[pd];W[dp];B[pq];W[dc];B[ce];W[cg];B[cq];W[cp];B[dq];W[fq]",
+};
+
+function rmNewlines(txt: string): string {
+    return txt.replace(/[\n\r]/g, "");
+}
+/*
+ * check that parse -> serialize roundtrip generates the same sgf
+ * (at least for the moves)
+ */
+test("sgf -> parseSGF() -> toSGF() roundtrip (moves only)", () => {
+    Object.entries(SGF_TEMPLATES).forEach(([key, template], index) => {
+        const moves_ori = (SGF_MOVES as any)[key];
+        const sgf = template.replace(/_MOVES_/, moves_ori);
+        const goban = new TestGoban({ original_sgf: sgf, removed: "" });
+        goban.engine.move_tree.traverse((node) => (node.edited = false));
+
+        const moves_gen = goban.engine.move_tree.toSGF();
+        expect(rmNewlines(moves_gen)).toBe(rmNewlines(moves_ori));
+    });
+});
+
+/*
+ * check that whatever moves we play, we get them back in sgf
+ */
+function checkPath(path: string) {
+    const goban = new TestGoban({ moves: [] });
+    const moves = goban.engine.decodeMoves(path);
+    for (let i = 0; i < moves.length; ++i) {
+        goban.engine.place(moves[i].x, moves[i].y);
+    }
+    const sgf = goban.engine.move_tree.toSGF();
+
+    // if we squash everything but the moves, we should get the moves
+    expect(sgf.replace(/[[;BW\n]/g, "").replace(/]/g, "")).toBe(path);
+}
+
+test("toSGF() simple path", () => {
+    const path = "aabbccddee";
+    checkPath(path);
+});

--- a/src/__tests__/Misc.test.ts
+++ b/src/__tests__/Misc.test.ts
@@ -1,4 +1,4 @@
-import { escapeSGFText } from "../Misc";
+import { escapeSGFText, newline2space } from "../Misc";
 
 // String.raw`...` is the real string
 // (without js interpreting \, of which we have a ton)
@@ -30,3 +30,8 @@ test("escapeSGFText handles colon iff need be", () => {
     expect(escapeSGFText("AC:AE")).toBe("AC:AE");
     expect(escapeSGFText("AC:AE", true)).toBe(String.raw`AC\:AE`);
 });
+
+test("newline2space replaces what it should", () => {
+    expect(newline2space("hello\nlucky\r\nboy")).toBe("hello lucky  boy");
+});
+

--- a/src/__tests__/Misc.test.ts
+++ b/src/__tests__/Misc.test.ts
@@ -1,18 +1,32 @@
 import { escapeSGFText } from "../Misc";
 
+// String.raw`...` is the real string
+// (without js interpreting \, of which we have a ton)
+
 test("escapeSGFText duplicates slashes", () => {
-    expect(escapeSGFText("f\\*\\a")).toBe("f\\\\*\\\\a");
+    expect(escapeSGFText(String.raw`f\*\a`)).toBe(String.raw`f\\*\\a`);
 });
 
 test("escapeSGFText escapes closing square bracket", () => {
-    expect(escapeSGFText("{}[]()")).toBe("{}[\\]()");
+    expect(escapeSGFText(String.raw`{}[]()`)).toBe(String.raw`{}[\]()`);
 });
 
 test("escapeSGFText escapes test string", () => {
-    expect(escapeSGFText("test [] test 2 \\[\\]")).toBe("test [\\] test 2 \\\\[\\\\\\]");
+    expect(escapeSGFText(String.raw`test [] test 2 \[\]`)).toBe(
+        String.raw`test [\] test 2 \\[\\\]`,
+    );
+});
+
+test("escapeSGFText changes non newline/carriage-return whitespace to spaces", () => {
+    expect(escapeSGFText("\thi\n\r my\u00a0\ffriend\n")).toBe(" hi\n\r my  friend\n");
 });
 
 test("escapeSGFText leaves other things be", () => {
-    const ugly = "[@#$%^&*()ěščřžýáí";
+    const ugly = "[@\r\nblah:#$\n%^&*()ěšč  řžý:áí";
     expect(escapeSGFText(ugly)).toBe(ugly);
+});
+
+test("escapeSGFText handles colon iff need be", () => {
+    expect(escapeSGFText("AC:AE")).toBe("AC:AE");
+    expect(escapeSGFText("AC:AE", true)).toBe(String.raw`AC\:AE`);
 });

--- a/src/__tests__/Misc.test.ts
+++ b/src/__tests__/Misc.test.ts
@@ -1,0 +1,18 @@
+import { escapeSGFText } from "../Misc";
+
+test('escapeSGFText duplicates slashes', () => {
+  expect(escapeSGFText("f\\*\\a")).toBe("f\\\\*\\\\a");
+});
+
+test('escapeSGFText escapes closing square bracket', () => {
+  expect(escapeSGFText("{}[]()")).toBe("{}[\\]()");
+});
+
+test('escapeSGFText escapes test string', () => {
+  expect(escapeSGFText("test [] test 2 \\[\\]")).toBe("test [\\] test 2 \\\\[\\\\\\]");
+});
+
+test('escapeSGFText leaves other things be', () => {
+  var ugly = "[@#$%^&*()ěščřžýáí";
+  expect(escapeSGFText(ugly)).toBe(ugly);
+});

--- a/src/__tests__/Misc.test.ts
+++ b/src/__tests__/Misc.test.ts
@@ -1,18 +1,18 @@
 import { escapeSGFText } from "../Misc";
 
-test('escapeSGFText duplicates slashes', () => {
-  expect(escapeSGFText("f\\*\\a")).toBe("f\\\\*\\\\a");
+test("escapeSGFText duplicates slashes", () => {
+    expect(escapeSGFText("f\\*\\a")).toBe("f\\\\*\\\\a");
 });
 
-test('escapeSGFText escapes closing square bracket', () => {
-  expect(escapeSGFText("{}[]()")).toBe("{}[\\]()");
+test("escapeSGFText escapes closing square bracket", () => {
+    expect(escapeSGFText("{}[]()")).toBe("{}[\\]()");
 });
 
-test('escapeSGFText escapes test string', () => {
-  expect(escapeSGFText("test [] test 2 \\[\\]")).toBe("test [\\] test 2 \\\\[\\\\\\]");
+test("escapeSGFText escapes test string", () => {
+    expect(escapeSGFText("test [] test 2 \\[\\]")).toBe("test [\\] test 2 \\\\[\\\\\\]");
 });
 
-test('escapeSGFText leaves other things be', () => {
-  var ugly = "[@#$%^&*()ěščřžýáí";
-  expect(escapeSGFText(ugly)).toBe(ugly);
+test("escapeSGFText leaves other things be", () => {
+    const ugly = "[@#$%^&*()ěščřžýáí";
+    expect(escapeSGFText(ugly)).toBe(ugly);
 });

--- a/src/__tests__/Misc.test.ts
+++ b/src/__tests__/Misc.test.ts
@@ -34,4 +34,3 @@ test("escapeSGFText handles colon iff need be", () => {
 test("newline2space replaces what it should", () => {
     expect(newline2space("hello\nlucky\r\nboy")).toBe("hello lucky  boy");
 });
-


### PR DESCRIPTION
Core of the PR is fixing SGF escaping issue:

https://github.com/online-go/online-go.com/issues/1547

The SGF changes were not tested, as the SGF is generated server side, but I think it is pretty safe, lints, etc were fine & I triple checked. 

Apart from that, various minor refactors around it were made:
- added tests for SGF escaping
- sgf now uses linear `string` concatenation (via `array.join`) instead of quadratic `txt += "...."`
- refactored coordinate string, to remove copy-paste & improve safety & consistency (moved to `GoMath`)
  - the code was well tested, so pretty safe I hope
- README now has info about tests 