### PR TITLE
onTap: remove unnecessary stone removal/scoring_mode code

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1580,10 +1580,10 @@ export class GoEngine extends TypedEventEmitter<Events> {
         };
     }
 
-    public toggleMetaGroupRemoval(x: number, y: number): Array<[-1 | 0 | 1, Group]> {
+    public toggleMetaGroupRemoval(x: number, y: number): Array<[0 | 1, Group]> {
         try {
             if (x >= 0 && y >= 0) {
-                const removing: -1 | 0 | 1 = !this.removal[y][x] ? 1 : 0;
+                const removing: 0 | 1 = !this.removal[y][x] ? 1 : 0;
                 const group = this.getGroup(x, y, true);
                 let removed_stones = this.setGroupForRemoval(x, y, removing)[1];
                 const empty_spaces = [];

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -18,15 +18,7 @@ import { JGOF, JGOFIntersection, JGOFNumericPlayerColor } from "./JGOF";
 
 import { AdHocFormat } from "./AdHocFormat";
 
-import {
-    GobanCore,
-    GobanConfig,
-    GobanSelectedThemes,
-    GobanMetrics,
-    GOBAN_FONT,
-    SCORE_ESTIMATION_TRIALS,
-    SCORE_ESTIMATION_TOLERANCE,
-} from "./GobanCore";
+import { GobanCore, GobanConfig, GobanSelectedThemes, GobanMetrics, GOBAN_FONT } from "./GobanCore";
 import { GoEngine, encodeMove, encodeMoves } from "./GoEngine";
 import { GoMath, Group } from "./GoMath";
 import { MoveTree } from "./MoveTree";
@@ -787,11 +779,11 @@ export class GobanCanvas extends GobanCore {
             let force_redraw = false;
 
             if (
-                (this.engine.phase === "stone removal" || this.scoring_mode) &&
+                this.engine.phase === "stone removal" &&
                 this.engine.isActivePlayer(this.player_id)
             ) {
-                let arrs: Array<[-1 | 0 | 1, Group]>;
-                if (event.shiftKey || event.ctrlKey || event.altKey || event.metaKey) {
+                let arrs: Array<[0 | 1, Group]>;
+                if (event.shiftKey) {
                     const removed: 0 | 1 = !this.engine.removal[y][x] ? 1 : 0;
                     arrs = [[removed, [{ x: x, y: y }]]];
                 } else {
@@ -799,11 +791,8 @@ export class GobanCanvas extends GobanCore {
                 }
 
                 for (let i = 0; i < arrs.length; ++i) {
-                    const arr: [-1 | 0 | 1, Group] = arrs[i];
-
-                    const removed = arr[0];
-                    const group = arr[1];
-                    if (group.length && !this.scoring_mode) {
+                    const [removed, group] = arrs[i];
+                    if (group.length) {
                         this.socket.send("game/removed_stones/set", {
                             auth: this.config.auth,
                             game_id: this.config.game_id,
@@ -811,13 +800,6 @@ export class GobanCanvas extends GobanCore {
                             removed: removed,
                             stones: encodeMoves(group),
                         });
-                    }
-                    if (this.scoring_mode) {
-                        this.score_estimate = this.engine.estimateScore(
-                            SCORE_ESTIMATION_TRIALS,
-                            SCORE_ESTIMATION_TOLERANCE,
-                        );
-                        this.redraw(true);
                     }
                 }
             } else if (this.mode === "puzzle") {

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -782,25 +782,23 @@ export class GobanCanvas extends GobanCore {
                 this.engine.phase === "stone removal" &&
                 this.engine.isActivePlayer(this.player_id)
             ) {
-                let arrs: Array<[0 | 1, Group]>;
+                let removed: 0 | 1;
+                let group: Group;
                 if (event.shiftKey) {
-                    const removed: 0 | 1 = !this.engine.removal[y][x] ? 1 : 0;
-                    arrs = [[removed, [{ x: x, y: y }]]];
+                    removed = !this.engine.removal[y][x] ? 1 : 0;
+                    group = [{ x, y }];
                 } else {
-                    arrs = this.engine.toggleMetaGroupRemoval(x, y);
+                    [[removed, group]] = this.engine.toggleMetaGroupRemoval(x, y);
                 }
 
-                for (let i = 0; i < arrs.length; ++i) {
-                    const [removed, group] = arrs[i];
-                    if (group.length) {
-                        this.socket.send("game/removed_stones/set", {
-                            auth: this.config.auth,
-                            game_id: this.config.game_id,
-                            player_id: this.config.player_id,
-                            removed: removed,
-                            stones: encodeMoves(group),
-                        });
-                    }
+                if (group.length) {
+                    this.socket.send("game/removed_stones/set", {
+                        auth: this.config.auth,
+                        game_id: this.config.game_id,
+                        player_id: this.config.player_id,
+                        removed: removed,
+                        stones: encodeMoves(group),
+                    });
                 }
             } else if (this.mode === "puzzle") {
                 let puzzle_mode = "place";

--- a/src/__tests__/GobanCanvas.test.ts
+++ b/src/__tests__/GobanCanvas.test.ts
@@ -355,42 +355,23 @@ describe("onTap", () => {
         expect(addCoordinatesToChatInput).toBeCalledWith("A2");
     });
 
-    // I'm not sure this behavior is actually desired, but capturing in the tests
-    // so that it will be easy to test a change to this behavior if desired
     test("Clicking on stones during stone removal sends two socket messages", () => {
-        const goban = new GobanCanvas(basicScorableBoardConfig({ phase: "stone removal" }));
+        new GobanCanvas(basicScorableBoardConfig({ phase: "stone removal" }));
         const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
 
-        // Just some checks that our setup is correct
-        expect(goban.engine.isActivePlayer(123)).toBe(true);
-        expect(goban.engine.board).toEqual([
-            [0, 1, 2, 0],
-            [0, 1, 2, 0],
-        ]);
+        simulateMouseClick(canvas, { x: 1, y: 0 });
 
-        canvas.dispatchEvent(
-            new MouseEvent("click", {
-                clientX: 25,
-                clientY: 15,
-            }),
-        );
+        //   0 1 2 3
+        // 0 .(x)o .
+        // 1 . x o .
 
-        expect(mock_socket.send).toBeCalledTimes(2);
+        expect(mock_socket.send).toBeCalledTimes(1);
         expect(mock_socket.send).toBeCalledWith(
             "game/removed_stones/set",
             expect.objectContaining({
                 player_id: 123,
                 removed: 1,
                 stones: "babbbabbbbba",
-            }),
-        );
-        // It is my understanding that this second call is not necessary -bpj
-        expect(mock_socket.send).toBeCalledWith(
-            "game/removed_stones/set",
-            expect.objectContaining({
-                player_id: 123,
-                removed: 0,
-                stones: "aaab",
             }),
         );
     });

--- a/src/__tests__/GobanCanvas.test.ts
+++ b/src/__tests__/GobanCanvas.test.ts
@@ -355,7 +355,7 @@ describe("onTap", () => {
         expect(addCoordinatesToChatInput).toBeCalledWith("A2");
     });
 
-    test("Clicking on stones during stone removal sends two socket messages", () => {
+    test("Clicking on stones during stone removal sends a socket message", () => {
         new GobanCanvas(basicScorableBoardConfig({ phase: "stone removal" }));
         const canvas = document.getElementById("board-canvas") as HTMLCanvasElement;
 


### PR DESCRIPTION
Now that this section is covered in tests, I figure a little refactoring is in order.

- cf600d4: add one more test to cover the ctrl-click case.  This passes before and after the refactor
- 04e40ee: Removes scoring_mode and ctrl/alt/metakey checks since onTap will never see these cases (see code snippet below)
- e1ef8d9: Remove the second socket message that gets sent when clicking a stone to remove it. 
    - I tested this manually and removing this seems to make no difference to the end user.  At the very least, it is unclear what it is supposed to mean.
    - Not only cleans up not network traffic, but also the code by reducing nesting.

----

The only place `onTap` is called is in `pointerUp()`.  This heavily simplified snippet should illustrate why `scoring_mode` and `ctrlKey`/`metaKey`/`altKey` are never true within `onTap()`:

```
const pointerUp = (ev: MouseEvent | TouchEvent, double_clicked: boolean): void => {
      ...
    if (this.scoring_mode) {
        // handle score estimate click
        return;
    }

    if (ev.ctrlKey || ev.metaKey || ev.altKey) {
        // add coordinates to chat
        return;
    }

    if (this.mode === "analyze" && this.analyze_tool === "draw") {
        // do nothing
    } else {
        this.onTap(ev, double_clicked, right_click);
    }
}
```

---

Screengrab of some manual testing.  localhost (with these changes) is left, beta (without these changes) is right. Note, when sending messages from beta, there are more socket messages, but the behavior in the UI is the same.

![output](https://user-images.githubusercontent.com/25233703/206376888-82802cef-7dc0-472d-89e6-b2b969a23335.gif)


