### PR TITLE
Hodge-podge of small code health improvements

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -44,7 +44,7 @@ export default {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     "global": {
-      "lines": 4
+      "lines": 45
     }
   },
 

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -997,7 +997,6 @@ export class GobanCanvas extends GobanCore {
                 /* Place our stone */
                 try {
                     if (
-                        (this.mode !== "edit" || !this.edit_color) &&
                         !(
                             this.mode === "analyze" &&
                             this.analyze_tool === "stone" &&
@@ -1088,19 +1087,6 @@ export class GobanCanvas extends GobanCore {
                         this.updateTitleAndStonePlacement();
                         this.emit("update");
                         this.playMovementSound();
-                        break;
-                    case "edit":
-                        delete this.move_selected;
-                        this.updateTitleAndStonePlacement();
-                        this.emit("update");
-
-                        this.playMovementSound();
-                        this.sendMove({
-                            auth: this.config.auth,
-                            game_id: this.config.game_id,
-                            player_id: this.config.player_id,
-                            move: "!" + this.engine.board[y][x] + encodeMove(x, y),
-                        });
                         break;
                 }
 
@@ -1549,10 +1535,9 @@ export class GobanCanvas extends GobanCore {
                 } else if (stone_color) {
                     color = stone_color;
                 } else if (
-                    this.mode === "edit" ||
-                    (this.mode === "analyze" &&
-                        this.analyze_tool === "stone" &&
-                        this.analyze_subtool !== "alternate")
+                    this.mode === "analyze" &&
+                    this.analyze_tool === "stone" &&
+                    this.analyze_subtool !== "alternate"
                 ) {
                     color = this.edit_color === "black" ? 1 : 2;
                     if (this.shift_key_is_down) {
@@ -2265,10 +2250,9 @@ export class GobanCanvas extends GobanCore {
                 } else if (stone_color) {
                     color = stone_color;
                 } else if (
-                    this.mode === "edit" ||
-                    (this.mode === "analyze" &&
-                        this.analyze_tool === "stone" &&
-                        this.analyze_subtool !== "alternate")
+                    this.mode === "analyze" &&
+                    this.analyze_tool === "stone" &&
+                    this.analyze_subtool !== "alternate"
                 ) {
                     color = this.edit_color === "black" ? 1 : 2;
                 } else if (this.move_selected) {

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -183,7 +183,11 @@ export interface GobanConfig extends GoEngineConfig, PuzzleConfig {
 
     // deprecated
     username?: string;
-    server_socket?: any;
+    server_socket?: {
+        on: (msg: string, cb: (data: any) => void) => void;
+        send: (msg: string, data: any) => void;
+        connected: boolean;
+    };
     connect_to_chat?: number | boolean;
 }
 

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -80,14 +80,7 @@ interface JGOFPlayerClockWithTimedOut extends JGOFPlayerClock {
     timed_out: boolean;
 }
 
-export type GobanModes =
-    | "play"
-    | "puzzle"
-    | "score estimation"
-    | "analyze"
-    | "conditional"
-    | "setup"
-    | "edit";
+export type GobanModes = "play" | "puzzle" | "score estimation" | "analyze" | "conditional";
 
 export type AnalysisTool = "stone" | "draw" | "label";
 export type AnalysisSubTool =
@@ -2332,7 +2325,6 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
                 if (
                     this.player_id &&
                     this.player_id === this.engine.playerToMove() &&
-                    this.mode !== "edit" &&
                     this.engine.cur_move.id === this.engine.last_official_move.id
                 ) {
                     if (
@@ -2354,10 +2346,7 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
                         this.emit("state_text", { title: _("Your move") });
                     }
                 } else {
-                    let color = this.engine.playerColor(this.engine.playerToMove());
-                    if (this.mode === "edit" && this.edit_color) {
-                        color = this.edit_color;
-                    }
+                    const color = this.engine.playerColor(this.engine.playerToMove());
 
                     let title;
                     if (color === "black") {
@@ -2400,15 +2389,6 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         if (this.stone_placement_enabled) {
             this.disableStonePlacement();
         }
-
-        /*
-        if (this.engine.phase === "play" || (this.engine.phase === "finished" && this.mode === "analyze")) {
-            let color = this.engine.playerColor(this.engine.playerToMove());
-            if (this.mode === "edit" && this.edit_color) {
-                color = this.edit_color;
-            }
-        }
-        */
 
         this.stone_placement_enabled = true;
         if (this.__last_pt && this.__last_pt.valid) {
@@ -2535,7 +2515,6 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
 
                 case "analyze":
                 case "conditional":
-                case "edit":
                 case "puzzle":
                     this.disableStonePlacement();
                     this.enableStonePlacement();

--- a/src/__tests__/GobanCanvas.test.ts
+++ b/src/__tests__/GobanCanvas.test.ts
@@ -155,4 +155,38 @@ describe("onTap", () => {
             [0, 0, 0],
         ]);
     });
+
+    test("Clicking submits a move in one-click-submit mode", () => {
+        const mock_socket = {
+            send: jest.fn(),
+            on: jest.fn(),
+            connected: true,
+        };
+        const goban = new GobanCanvas({
+            width: 3,
+            height: 3,
+            square_size: 10,
+            board_div: board_div,
+            interactive: true,
+            one_click_submit: true,
+            server_socket: mock_socket,
+        });
+        const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
+
+        goban.enableStonePlacement();
+        simulateMouseClick(canvas, { x: 0, y: 0 });
+
+        expect(goban.engine.board).toEqual([
+            [1, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]);
+        expect(mock_socket.send).toBeCalledWith(
+            "game/move",
+            expect.objectContaining({
+                move: "aa",
+            }),
+            expect.any(Function),
+        );
+    });
 });

--- a/src/__tests__/GobanCanvas.test.ts
+++ b/src/__tests__/GobanCanvas.test.ts
@@ -8,6 +8,23 @@ import { GobanCanvas } from "../GobanCanvas";
 
 let board_div: HTMLDivElement;
 
+// Nothing special about this square size, just easy to do mental math with
+const TEST_SQUARE_SIZE = 10;
+function simulateMouseClick(canvas: HTMLCanvasElement, { x, y }: { x: number; y: number }) {
+    const eventInitDict = {
+        // 1.5 assumes axis labels, which take up exactly one stone width
+        clientX: (x + 1.5) * TEST_SQUARE_SIZE,
+        clientY: (y + 1.5) * TEST_SQUARE_SIZE,
+    } as const;
+
+    // Some actions are triggered on 'mousedown', others on 'click'
+    // As far as the onTap tests are concerned, it doesn't matter which, so we
+    // trigger all three mouse events when simulating the mouse click.
+    canvas.dispatchEvent(new MouseEvent("mousedown", eventInitDict));
+    canvas.dispatchEvent(new MouseEvent("mouseup", eventInitDict));
+    canvas.dispatchEvent(new MouseEvent("click", eventInitDict));
+}
+
 describe("onTap", () => {
     beforeEach(() => {
         board_div = document.createElement("div");
@@ -27,12 +44,8 @@ describe("onTap", () => {
             interactive: true,
         });
         const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
-        const mouse_event = new MouseEvent("click", {
-            clientX: 15,
-            clientY: 15,
-        });
 
-        canvas.dispatchEvent(mouse_event);
+        simulateMouseClick(canvas, { x: 0, y: 0 });
 
         expect(goban.engine.board).toEqual([
             [0, 0, 0],
@@ -50,13 +63,9 @@ describe("onTap", () => {
             interactive: true,
         });
         const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
-        const mouse_event = new MouseEvent("click", {
-            clientX: 15,
-            clientY: 15,
-        });
 
         goban.enableStonePlacement();
-        canvas.dispatchEvent(mouse_event);
+        simulateMouseClick(canvas, { x: 0, y: 0 });
 
         expect(goban.engine.board).toEqual([
             [1, 0, 0],
@@ -74,37 +83,9 @@ describe("onTap", () => {
             interactive: true,
         });
         const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
-        const mouse_event = new MouseEvent("click", {
-            clientX: 20,
-            clientY: 15,
-        });
 
         goban.enableStonePlacement();
-        canvas.dispatchEvent(mouse_event);
-
-        expect(goban.engine.board).toEqual([
-            [0, 0, 0],
-            [0, 0, 0],
-            [0, 0, 0],
-        ]);
-    });
-
-    test("clicking the midpoint of two intersections has no effect", () => {
-        const goban = new GobanCanvas({
-            width: 3,
-            height: 3,
-            square_size: 10,
-            board_div: board_div,
-            interactive: true,
-        });
-        const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
-        const mouse_event = new MouseEvent("click", {
-            clientX: 20,
-            clientY: 15,
-        });
-
-        goban.enableStonePlacement();
-        canvas.dispatchEvent(mouse_event);
+        simulateMouseClick(canvas, { x: 0.5, y: 0 });
 
         expect(goban.engine.board).toEqual([
             [0, 0, 0],
@@ -150,5 +131,28 @@ describe("onTap", () => {
             [0, 0, 0],
         ]);
         expect(goban.engine.cur_move.move_number).toBe(2);
+    });
+
+    test("Clicking with the triangle subtool places a triangle", () => {
+        const goban = new GobanCanvas({
+            width: 3,
+            height: 3,
+            square_size: 10,
+            board_div: board_div,
+            interactive: true,
+            mode: "analyze",
+        });
+        const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
+
+        goban.enableStonePlacement();
+        goban.setAnalyzeTool("label", "triangle");
+        simulateMouseClick(canvas, { x: 0, y: 0 });
+
+        expect(goban.getMarks(0, 0)).toEqual({ triangle: true });
+        expect(goban.engine.board).toEqual([
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]);
     });
 });


### PR DESCRIPTION
See discussion on #97 for context

- Remove "edit" mode
    - It was unclear what this mode was used for.  It seems similar to placing white or black stones in "analyze" mode, except the "game/move" message is emitted.  At any rate, neither of the other repos use this mode.
- Remove "setup" mode
    - No logic associated with this mode. Likely some confusion with `PuzzlePlacementSetting.mode`.
- Add test for the label subtool (the test places one "triangle" label)
    - Technically, this is not handled in `onTap()`, but we do need to make sure `onTap()` exits without unwanted side-effects
- Add a test for one click submit, mocking the socket
    - I also added a type for `server_socket` in `GobanConfig`.  Does not appear to break the other repos.
- Delete a duplicate test - somehow I ended up with two  "shift clicking in analyze mode jumps to move" test in a previous PR.  I got rid of one. 
- Increase lines covered to 45% (I think just importing `GobanCore`/`GobanCanvas` accounts for most of this)