### PR TITLE
Oje sequence to moves

### DIFF
--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -37,6 +37,24 @@ export interface BoardState {
 
 type BoardTransform = (x: number, y: number) => { x: number; y: number };
 
+// OJE Sequence format is '.root.K10.Q1'  ...
+export function ojeSequenceToMoves(sequence: string): Array<JGOFMove> {
+    const plays = sequence.split(".");
+
+    if (plays.shift() !== "" || plays.shift() !== "root") {
+        throw new Error("Sequence passed to sequenceToMoves does not start with .root");
+    }
+
+    const moves = plays.map((play) => {
+        if (play === "pass") {
+            return { x: -1, y: -1 };
+        }
+        return GoMath.decodeGTPCoordinate(play, 19, 19);
+    });
+
+    return moves;
+}
+
 export class GoMath {
     private state: BoardState;
     public group_id_map: Array<Array<number>>;

--- a/src/__tests__/GoMath.test.ts
+++ b/src/__tests__/GoMath.test.ts
@@ -1,5 +1,6 @@
 import { GoMath, BoardState } from "../GoMath";
 import { JGOFNumericPlayerColor } from "../JGOF";
+import * as GoMathFunction from "../GoMath";
 
 describe("GoMath constructor", () => {
     test("basic board state", () => {
@@ -509,5 +510,28 @@ describe("sortMoves", () => {
 
     test("repeat elements", () => {
         expect(GoMath.sortMoves("aaaaaa", 2, 2)).toBe("aaaaaa");
+    });
+});
+
+describe("ojeSequenceToMoves", () => {
+    test("bad sequence", () => {
+        expect(() => {
+            GoMathFunction.ojeSequenceToMoves("nonsense");
+        }).toThrow("root");
+    });
+
+    test.each([
+        [".root", []],
+        [".root.A19", [{ x: 0, y: 0 }]],
+        [
+            ".root.A19.pass.K10",
+            [
+                { x: 0, y: 0 },
+                { x: -1, y: -1 },
+                { x: 9, y: 9 },
+            ],
+        ],
+    ])("id of %s", (sequence, id) => {
+        expect(GoMathFunction.ojeSequenceToMoves(sequence)).toStrictEqual(id);
     });
 });


### PR DESCRIPTION
Adds a function to get an `Array<JGOFMove>` from an OJE position (which is a move-sequence-string)

This is handy if you need to initailize a Goban from an OJE position :)

I put this into the `GoMath` file, because it seems to be `GoMath`.  I discovered I don't really know why tons of functions in there are inside the GoMath class.

I could't use my new function in the way that I wanted to do when it was in the class.