### PR TITLE
Jm fix analyze on network fail

### DIFF
--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -2082,8 +2082,15 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
             (this.config as any)[k] = (config as any)[k];
         }
         this.clearMessage();
-        this.width = config.width || 19;
-        this.height = config.height || 19;
+
+        const new_width = config.width || 19;
+        const new_height = config.height || 19;
+        // this signalizes that we can keep the old engine
+        // we progressively && more and more conditions
+        let keep_old_engine = new_width === this.width && new_height === this.height;
+        this.width = new_width;
+        this.height = new_height;
+
         delete this.move_selected;
 
         this.bounds = config.bounds || {
@@ -2152,15 +2159,55 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         }
 
         /* This must be done last as it will invoke the appropriate .set actions to set the board in it's correct state */
-        const old_engine = this.engine;
-        this.engine = new GoEngine(config, this);
-        this.engine.parentEventEmitter = this;
-        this.engine.getState_callback = () => {
-            return this.getState();
-        };
-        this.engine.setState_callback = (state) => {
-            return this.setState(state);
-        };
+        let old_engine = this.engine;
+
+        // we need to have an engine to be able to keep it
+        keep_old_engine = keep_old_engine && old_engine !== null && old_engine !== undefined;
+        // we only keep the old engine in analyze mode & finished state
+        // JM: this keep_old_engine functionality is being added to fix resetting analyze state on network
+        // reconnect
+        keep_old_engine =
+            keep_old_engine && this.mode === "analyze" && old_engine.phase === "finished";
+
+        // NOTE: the construction needs to be side-effect free, because we might not use the new state
+        // so we create the engine twice (in case where keep_old_engine = false)
+        // here, it is created without the callback to `this` so that it cannot mess things up
+        let new_engine = new GoEngine(config);
+
+        if (old_engine) {
+            console.log("old size", old_engine.move_tree.size());
+            console.log("new size", new_engine.move_tree.size());
+            console.log(
+                "old contains new",
+                old_engine.move_tree.containsOtherTreeAsSubset(new_engine.move_tree),
+            );
+            console.log(
+                "new contains old",
+                new_engine.move_tree.containsOtherTreeAsSubset(old_engine.move_tree),
+            );
+        }
+
+        // more sanity checks
+        keep_old_engine = keep_old_engine && old_engine.phase === new_engine.phase;
+        // just to be on the safe side,
+        // we only keep the old engine, if replacing it with new would not bring no new moves
+        // (meaning: old has at least all the moves of new one, possibly more == such as the analysis)
+        keep_old_engine =
+            keep_old_engine && old_engine.move_tree.containsOtherTreeAsSubset(new_engine.move_tree);
+
+        if (!keep_old_engine) {
+            // we create the engine anew, this time with the callback argument,
+            // in case the constructor some side effects on `this`
+            // (JM: which it currently does)
+            this.engine = new GoEngine(config, this);
+            this.engine.parentEventEmitter = this;
+            this.engine.getState_callback = () => {
+                return this.getState();
+            };
+            this.engine.setState_callback = (state) => {
+                return this.setState(state);
+            };
+        }
 
         this.paused_since = config.paused_since;
         this.pause_control = config.pause_control;

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -2159,7 +2159,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         }
 
         /* This must be done last as it will invoke the appropriate .set actions to set the board in it's correct state */
-        let old_engine = this.engine;
+        const old_engine = this.engine;
 
         // we need to have an engine to be able to keep it
         keep_old_engine = keep_old_engine && old_engine !== null && old_engine !== undefined;
@@ -2172,7 +2172,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         // NOTE: the construction needs to be side-effect free, because we might not use the new state
         // so we create the engine twice (in case where keep_old_engine = false)
         // here, it is created without the callback to `this` so that it cannot mess things up
-        let new_engine = new GoEngine(config);
+        const new_engine = new GoEngine(config);
 
         if (old_engine) {
             console.log("old size", old_engine.move_tree.size());

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -497,7 +497,7 @@ export class MoveTree {
             return this.trunk_next;
         }
         for (let i = 0; i < this.branches.length; ++i) {
-            let child = this.branches[i];
+            const child = this.branches[i];
             if (predicate(child)) {
                 return child;
             }
@@ -513,8 +513,10 @@ export class MoveTree {
     containsOtherTreeAsChild(other: MoveTree): boolean {
         // there can be at most one candidate children to look for the subtree
         // so the only candidate is the one child that has matching root
-        let candidate = this.findChildWhich((myChild) => myChild.hasTheSameRootMoveAs(other));
-        if (candidate == null) return false;
+        const candidate = this.findChildWhich((myChild) => myChild.hasTheSameRootMoveAs(other));
+        if (candidate == null) {
+            return false;
+        }
         // it also needs to have all children recursively
         return candidate.hasAllChildrenOf(other);
     }
@@ -522,11 +524,15 @@ export class MoveTree {
     hasAllChildrenOf(other: MoveTree): boolean {
         // in order to contain all children of other, we need to:
         // a) contain other's trunk as a subset
-        if (other.trunk_next && !this.containsOtherTreeAsChild(other.trunk_next)) return false;
+        if (other.trunk_next && !this.containsOtherTreeAsChild(other.trunk_next)) {
+            return false;
+        }
         // b) contain all the branches
         for (let i = 0; i < other.branches.length; ++i) {
-            let otherChild = other.branches[i];
-            if (!this.containsOtherTreeAsChild(otherChild)) return false;
+            const otherChild = other.branches[i];
+            if (!this.containsOtherTreeAsChild(otherChild)) {
+                return false;
+            }
         }
         return true;
     }

--- a/src/__tests__/GoEngine_sgf.test.ts
+++ b/src/__tests__/GoEngine_sgf.test.ts
@@ -123,13 +123,13 @@ function checkPath(path: string): MoveTree {
 
 test("toSGF() simple path && tree subsets", () => {
     const path = "aabbccddee";
-    let mt1 = checkPath(path);
+    const mt1 = checkPath(path);
 
     const path2 = "aabbccdd";
-    let mt2 = checkPath(path2);
+    const mt2 = checkPath(path2);
 
     const path3 = "aabbddcc";
-    let mt3 = checkPath(path3);
+    const mt3 = checkPath(path3);
 
     expect(mt1.containsOtherTreeAsSubset(mt2)).toBe(true);
     expect(mt2.containsOtherTreeAsSubset(mt1)).toBe(false);

--- a/src/__tests__/GoEngine_sgf.test.ts
+++ b/src/__tests__/GoEngine_sgf.test.ts
@@ -10,11 +10,13 @@
 (global as any).CLIENT = true;
 
 import { TestGoban } from "../TestGoban";
+import { MoveTree } from "../MoveTree";
 
 type SGFTestcase = {
     template: string;
     moves: string;
     id: string;
+    size: number;
 };
 
 const SGF_TEST_CASES: Array<SGFTestcase> = [
@@ -23,12 +25,34 @@ const SGF_TEST_CASES: Array<SGFTestcase> = [
             "(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2] RU[Japanese]SZ[19]KM[0.00]PW[White]PB[Black]_MOVES_)",
         moves: ";W[aa]C[příliš žluťoučký kůň úpěl ďábelské ódy];W[pd]",
         id: "unicode",
+        size: 3,
     },
     {
         template:
             "(;FF[4]GM[1]SZ[19]AP[]US[]EV[74th Honinbo challenger decision match]PC[]PB[Shibano Toramaru]BR[7d]PW[Kono Rin]WR[9d]KM[6.5]RE[W+1.5]DT[2019-04-10]TM[0]_MOVES_)",
         moves: ";B[pd];W[dp];B[pq];W[dc];B[ce];W[cg];B[cq];W[cp];B[dq];W[fq]",
         id: "honinbo game",
+        size: 11,
+    },
+    {
+        template: "(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2]RU[Japanese]SZ[19]KM[0.00]_MOVES_)",
+        moves: "(;B[dd];W[dc](;B[ec];W[eb])(;B[ed]))(;B[pd];W[nd];B[nc];W[mc];B[oc])",
+        id: "cgoban_tree1",
+        size: 11,
+    },
+    {
+        template: "(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2]RU[Japanese]SZ[19]KM[0.00]_MOVES_)",
+        moves: "(;B[dd];W[dc];B[ec])(;B[pd];W[nd];B[nc])",
+        id: "cgoban_tree2",
+        size: 7,
+    },
+    {
+        template: "(;GM[1]FF[4]CA[UTF-8]AP[CGoban:3]ST[2]RU[Japanese]SZ[19]KM[0.00]_MOVES_)",
+        // just like previous testcase, but
+        //                ||  here is a small difference
+        moves: "(;B[dd];W[eb];B[ec])(;B[pd];W[nd];B[nc])",
+        id: "cgoban_tree3",
+        size: 7,
     },
 ];
 
@@ -41,7 +65,7 @@ function rmNewlines(txt: string): string {
  */
 test.each(SGF_TEST_CASES)(
     "sgf -> parseSGF() -> toSGF() roundtrip (moves only)",
-    ({ template, moves, id }) => {
+    ({ template, moves, id, size }) => {
         const sgf = template.replace(/_MOVES_/, moves);
         const goban = new TestGoban({ original_sgf: sgf, removed: "" });
         // by default, `edited = true` when `original_sgf` is used, which causes
@@ -51,13 +75,40 @@ test.each(SGF_TEST_CASES)(
 
         const moves_gen = goban.engine.move_tree.toSGF();
         expect(rmNewlines(moves_gen)).toBe(rmNewlines(moves));
+        expect(goban.engine.move_tree.size()).toBe(size);
     },
 );
 
 /*
+ * check that tree subset works
+ */
+
+function load(tc: SGFTestcase): MoveTree {
+    const goban = new TestGoban({
+        original_sgf: tc.template.replace(/_MOVES_/, tc.moves),
+        removed: "",
+    });
+    return goban.engine.move_tree;
+}
+
+test("containsOtherTreeAsSubset()", () => {
+    const cgo1 = load(SGF_TEST_CASES[2]);
+    const cgo2 = load(SGF_TEST_CASES[3]);
+    const cgo3 = load(SGF_TEST_CASES[4]);
+
+    expect(cgo1.containsOtherTreeAsSubset(cgo2)).toBe(true);
+    expect(cgo2.containsOtherTreeAsSubset(cgo1)).toBe(false);
+
+    expect(cgo1.containsOtherTreeAsSubset(cgo3)).toBe(false);
+    expect(cgo2.containsOtherTreeAsSubset(cgo3)).toBe(false);
+    expect(cgo3.containsOtherTreeAsSubset(cgo1)).toBe(false);
+    expect(cgo3.containsOtherTreeAsSubset(cgo2)).toBe(false);
+});
+
+/*
  * check that whatever moves we play, we get them back in sgf
  */
-function checkPath(path: string) {
+function checkPath(path: string): MoveTree {
     const goban = new TestGoban({ moves: [] });
     const moves = goban.engine.decodeMoves(path);
     for (let i = 0; i < moves.length; ++i) {
@@ -67,9 +118,26 @@ function checkPath(path: string) {
 
     // if we squash everything but the moves, we should get the moves
     expect(sgf.replace(/[[;BW\n]/g, "").replace(/]/g, "")).toBe(path);
+    return goban.engine.move_tree;
 }
 
-test("toSGF() simple path", () => {
+test("toSGF() simple path && tree subsets", () => {
     const path = "aabbccddee";
-    checkPath(path);
+    let mt1 = checkPath(path);
+
+    const path2 = "aabbccdd";
+    let mt2 = checkPath(path2);
+
+    const path3 = "aabbddcc";
+    let mt3 = checkPath(path3);
+
+    expect(mt1.containsOtherTreeAsSubset(mt2)).toBe(true);
+    expect(mt2.containsOtherTreeAsSubset(mt1)).toBe(false);
+
+    // path 3 has different order of moves, so it should not be
+    // counted as a tree subset
+    expect(mt1.containsOtherTreeAsSubset(mt3)).toBe(false);
+    expect(mt2.containsOtherTreeAsSubset(mt3)).toBe(false);
+    expect(mt3.containsOtherTreeAsSubset(mt1)).toBe(false);
+    expect(mt3.containsOtherTreeAsSubset(mt2)).toBe(false);
 });


### PR DESCRIPTION
This fixes the following issue https://github.com/online-go/online-go.com/issues/1932

**Problem TL;DR:** analyze state is local, on network loss & reconnect, it goes away, which hurts

**Fix summary:** check whether the new engine (/state) has any new info (== the new move tree is subset of the old one), if not, keep the old one.

**Previously**, each call of `load` (e.g. on disconnect / connect cycle) would re-initialize the `GoEngine` anew. This is a problem if the user was in analyze mode which is only stored locally, it would get overwritten on the `load`

**Now**, the `GobanCore.load` checks, and if the newly loaded information is only a subset of the current move tree (&& we are in analyze mode && few other checks), we do not update the engine & keep the old one.

**Caveat:**  we create the `GoEngine` twice now (once without side effects) to check whether there have been changes in the `MoveTree` and for the second time, to allow side-effects tied to `goban_callback`. This can be improved by either refactoring the `GoEngine` to put the side-effecty part aside (I am not even sure how much of it happens, but I do not want to dig there & assume it is safe elsewhere, so I think this is probably a good solution - the parsing of the gamedata is fast).
