### PR TITLE
Prevent right-click from placing a stone in play-mode

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -696,6 +696,12 @@ export class GobanCanvas extends GobanCore {
             return;
         }
 
+        // If there are modes where right click should not behave as if you clicked a placement on the canvas
+        // then return here instead of proceeding.
+        if (right_click && this.mode === "play") {
+            return;
+        }
+
         const pos = getRelativeEventPosition(event);
         const xx = pos.x;
         const yy = pos.y;


### PR DESCRIPTION
Fixed #92.

This is the change suggested by @benjaminpjones  in #93 - the minimal change to deal with the specific pain point.

It does not attempt to make right-click consistent across modes, it just stops it placing a stone in play mode.
