### PR TITLE
Remove submitBlinkTimer.

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -742,10 +742,6 @@ export class GobanCanvas extends GobanCore {
         }
 
         this.setSubmit(undefined);
-        if (this.submitBlinkTimer) {
-            clearTimeout(this.submitBlinkTimer);
-            delete this.submitBlinkTimer;
-        }
 
         const tap_time = Date.now();
         let removed_count = 0;

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -583,7 +583,6 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
     protected show_variation_move_numbers: boolean;
     protected square_size: number = 10;
     protected stone_placement_enabled: boolean;
-    protected submitBlinkTimer?: ReturnType<typeof setTimeout>;
     protected sendLatencyTimer?: ReturnType<typeof setInterval>;
     //protected syncToCurrentReviewMove;
     //protected waiting_for_game_to_begin;
@@ -1770,10 +1769,6 @@ export abstract class GobanCore extends TypedEventEmitter<Events> {
         /* Clear various timeouts that may be running */
         this.clock_should_be_paused_for_move_submission = false;
         this.setGameClock(null);
-        if (this.submitBlinkTimer) {
-            clearTimeout(this.submitBlinkTimer);
-            delete this.submitBlinkTimer;
-        }
 
         delete (this as any).isPlayerController;
         delete (this as any).isPlayerOwner;


### PR DESCRIPTION
One would expect that this field would be set with the result of a `setTimeout()`, but it never is.  The property is protected,  and as far as I know, `GobanCanvas` is the only relevant class to inherit from `GobanCore`, so if `GobanCanvas` is not setting the timeout either, it is safe to remove.