### PR TITLE
Remove foreachNeighbor() as an argument to GoMath

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1073,8 +1073,8 @@ export class GoEngine extends TypedEventEmitter<Events> {
         done_array[idx] = true;
         fn_of_neighbor_pt(x, y);
     }
-    /** Public for usage in GoStoneGroup */
-    public foreachNeighbor(
+
+    private foreachNeighbor(
         pt_or_group: Intersection | Group,
         fn_of_neighbor_pt: (x: number, y: number) => void,
     ): void {

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -29,10 +29,6 @@ export interface BoardState {
     height: number;
     board: Array<Array<JGOFNumericPlayerColor>>;
     removal: Array<Array<number>>;
-    foreachNeighbor: (
-        pt_or_group: Intersection | Group,
-        fn_of_neighbor_pt: (x: number, y: number) => void,
-    ) => void;
 }
 
 type BoardTransform = (x: number, y: number) => { x: number; y: number };

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -639,7 +639,6 @@ export class ScoreEstimator {
                         if (this.board[yy][xx] === color || (color === 0 && this.removed[yy][xx])) {
                             this.groups[yy][xx] = g;
                             g.add(xx, yy, color);
-                            //this.foreachNeighbor({"x": xx, "y": yy}, function(x,y) { stack.push(x); stack.push(y); });
                             this.foreachNeighbor({ x: xx, y: yy }, push_on_stack);
                         }
                     }
@@ -882,7 +881,7 @@ export class ScoreEstimator {
 
         return this;
     }
-    public foreachNeighbor(
+    private foreachNeighbor(
         pt_or_group: Intersection | Group,
         fn_of_neighbor_pt: (x: number, y: number) => void,
     ): void {

--- a/src/__tests__/GoMath.test.ts
+++ b/src/__tests__/GoMath.test.ts
@@ -18,8 +18,6 @@ describe("GoMath constructor", () => {
             height: 3,
             board: THREExTHREE_board,
             removal: THREExTHREE_removal,
-            // Why does the test pass even if I pass in a no-op here?
-            foreachNeighbor: () => {},
         };
 
         const gomath_obj = new GoMath(board_state);

--- a/src/__tests__/GoMath_GoStoneGroup.test.ts
+++ b/src/__tests__/GoMath_GoStoneGroup.test.ts
@@ -31,7 +31,6 @@ function makeGoMathWithFeatureBoard() {
         removal: REMOVAL,
         width: 5,
         height: 5,
-        foreachNeighbor: () => {},
     });
 }
 


### PR DESCRIPTION
`GoMath` appears not to use this function, but rather implements [its own flood fill](https://github.com/online-go/goban/blob/a36c53c93ffdbc1f1d8452ba36e4ba68e87140eb/src/GoMath.ts#L53-L77).

Also, since the comment `/** Public for usage in GoStoneGroup */` is not accurate, I made these methods private.