### PR TITLE
Factor `GoStoneGroups` out of `GoMath`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "goban",
-    "version": "0.6.0",
+    "version": "0.6.1",
     "description": "",
     "main": "lib/goban.js",
     "types": "lib/goban.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "goban",
-    "version": "0.5.118",
+    "version": "0.6.0",
     "description": "",
     "main": "lib/goban.js",
     "types": "lib/goban.d.ts",

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -248,7 +248,6 @@ export function num2char(num: number): string {
     return coor_num2ch(num);
 }
 
-// (note: GoEngine has a function called encodeMove, not to be confused with this utility)
 export function encodeMove(x: number | Move, y?: number): string {
     if (typeof x === "number") {
         if (typeof y !== "number") {

--- a/src/GoMath.ts
+++ b/src/GoMath.ts
@@ -14,28 +14,372 @@
  * limitations under the License.
  */
 
-import { GoStoneGroup } from "./GoStoneGroup";
 import { JGOFIntersection, JGOFMove, JGOFNumericPlayerColor } from "./JGOF";
 import { AdHocPackedMove } from "./AdHocFormat";
 
 export type Move = JGOFMove;
 export type Intersection = JGOFIntersection;
-export type Group = Array<JGOFIntersection>;
 export type NumberMatrix = Array<Array<number>>;
 export type StringMatrix = Array<Array<string>>;
 
-export interface BoardState {
-    width: number;
-    height: number;
-    board: Array<Array<JGOFNumericPlayerColor>>;
-    removal: Array<Array<number>>;
-    foreachNeighbor: (
-        pt_or_group: Intersection | Group,
-        fn_of_neighbor_pt: (x: number, y: number) => void,
-    ) => void;
+export function makeMatrix(width: number, height: number, initialValue: number = 0): NumberMatrix {
+    const ret: NumberMatrix = [];
+    for (let y = 0; y < height; ++y) {
+        ret.push([]);
+        for (let x = 0; x < width; ++x) {
+            ret[y].push(initialValue);
+        }
+    }
+    return ret;
+}
+export function makeStringMatrix(
+    width: number,
+    height: number,
+    initialValue: string = "",
+): StringMatrix {
+    const ret: StringMatrix = [];
+    for (let y = 0; y < height; ++y) {
+        ret.push([]);
+        for (let x = 0; x < width; ++x) {
+            ret[y].push(initialValue);
+        }
+    }
+    return ret;
+}
+export function makeObjectMatrix<T>(width: number, height: number): Array<Array<T>> {
+    const ret = new Array<Array<T>>(height);
+    for (let y = 0; y < height; ++y) {
+        const row = new Array<T>(width);
+        for (let x = 0; x < width; ++x) {
+            row[x] = {} as T;
+        }
+        ret[y] = row;
+    }
+    return ret;
+}
+export function makeEmptyObjectMatrix<T>(width: number, height: number): Array<Array<T>> {
+    const ret = new Array<Array<T>>(height);
+    for (let y = 0; y < height; ++y) {
+        const row = new Array<T>(width);
+        ret[y] = row;
+    }
+    return ret;
+}
+const COOR_SEQ = "abcdefghijklmnopqrstuvwxyz";
+
+export function coor_ch2num(ch: string): number {
+    return COOR_SEQ.indexOf(ch?.toLowerCase());
 }
 
-type BoardTransform = (x: number, y: number) => { x: number; y: number };
+export function coor_num2ch(coor: number): string {
+    return COOR_SEQ[coor];
+}
+
+const PRETTY_COOR_SEQ = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
+
+export function pretty_coor_ch2num(ch: string): number {
+    return PRETTY_COOR_SEQ.indexOf(ch?.toUpperCase());
+}
+
+export function pretty_coor_num2ch(coor: number): string {
+    return PRETTY_COOR_SEQ[coor];
+}
+
+export function prettyCoords(x: number, y: number, board_height: number): string {
+    if (x >= 0) {
+        return pretty_coor_num2ch(x) + ("" + (board_height - y));
+    }
+    return "pass";
+}
+export function decodeGTPCoordinate(move: string, width: number, height: number): JGOFMove {
+    if (move === ".." || move.toLowerCase() === "pass") {
+        return { x: -1, y: -1 };
+    }
+    let y = height - parseInt(move.substr(1));
+    const x = pretty_coor_ch2num(move[0]);
+    if (x === -1) {
+        y = -1;
+    }
+    return { x, y };
+}
+
+//  TBD: A description of the scope, intent, and even known use-cases of this would be very helpful.
+//     (My head spins trying to understand what this takes care of, and how not to break that)
+export function decodeMoves(
+    move_obj:
+        | AdHocPackedMove
+        | string
+        | Array<AdHocPackedMove>
+        | [object]
+        | Array<JGOFMove>
+        | JGOFMove
+        | undefined,
+    width: number,
+    height: number,
+): Array<JGOFMove> {
+    const ret: Array<Move> = [];
+
+    if (!move_obj) {
+        return [];
+    }
+
+    function decodeSingleMoveArray(arr: [number, number, number, number?, object?]): Move {
+        const obj: Move = {
+            x: arr[0],
+            y: arr[1],
+            timedelta: arr.length > 2 ? arr[2] : -1,
+            color: (arr.length > 3 ? arr[3] : 0) as JGOFNumericPlayerColor,
+        };
+        const extra: any = arr.length > 4 ? arr[4] : {};
+        for (const k in extra) {
+            (obj as any)[k] = extra[k];
+        }
+        return obj;
+    }
+
+    if (move_obj instanceof Array) {
+        if (move_obj.length === 0) {
+            return [];
+        }
+        if (typeof move_obj[0] === "number") {
+            ret.push(decodeSingleMoveArray(move_obj as [number, number, number, number]));
+        } else {
+            if (
+                typeof move_obj[0] === "object" &&
+                "x" in move_obj[0] &&
+                typeof move_obj[0].x === "number"
+            ) {
+                return move_obj as Array<JGOFMove>;
+            }
+
+            for (let i = 0; i < move_obj.length; ++i) {
+                const mv: any = move_obj[i];
+                if (mv instanceof Array && typeof mv[0] === "number") {
+                    ret.push(decodeSingleMoveArray(mv as [number, number, number, number]));
+                } else {
+                    throw new Error(`Unrecognized move format: ${mv}`);
+                }
+            }
+        }
+    } else if (typeof move_obj === "string") {
+        if (!height || !width) {
+            throw new Error(
+                `decodeMoves requires a height and width to be set when decoding a string coordinate`,
+            );
+        }
+
+        if (/[a-zA-Z][0-9]/.test(move_obj)) {
+            /* coordinate form, used from human input. */
+            const move_string = move_obj;
+
+            const moves = move_string.split(/([a-zA-Z][0-9]+|pass|[.][.])/);
+            for (let i = 0; i < moves.length; ++i) {
+                if (i % 2) {
+                    /* even are the 'splits', which should always be blank unless there is an error */
+                    let x = pretty_char2num(moves[i][0]);
+                    let y = height - parseInt(moves[i].substring(1));
+                    if ((width && x >= width) || x < 0) {
+                        x = y = -1;
+                    }
+                    if ((height && y >= height) || y < 0) {
+                        x = y = -1;
+                    }
+                    ret.push({ x: x, y: y, edited: false, color: 0 });
+                } else {
+                    if (moves[i] !== "") {
+                        throw "Unparsed move input: " + moves[i];
+                    }
+                }
+            }
+        } else {
+            /* Pure letter encoded form, used for all records */
+            const move_string = move_obj;
+
+            for (let i = 0; i < move_string.length - 1; i += 2) {
+                let edited = false;
+                let color: JGOFNumericPlayerColor = 0;
+                if (move_string[i + 0] === "!") {
+                    edited = true;
+                    if (move_string.substr(i, 10) === "!undefined") {
+                        /* bad data */
+                        color = 0;
+                        i += 10;
+                    } else {
+                        color = parseInt(move_string[i + 1]) as JGOFNumericPlayerColor;
+                        i += 2;
+                    }
+                }
+
+                let x = char2num(move_string[i]);
+                let y = char2num(move_string[i + 1]);
+                if (width && x >= width) {
+                    x = y = -1;
+                }
+                if (height && y >= height) {
+                    x = y = -1;
+                }
+                ret.push({ x: x, y: y, edited: edited, color: color });
+            }
+        }
+    } else if (typeof move_obj === "object" && "x" in move_obj && typeof move_obj.x === "number") {
+        return [move_obj] as Array<JGOFMove>;
+    } else {
+        throw new Error("Invalid move format: " + JSON.stringify(move_obj));
+    }
+
+    return ret;
+}
+function char2num(ch: string): number {
+    if (ch === ".") {
+        return -1;
+    }
+    return coor_ch2num(ch);
+}
+function pretty_char2num(ch: string): number {
+    if (ch === ".") {
+        return -1;
+    }
+    return pretty_coor_ch2num(ch);
+}
+export function num2char(num: number): string {
+    if (num === -1) {
+        return ".";
+    }
+    return coor_num2ch(num);
+}
+
+// (note: GoEngine has a function called encodeMove, not to be confused with this utility)
+export function encodeMove(x: number | Move, y?: number): string {
+    if (typeof x === "number") {
+        if (typeof y !== "number") {
+            throw new Error(`Invalid y parameter to encodeMove y = ${y}`);
+        }
+        return num2char(x) + num2char(y);
+    } else {
+        const mv: Move = x;
+
+        if (!mv.edited) {
+            return num2char(mv.x) + num2char(mv.y);
+        } else {
+            return "!" + mv.color + num2char(mv.x) + num2char(mv.y);
+        }
+    }
+}
+
+export function encodeMoves(lst: Array<Move>): string {
+    let ret = "";
+    for (let i = 0; i < lst.length; ++i) {
+        ret += encodeMove(lst[i]);
+    }
+    return ret;
+}
+
+export function encodePrettyCoord(coord: string, height: number): string {
+    // "C12" with no "I".   TBD: give these different `string`s proper type names.
+    const x = num2char(pretty_char2num(coord.charAt(0).toLowerCase()));
+    const y = num2char(height - parseInt(coord.substring(1)));
+    return x + y;
+}
+
+export function encodeMoveToArray(mv: Move): AdHocPackedMove {
+    // Note: despite the name here, AdHocPackedMove became a tuple at some point!
+    let extra: any = {};
+    if (mv.blur) {
+        extra.blur = mv.blur;
+    }
+    if (mv.sgf_downloaded_by) {
+        extra.sgf_downloaded_by = mv.sgf_downloaded_by;
+    }
+    if (mv.played_by) {
+        extra.played_by = mv.played_by;
+    }
+    if (mv.player_update) {
+        extra.player_update = mv.player_update;
+    }
+
+    // don't add an extra if there is nothing extra...
+    if (Object.keys(extra).length === 0) {
+        extra = undefined;
+    }
+
+    const arr: AdHocPackedMove = [mv.x, mv.y, mv.timedelta ? mv.timedelta : -1, undefined, extra];
+    if (mv.edited) {
+        arr[3] = mv.color;
+        if (!extra) {
+            arr.pop();
+        }
+    } else {
+        if (!extra) {
+            arr.pop(); // extra
+            arr.pop(); // edited
+        }
+    }
+    return arr;
+}
+export function encodeMovesToArray(moves: Array<Move>): Array<AdHocPackedMove> {
+    const ret: Array<AdHocPackedMove> = [];
+    for (let i = 0; i < moves.length; ++i) {
+        ret.push(encodeMoveToArray(moves[i]));
+    }
+    return ret;
+}
+
+export function stripModeratorOnlyExtraInformation(move: AdHocPackedMove): AdHocPackedMove {
+    const moderator_only_extra_info = ["blur", "sgf_downloaded_by"];
+
+    if (move.length === 5 && move[4]) {
+        // the packed move has a defined `extra` field that we have to filter
+        let filtered_extra: any = { ...move[4] };
+        for (const field of moderator_only_extra_info) {
+            delete filtered_extra[field];
+        }
+        if (Object.keys(filtered_extra).length === 0) {
+            filtered_extra = undefined;
+        }
+
+        //filtered_extra.stripped = true;  // this is how you can tell by looking at a move structure in flight whether it went through here.
+        const filtered_move = [...move.slice(0, 4), filtered_extra];
+        while (filtered_move.length > 3 && !filtered_move[filtered_move.length - 1]) {
+            filtered_move.pop();
+        }
+        return filtered_move as AdHocPackedMove;
+    }
+    return move;
+}
+
+/**
+ * Removes superfluous fields from the JGOFMove objects, such as
+ * edited=false and color=0. This does not modify the original array.
+ */
+export function trimJGOFMoves(arr: Array<JGOFMove>): Array<JGOFMove> {
+    return arr.map((o) => {
+        const r: JGOFMove = {
+            x: o.x,
+            y: o.y,
+        };
+        if (o.edited) {
+            r.edited = o.edited;
+        }
+        if (o.color) {
+            r.color = o.color;
+        }
+        if (o.timedelta) {
+            r.timedelta = o.timedelta;
+        }
+        return r;
+    });
+}
+
+/** Returns a sorted move string, this is used in our stone removal logic */
+export function sortMoves(move_string: string, width: number, height: number): string {
+    const moves = decodeMoves(move_string, width, height);
+    moves.sort((a, b) => {
+        const av = (a.edited ? 1 : 0) * 10000 + a.x + a.y * 100;
+        const bv = (b.edited ? 1 : 0) * 10000 + b.x + b.y * 100;
+        return av - bv;
+    });
+    return encodeMoves(moves);
+}
 
 // OJE Sequence format is '.root.K10.Q1'  ...
 export function ojeSequenceToMoves(sequence: string): Array<JGOFMove> {
@@ -49,567 +393,69 @@ export function ojeSequenceToMoves(sequence: string): Array<JGOFMove> {
         if (play === "pass") {
             return { x: -1, y: -1 };
         }
-        return GoMath.decodeGTPCoordinate(play, 19, 19);
+        return decodeGTPCoordinate(play, 19, 19);
     });
 
     return moves;
 }
 
-export class GoMath {
-    private state: BoardState;
-    public group_id_map: Array<Array<number>>;
-    public groups: Array<GoStoneGroup>;
+// This is intended to be an "easy to understand" method of generating a unique id
+// for a board position.
 
-    constructor(state: BoardState, original_board?: Array<Array<number>>) {
-        const groups: Array<GoStoneGroup> = Array(1); // this is indexed by group_id, so we 1 index this array so group_id >= 1
-        const group_id_map: Array<Array<number>> = GoMath.makeMatrix(state.width, state.height);
+// The "id" is the list of all the positions of the stones, black first then white,
+// separated by a colon.
 
-        this.state = state;
-        this.group_id_map = group_id_map;
-        this.groups = groups;
+// There are in fact 8 possible ways to list the positions (all the rotations and
+// reflections of the position).   The id is the lowest (alpha-numerically) of these.
 
-        const floodFill = (
-            x: number,
-            y: number,
-            color: JGOFNumericPlayerColor,
-            dame: boolean,
-            id: number,
-        ): void => {
-            if (x >= 0 && x < this.state.width) {
-                if (y >= 0 && y < this.state.height) {
-                    if (
-                        this.state.board[y][x] === color &&
-                        group_id_map[y][x] === 0 &&
-                        (!original_board ||
-                            (!dame && (original_board[y][x] !== 0 || !this.state.removal[y][x])) ||
-                            (dame && original_board[y][x] === 0 && this.state.removal[y][x]))
-                    ) {
-                        group_id_map[y][x] = id;
-                        floodFill(x - 1, y, color, dame, id);
-                        floodFill(x + 1, y, color, dame, id);
-                        floodFill(x, y - 1, color, dame, id);
-                        floodFill(x, y + 1, color, dame, id);
-                    }
+// Colour independence for the position is achieved by takeing the lexically lower
+// of the ids of the position with black and white reversed.
+
+// The "easy to understand" part is that the id can be compared visually to the
+// board position
+
+// The downside is that the id string can be moderately long for boards with lots of stones
+
+type BoardTransform = (x: number, y: number) => { x: number; y: number };
+
+export function positionId(
+    position: Array<Array<JGOFNumericPlayerColor>>,
+    height: number,
+    width: number,
+): string {
+    // The basic algorithm is to list where each of the stones are, in a long string.
+    // We do this once for each transform, selecting the lowest (lexixally) as we go.
+
+    const tforms: Array<BoardTransform> = [
+        (x, y) => ({ x, y }),
+        (x, y) => ({ x, y: height - y - 1 }),
+        (x, y) => ({ x: y, y: x }),
+        (x, y) => ({ x: y, y: width - x - 1 }),
+        (x, y) => ({ x: height - y - 1, y: x }),
+        (x, y) => ({ x: height - y - 1, y: width - x - 1 }),
+        (x, y) => ({ x: width - x - 1, y }),
+        (x, y) => ({ x: width - x - 1, y: height - y - 1 }),
+    ];
+
+    const ids = [];
+
+    for (const tform of tforms) {
+        let black_state = "";
+        let white_state = "";
+        for (let x = 0; x < width; x++) {
+            for (let y = 0; y < height; y++) {
+                const c = tform(x, y);
+                if (position[x][y] === JGOFNumericPlayerColor.BLACK) {
+                    black_state += encodeMove(c.x, c.y);
+                }
+                if (position[x][y] === JGOFNumericPlayerColor.WHITE) {
+                    white_state += encodeMove(c.x, c.y);
                 }
             }
-        };
-
-        /* Build groups */
-        let groupId = 1;
-        for (let y = 0; y < this.state.height; ++y) {
-            for (let x = 0; x < this.state.width; ++x) {
-                if (group_id_map[y][x] === 0) {
-                    floodFill(
-                        x,
-                        y,
-                        this.state.board[y][x],
-                        !!(
-                            original_board &&
-                            this.state.removal[y][x] &&
-                            original_board[y][x] === 0
-                        ),
-                        groupId++,
-                    );
-                }
-
-                if (!(group_id_map[y][x] in groups)) {
-                    groups.push(
-                        new GoStoneGroup(
-                            this.state,
-                            group_id_map[y][x],
-                            this.state.board[y][x],
-                            !!(
-                                original_board &&
-                                this.state.removal[y][x] &&
-                                original_board[y][x] === 0
-                            ),
-                        ),
-                    );
-                }
-                groups[group_id_map[y][x]].addStone(x, y);
-            }
         }
 
-        /* Compute group neighbors */
-        this.foreachGroup((gr) => {
-            gr.foreachStone((pt) => {
-                const x = pt.x;
-                const y = pt.y;
-                if (x - 1 >= 0 && group_id_map[y][x - 1] !== gr.id) {
-                    gr.addNeighborGroup(groups[group_id_map[y][x - 1]]);
-                }
-                if (x + 1 < this.state.width && group_id_map[y][x + 1] !== gr.id) {
-                    gr.addNeighborGroup(groups[group_id_map[y][x + 1]]);
-                }
-                if (y - 1 >= 0 && group_id_map[y - 1][x] !== gr.id) {
-                    gr.addNeighborGroup(groups[group_id_map[y - 1][x]]);
-                }
-                if (y + 1 < this.state.height && group_id_map[y + 1][x] !== gr.id) {
-                    gr.addNeighborGroup(groups[group_id_map[y + 1][x]]);
-                }
-                for (let Y = -1; Y <= 1; ++Y) {
-                    for (let X = -1; X <= 1; ++X) {
-                        if (
-                            x + X >= 0 &&
-                            x + X < this.state.width &&
-                            y + Y >= 0 &&
-                            y + Y < this.state.height
-                        ) {
-                            gr.addCornerGroup(x + X, y + Y, groups[group_id_map[y + Y][x + X]]);
-                        }
-                    }
-                }
-            });
-        });
-
-        this.foreachGroup((gr) => {
-            gr.computeIsTerritory();
-        });
-        this.foreachGroup((gr) => {
-            gr.computeIsTerritoryInSeki();
-        });
-        this.foreachGroup((gr) => {
-            gr.computeIsEye();
-        });
-        this.foreachGroup((gr) => {
-            gr.computeIsStrongEye();
-        });
-        this.foreachGroup((gr) => {
-            gr.computeIsStrongString();
-        });
-    }
-    public foreachGroup(fn: (gr: GoStoneGroup) => void) {
-        for (let i = 1; i < this.groups.length; ++i) {
-            fn(this.groups[i]);
-        }
+        ids.push(`${black_state}.${white_state}`);
     }
 
-    public static makeMatrix(
-        width: number,
-        height: number,
-        initialValue: number = 0,
-    ): NumberMatrix {
-        const ret: NumberMatrix = [];
-        for (let y = 0; y < height; ++y) {
-            ret.push([]);
-            for (let x = 0; x < width; ++x) {
-                ret[y].push(initialValue);
-            }
-        }
-        return ret;
-    }
-    public static makeStringMatrix(
-        width: number,
-        height: number,
-        initialValue: string = "",
-    ): StringMatrix {
-        const ret: StringMatrix = [];
-        for (let y = 0; y < height; ++y) {
-            ret.push([]);
-            for (let x = 0; x < width; ++x) {
-                ret[y].push(initialValue);
-            }
-        }
-        return ret;
-    }
-    public static makeObjectMatrix<T>(width: number, height: number): Array<Array<T>> {
-        const ret = new Array<Array<T>>(height);
-        for (let y = 0; y < height; ++y) {
-            const row = new Array<T>(width);
-            for (let x = 0; x < width; ++x) {
-                row[x] = {} as T;
-            }
-            ret[y] = row;
-        }
-        return ret;
-    }
-    public static makeEmptyObjectMatrix<T>(width: number, height: number): Array<Array<T>> {
-        const ret = new Array<Array<T>>(height);
-        for (let y = 0; y < height; ++y) {
-            const row = new Array<T>(width);
-            ret[y] = row;
-        }
-        return ret;
-    }
-    public static readonly COOR_SEQ = "abcdefghijklmnopqrstuvwxyz";
-
-    public static coor_ch2num(ch: string): number {
-        return GoMath.COOR_SEQ.indexOf(ch?.toLowerCase());
-    }
-
-    public static coor_num2ch(coor: number): string {
-        return GoMath.COOR_SEQ[coor];
-    }
-
-    public static readonly PRETTY_COOR_SEQ = "ABCDEFGHJKLMNOPQRSTUVWXYZ";
-
-    public static pretty_coor_ch2num(ch: string): number {
-        return GoMath.PRETTY_COOR_SEQ.indexOf(ch?.toUpperCase());
-    }
-
-    public static pretty_coor_num2ch(coor: number): string {
-        return GoMath.PRETTY_COOR_SEQ[coor];
-    }
-
-    public static prettyCoords(x: number, y: number, board_height: number): string {
-        if (x >= 0) {
-            return GoMath.pretty_coor_num2ch(x) + ("" + (board_height - y));
-        }
-        return "pass";
-    }
-    public static decodeGTPCoordinate(move: string, width: number, height: number): JGOFMove {
-        if (move === ".." || move.toLowerCase() === "pass") {
-            return { x: -1, y: -1 };
-        }
-        let y = height - parseInt(move.substr(1));
-        const x = GoMath.pretty_coor_ch2num(move[0]);
-        if (x === -1) {
-            y = -1;
-        }
-        return { x, y };
-    }
-
-    //  TBD: A description of the scope, intent, and even known use-cases of this would be very helpful.
-    //     (My head spins trying to understand what this takes care of, and how not to break that)
-    public static decodeMoves(
-        move_obj:
-            | AdHocPackedMove
-            | string
-            | Array<AdHocPackedMove>
-            | [object]
-            | Array<JGOFMove>
-            | JGOFMove
-            | undefined,
-        width: number,
-        height: number,
-    ): Array<JGOFMove> {
-        const ret: Array<Move> = [];
-
-        if (!move_obj) {
-            return [];
-        }
-
-        function decodeSingleMoveArray(arr: [number, number, number, number?, object?]): Move {
-            const obj: Move = {
-                x: arr[0],
-                y: arr[1],
-                timedelta: arr.length > 2 ? arr[2] : -1,
-                color: (arr.length > 3 ? arr[3] : 0) as JGOFNumericPlayerColor,
-            };
-            const extra: any = arr.length > 4 ? arr[4] : {};
-            for (const k in extra) {
-                (obj as any)[k] = extra[k];
-            }
-            return obj;
-        }
-
-        if (move_obj instanceof Array) {
-            if (move_obj.length === 0) {
-                return [];
-            }
-            if (typeof move_obj[0] === "number") {
-                ret.push(decodeSingleMoveArray(move_obj as [number, number, number, number]));
-            } else {
-                if (
-                    typeof move_obj[0] === "object" &&
-                    "x" in move_obj[0] &&
-                    typeof move_obj[0].x === "number"
-                ) {
-                    return move_obj as Array<JGOFMove>;
-                }
-
-                for (let i = 0; i < move_obj.length; ++i) {
-                    const mv: any = move_obj[i];
-                    if (mv instanceof Array && typeof mv[0] === "number") {
-                        ret.push(decodeSingleMoveArray(mv as [number, number, number, number]));
-                    } else {
-                        throw new Error(`Unrecognized move format: ${mv}`);
-                    }
-                }
-            }
-        } else if (typeof move_obj === "string") {
-            if (!height || !width) {
-                throw new Error(
-                    `decodeMoves requires a height and width to be set when decoding a string coordinate`,
-                );
-            }
-
-            if (/[a-zA-Z][0-9]/.test(move_obj)) {
-                /* coordinate form, used from human input. */
-                const move_string = move_obj;
-
-                const moves = move_string.split(/([a-zA-Z][0-9]+|pass|[.][.])/);
-                for (let i = 0; i < moves.length; ++i) {
-                    if (i % 2) {
-                        /* even are the 'splits', which should always be blank unless there is an error */
-                        let x = GoMath.pretty_char2num(moves[i][0]);
-                        let y = height - parseInt(moves[i].substring(1));
-                        if ((width && x >= width) || x < 0) {
-                            x = y = -1;
-                        }
-                        if ((height && y >= height) || y < 0) {
-                            x = y = -1;
-                        }
-                        ret.push({ x: x, y: y, edited: false, color: 0 });
-                    } else {
-                        if (moves[i] !== "") {
-                            throw "Unparsed move input: " + moves[i];
-                        }
-                    }
-                }
-            } else {
-                /* Pure letter encoded form, used for all records */
-                const move_string = move_obj;
-
-                for (let i = 0; i < move_string.length - 1; i += 2) {
-                    let edited = false;
-                    let color: JGOFNumericPlayerColor = 0;
-                    if (move_string[i + 0] === "!") {
-                        edited = true;
-                        if (move_string.substr(i, 10) === "!undefined") {
-                            /* bad data */
-                            color = 0;
-                            i += 10;
-                        } else {
-                            color = parseInt(move_string[i + 1]) as JGOFNumericPlayerColor;
-                            i += 2;
-                        }
-                    }
-
-                    let x = GoMath.char2num(move_string[i]);
-                    let y = GoMath.char2num(move_string[i + 1]);
-                    if (width && x >= width) {
-                        x = y = -1;
-                    }
-                    if (height && y >= height) {
-                        x = y = -1;
-                    }
-                    ret.push({ x: x, y: y, edited: edited, color: color });
-                }
-            }
-        } else if (
-            typeof move_obj === "object" &&
-            "x" in move_obj &&
-            typeof move_obj.x === "number"
-        ) {
-            return [move_obj] as Array<JGOFMove>;
-        } else {
-            throw new Error("Invalid move format: " + JSON.stringify(move_obj));
-        }
-
-        return ret;
-    }
-    private static char2num(ch: string): number {
-        if (ch === ".") {
-            return -1;
-        }
-        return GoMath.coor_ch2num(ch);
-    }
-    private static pretty_char2num(ch: string): number {
-        if (ch === ".") {
-            return -1;
-        }
-        return GoMath.pretty_coor_ch2num(ch);
-    }
-    public static num2char(num: number): string {
-        if (num === -1) {
-            return ".";
-        }
-        return GoMath.coor_num2ch(num);
-    }
-    public static encodeMove(x: number | Move, y?: number): string {
-        if (typeof x === "number") {
-            if (typeof y !== "number") {
-                throw new Error(`Invalid y parameter to encodeMove y = ${y}`);
-            }
-            return GoMath.num2char(x) + GoMath.num2char(y);
-        } else {
-            const mv: Move = x;
-
-            if (!mv.edited) {
-                return GoMath.num2char(mv.x) + GoMath.num2char(mv.y);
-            } else {
-                return "!" + mv.color + GoMath.num2char(mv.x) + GoMath.num2char(mv.y);
-            }
-        }
-    }
-
-    public static encodePrettyCoord(coord: string, height: number): string {
-        // "C12" with no "I".   TBD: give these different `string`s proper type names.
-        const x = GoMath.num2char(GoMath.pretty_char2num(coord.charAt(0).toLowerCase()));
-        const y = GoMath.num2char(height - parseInt(coord.substring(1)));
-        return x + y;
-    }
-
-    public static encodeMoves(lst: Array<Move>): string {
-        let ret = "";
-        for (let i = 0; i < lst.length; ++i) {
-            ret += GoMath.encodeMove(lst[i]);
-        }
-        return ret;
-    }
-    public static encodeMoveToArray(mv: Move): AdHocPackedMove {
-        // Note: despite the name here, AdHocPackedMove became a tuple at some point!
-        let extra: any = {};
-        if (mv.blur) {
-            extra.blur = mv.blur;
-        }
-        if (mv.sgf_downloaded_by) {
-            extra.sgf_downloaded_by = mv.sgf_downloaded_by;
-        }
-        if (mv.played_by) {
-            extra.played_by = mv.played_by;
-        }
-        if (mv.player_update) {
-            extra.player_update = mv.player_update;
-        }
-
-        // don't add an extra if there is nothing extra...
-        if (Object.keys(extra).length === 0) {
-            extra = undefined;
-        }
-
-        const arr: AdHocPackedMove = [
-            mv.x,
-            mv.y,
-            mv.timedelta ? mv.timedelta : -1,
-            undefined,
-            extra,
-        ];
-        if (mv.edited) {
-            arr[3] = mv.color;
-            if (!extra) {
-                arr.pop();
-            }
-        } else {
-            if (!extra) {
-                arr.pop(); // extra
-                arr.pop(); // edited
-            }
-        }
-        return arr;
-    }
-    public static encodeMovesToArray(moves: Array<Move>): Array<AdHocPackedMove> {
-        const ret: Array<AdHocPackedMove> = [];
-        for (let i = 0; i < moves.length; ++i) {
-            ret.push(GoMath.encodeMoveToArray(moves[i]));
-        }
-        return ret;
-    }
-
-    public static stripModeratorOnlyExtraInformation(move: AdHocPackedMove): AdHocPackedMove {
-        const moderator_only_extra_info = ["blur", "sgf_downloaded_by"];
-
-        if (move.length === 5 && move[4]) {
-            // the packed move has a defined `extra` field that we have to filter
-            let filtered_extra: any = { ...move[4] };
-            for (const field of moderator_only_extra_info) {
-                delete filtered_extra[field];
-            }
-            if (Object.keys(filtered_extra).length === 0) {
-                filtered_extra = undefined;
-            }
-
-            //filtered_extra.stripped = true;  // this is how you can tell by looking at a move structure in flight whether it went through here.
-            const filtered_move = [...move.slice(0, 4), filtered_extra];
-            while (filtered_move.length > 3 && !filtered_move[filtered_move.length - 1]) {
-                filtered_move.pop();
-            }
-            return filtered_move as AdHocPackedMove;
-        }
-        return move;
-    }
-
-    /**
-     * Removes superfluous fields from the JGOFMove objects, such as
-     * edited=false and color=0. This does not modify the original array.
-     */
-    public static trimJGOFMoves(arr: Array<JGOFMove>): Array<JGOFMove> {
-        return arr.map((o) => {
-            const r: JGOFMove = {
-                x: o.x,
-                y: o.y,
-            };
-            if (o.edited) {
-                r.edited = o.edited;
-            }
-            if (o.color) {
-                r.color = o.color;
-            }
-            if (o.timedelta) {
-                r.timedelta = o.timedelta;
-            }
-            return r;
-        });
-    }
-
-    /** Returns a sorted move string, this is used in our stone removal logic */
-    public static sortMoves(move_string: string, width: number, height: number): string {
-        const moves = GoMath.decodeMoves(move_string, width, height);
-        moves.sort((a, b) => {
-            const av = (a.edited ? 1 : 0) * 10000 + a.x + a.y * 100;
-            const bv = (b.edited ? 1 : 0) * 10000 + b.x + b.y * 100;
-            return av - bv;
-        });
-        return GoMath.encodeMoves(moves);
-    }
-
-    // This is intended to be an "easy to understand" method of generating a unique id
-    // for a board position.
-
-    // The "id" is the list of all the positions of the stones, black first then white,
-    // separated by a colon.
-
-    // There are in fact 8 possible ways to list the positions (all the rotations and
-    // reflections of the position).   The id is the lowest (alpha-numerically) of these.
-
-    // Colour independence for the position is achieved by takeing the lexically lower
-    // of the ids of the position with black and white reversed.
-
-    // The "easy to understand" part is that the id can be compared visually to the
-    // board position
-
-    // The downside is that the id string can be moderately long for boards with lots of stones
-
-    public static positionId(
-        position: Array<Array<JGOFNumericPlayerColor>>,
-        height: number,
-        width: number,
-    ): string {
-        // The basic algorithm is to list where each of the stones are, in a long string.
-        // We do this once for each transform, selecting the lowest (lexixally) as we go.
-
-        const tforms: Array<BoardTransform> = [
-            (x, y) => ({ x, y }),
-            (x, y) => ({ x, y: height - y - 1 }),
-            (x, y) => ({ x: y, y: x }),
-            (x, y) => ({ x: y, y: width - x - 1 }),
-            (x, y) => ({ x: height - y - 1, y: x }),
-            (x, y) => ({ x: height - y - 1, y: width - x - 1 }),
-            (x, y) => ({ x: width - x - 1, y }),
-            (x, y) => ({ x: width - x - 1, y: height - y - 1 }),
-        ];
-
-        const ids = [];
-
-        for (const tform of tforms) {
-            let black_state = "";
-            let white_state = "";
-            for (let x = 0; x < width; x++) {
-                for (let y = 0; y < height; y++) {
-                    const c = tform(x, y);
-                    if (position[x][y] === JGOFNumericPlayerColor.BLACK) {
-                        black_state += GoMath.encodeMove(c.x, c.y);
-                    }
-                    if (position[x][y] === JGOFNumericPlayerColor.WHITE) {
-                        white_state += GoMath.encodeMove(c.x, c.y);
-                    }
-                }
-            }
-
-            ids.push(`${black_state}.${white_state}`);
-        }
-
-        return ids.reduce((prev, current) => (current < prev ? current : prev));
-    }
+    return ids.reduce((prev, current) => (current < prev ? current : prev));
 }

--- a/src/GoStoneGroup.ts
+++ b/src/GoStoneGroup.ts
@@ -14,8 +14,21 @@
  * limitations under the License.
  */
 
-import { BoardState, Intersection } from "./GoMath";
-import { JGOFNumericPlayerColor } from "./JGOF";
+import { Intersection } from "./GoMath";
+import { JGOFNumericPlayerColor, JGOFIntersection } from "./JGOF";
+
+export type Group = Array<JGOFIntersection>;
+
+export interface BoardState {
+    width: number;
+    height: number;
+    board: Array<Array<JGOFNumericPlayerColor>>;
+    removal: Array<Array<number>>;
+    foreachNeighbor: (
+        pt_or_group: Intersection | Group,
+        fn_of_neighbor_pt: (x: number, y: number) => void,
+    ) => void;
+}
 
 export class GoStoneGroup {
     probable_color: JGOFNumericPlayerColor;

--- a/src/GoStoneGroup.ts
+++ b/src/GoStoneGroup.ts
@@ -24,10 +24,6 @@ export interface BoardState {
     height: number;
     board: Array<Array<JGOFNumericPlayerColor>>;
     removal: Array<Array<number>>;
-    foreachNeighbor: (
-        pt_or_group: Intersection | Group,
-        fn_of_neighbor_pt: (x: number, y: number) => void,
-    ) => void;
 }
 
 export class GoStoneGroup {

--- a/src/GoStoneGroups.ts
+++ b/src/GoStoneGroups.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2012-2020 Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as GoMath from "./GoMath";
+import { GoStoneGroup, BoardState } from "./GoStoneGroup";
+import { JGOFNumericPlayerColor } from "./JGOF";
+
+export class GoStoneGroups {
+    private state: BoardState;
+    public group_id_map: Array<Array<number>>;
+    public groups: Array<GoStoneGroup>;
+
+    constructor(state: BoardState, original_board?: Array<Array<number>>) {
+        const groups: Array<GoStoneGroup> = Array(1); // this is indexed by group_id, so we 1 index this array so group_id >= 1
+        const group_id_map: Array<Array<number>> = GoMath.makeMatrix(state.width, state.height);
+
+        this.state = state;
+        this.group_id_map = group_id_map;
+        this.groups = groups;
+
+        const floodFill = (
+            x: number,
+            y: number,
+            color: JGOFNumericPlayerColor,
+            dame: boolean,
+            id: number,
+        ): void => {
+            if (x >= 0 && x < this.state.width) {
+                if (y >= 0 && y < this.state.height) {
+                    if (
+                        this.state.board[y][x] === color &&
+                        group_id_map[y][x] === 0 &&
+                        (!original_board ||
+                            (!dame && (original_board[y][x] !== 0 || !this.state.removal[y][x])) ||
+                            (dame && original_board[y][x] === 0 && this.state.removal[y][x]))
+                    ) {
+                        group_id_map[y][x] = id;
+                        floodFill(x - 1, y, color, dame, id);
+                        floodFill(x + 1, y, color, dame, id);
+                        floodFill(x, y - 1, color, dame, id);
+                        floodFill(x, y + 1, color, dame, id);
+                    }
+                }
+            }
+        };
+
+        /* Build groups */
+        let groupId = 1;
+        for (let y = 0; y < this.state.height; ++y) {
+            for (let x = 0; x < this.state.width; ++x) {
+                if (group_id_map[y][x] === 0) {
+                    floodFill(
+                        x,
+                        y,
+                        this.state.board[y][x],
+                        !!(
+                            original_board &&
+                            this.state.removal[y][x] &&
+                            original_board[y][x] === 0
+                        ),
+                        groupId++,
+                    );
+                }
+
+                if (!(group_id_map[y][x] in groups)) {
+                    groups.push(
+                        new GoStoneGroup(
+                            this.state,
+                            group_id_map[y][x],
+                            this.state.board[y][x],
+                            !!(
+                                original_board &&
+                                this.state.removal[y][x] &&
+                                original_board[y][x] === 0
+                            ),
+                        ),
+                    );
+                }
+                groups[group_id_map[y][x]].addStone(x, y);
+            }
+        }
+
+        /* Compute group neighbors */
+        this.foreachGroup((gr) => {
+            gr.foreachStone((pt) => {
+                const x = pt.x;
+                const y = pt.y;
+                if (x - 1 >= 0 && group_id_map[y][x - 1] !== gr.id) {
+                    gr.addNeighborGroup(groups[group_id_map[y][x - 1]]);
+                }
+                if (x + 1 < this.state.width && group_id_map[y][x + 1] !== gr.id) {
+                    gr.addNeighborGroup(groups[group_id_map[y][x + 1]]);
+                }
+                if (y - 1 >= 0 && group_id_map[y - 1][x] !== gr.id) {
+                    gr.addNeighborGroup(groups[group_id_map[y - 1][x]]);
+                }
+                if (y + 1 < this.state.height && group_id_map[y + 1][x] !== gr.id) {
+                    gr.addNeighborGroup(groups[group_id_map[y + 1][x]]);
+                }
+                for (let Y = -1; Y <= 1; ++Y) {
+                    for (let X = -1; X <= 1; ++X) {
+                        if (
+                            x + X >= 0 &&
+                            x + X < this.state.width &&
+                            y + Y >= 0 &&
+                            y + Y < this.state.height
+                        ) {
+                            gr.addCornerGroup(x + X, y + Y, groups[group_id_map[y + Y][x + X]]);
+                        }
+                    }
+                }
+            });
+        });
+
+        this.foreachGroup((gr) => {
+            gr.computeIsTerritory();
+        });
+        this.foreachGroup((gr) => {
+            gr.computeIsTerritoryInSeki();
+        });
+        this.foreachGroup((gr) => {
+            gr.computeIsEye();
+        });
+        this.foreachGroup((gr) => {
+            gr.computeIsStrongEye();
+        });
+        this.foreachGroup((gr) => {
+            gr.computeIsStrongString();
+        });
+    }
+
+    public foreachGroup(fn: (gr: GoStoneGroup) => void) {
+        for (let i = 1; i < this.groups.length; ++i) {
+            fn(this.groups[i]);
+        }
+    }
+}

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -27,8 +27,9 @@ import {
     SCORE_ESTIMATION_TRIALS,
     SCORE_ESTIMATION_TOLERANCE,
 } from "./GobanCore";
-import { GoEngine, encodeMove, encodeMoves } from "./GoEngine";
-import { GoMath, Group } from "./GoMath";
+import { GoEngine } from "./GoEngine";
+import * as GoMath from "./GoMath";
+import { Group } from "./GoStoneGroup";
 import { MoveTree } from "./MoveTree";
 import { GoTheme } from "./GoTheme";
 import { GoThemes } from "./GoThemes";
@@ -765,7 +766,7 @@ export class GobanCanvas extends GobanCore {
                 auth: this.config.auth,
                 game_id: this.config.game_id,
                 player_id: this.config.player_id,
-                move: encodeMove(x, y),
+                move: GoMath.encodeMove(x, y),
             });
             if (sent) {
                 this.playMovementSound();
@@ -809,7 +810,7 @@ export class GobanCanvas extends GobanCore {
                             game_id: this.config.game_id,
                             player_id: this.config.player_id,
                             removed: removed,
-                            stones: encodeMoves(group),
+                            stones: GoMath.encodeMoves(group),
                         });
                     }
                     if (this.scoring_mode) {

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -18,15 +18,7 @@ import { JGOF, JGOFIntersection, JGOFNumericPlayerColor } from "./JGOF";
 
 import { AdHocFormat } from "./AdHocFormat";
 
-import {
-    GobanCore,
-    GobanConfig,
-    GobanSelectedThemes,
-    GobanMetrics,
-    GOBAN_FONT,
-    SCORE_ESTIMATION_TRIALS,
-    SCORE_ESTIMATION_TOLERANCE,
-} from "./GobanCore";
+import { GobanCore, GobanConfig, GobanSelectedThemes, GobanMetrics, GOBAN_FONT } from "./GobanCore";
 import { GoEngine } from "./GoEngine";
 import * as GoMath from "./GoMath";
 import { Group } from "./GoStoneGroup";
@@ -806,7 +798,7 @@ export class GobanCanvas extends GobanCore {
                         game_id: this.config.game_id,
                         player_id: this.config.player_id,
                         removed: removed,
-                        stones: encodeMoves(group),
+                        stones: GoMath.encodeMoves(group),
                     });
                 }
             } else if (this.mode === "puzzle") {

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -21,7 +21,6 @@ import {
     GoEngineConfig,
     GoEnginePhase,
     GoEngineRules,
-    encodeMove,
     ReviewMessage,
     PlayerColor,
     PuzzleConfig,
@@ -29,7 +28,8 @@ import {
     Score,
 } from "./GoEngine";
 import { GobanMoveError } from "./GobanError";
-import { GoMath, Move, NumberMatrix, Intersection } from "./GoMath";
+import { Move, NumberMatrix, Intersection, encodeMove } from "./GoMath";
+import * as GoMath from "./GoMath";
 import { GoConditionalMove, ConditionalMoveResponse } from "./GoConditionalMove";
 import { MoveTree, MarkInterface, MoveTreePenMarks } from "./MoveTree";
 import { init_score_estimator, ScoreEstimator } from "./ScoreEstimator";

--- a/src/MoveTree.ts
+++ b/src/MoveTree.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { GoMath } from "./GoMath";
+import * as GoMath from "./GoMath";
 import { GoEngine, GoEngineState } from "./GoEngine";
-import { encodeMove } from "./GoEngine";
+import { encodeMove } from "./GoMath";
 import { AdHocPackedMove } from "./AdHocFormat";
 import { JGOFNumericPlayerColor, JGOFPlayerSummary } from "./JGOF";
 import { escapeSGFText, newline2space } from "./Misc";

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -15,9 +15,12 @@
  */
 
 import { dup } from "./GoUtil";
-import { GoMath, Intersection, Group } from "./GoMath";
+import { Intersection, encodeMove, encodeMoves } from "./GoMath";
+import * as GoMath from "./GoMath";
+import { Group } from "./GoStoneGroup";
+import { GoStoneGroups } from "./GoStoneGroups";
 import { GobanCore } from "./GobanCore";
-import { GoEngine, encodeMove, encodeMoves, PlayerScore, GoEngineRules } from "./GoEngine";
+import { GoEngine, PlayerScore, GoEngineRules } from "./GoEngine";
 import { JGOFNumericPlayerColor } from "./JGOF";
 import { _ } from "./translate";
 
@@ -825,10 +828,10 @@ export class ScoreEstimator {
 
         //if (this.phase !== "play") {
         if (this.engine.score_territory) {
-            const gm = new GoMath(this);
+            const groups = new GoStoneGroups(this);
             //console.log(gm);
 
-            gm.foreachGroup((gr) => {
+            groups.foreachGroup((gr) => {
                 if (gr.is_territory) {
                     //console.log(gr);
                     if (!this.engine.score_territory_in_seki && gr.is_territory_in_seki) {

--- a/src/__tests__/GoMath.test.ts
+++ b/src/__tests__/GoMath.test.ts
@@ -1,8 +1,9 @@
-import { GoMath, BoardState } from "../GoMath";
+import { BoardState } from "../GoStoneGroup";
+import { GoStoneGroups } from "../GoStoneGroups";
 import { JGOFNumericPlayerColor } from "../JGOF";
-import * as GoMathFunction from "../GoMath";
+import * as GoMath from "../GoMath";
 
-describe("GoMath constructor", () => {
+describe("GoStoneGroups constructor", () => {
     test("basic board state", () => {
         const THREExTHREE_board: Array<Array<JGOFNumericPlayerColor>> = [
             [1, 0, 2],
@@ -23,24 +24,24 @@ describe("GoMath constructor", () => {
             foreachNeighbor: () => {},
         };
 
-        const gomath_obj = new GoMath(board_state);
+        const board = new GoStoneGroups(board_state);
 
         // TODO: examine usage in real code and flesh out expectations to reflect that usage
-        expect(gomath_obj.groups.length).toBe(7);
-        expect(gomath_obj.groups[0]).toBe(undefined); // what does this element represent?
-        expect(gomath_obj.groups[1].points).toEqual([{ x: 0, y: 0 }]);
-        expect(gomath_obj.groups[2].points).toEqual([{ x: 1, y: 0 }]);
-        expect(gomath_obj.groups[3].points).toEqual([{ x: 2, y: 0 }]);
-        expect(gomath_obj.groups[4].points).toEqual([
+        expect(board.groups.length).toBe(7);
+        expect(board.groups[0]).toBe(undefined); // what does this element represent?
+        expect(board.groups[1].points).toEqual([{ x: 0, y: 0 }]);
+        expect(board.groups[2].points).toEqual([{ x: 1, y: 0 }]);
+        expect(board.groups[3].points).toEqual([{ x: 2, y: 0 }]);
+        expect(board.groups[4].points).toEqual([
             { x: 0, y: 1 },
             { x: 0, y: 2 },
         ]);
-        expect(gomath_obj.groups[5].points).toEqual([
+        expect(board.groups[5].points).toEqual([
             { x: 1, y: 1 },
             { x: 2, y: 1 },
             { x: 2, y: 2 },
         ]);
-        expect(gomath_obj.groups[6].points).toEqual([{ x: 1, y: 2 }]);
+        expect(board.groups[6].points).toEqual([{ x: 1, y: 2 }]);
     });
 });
 
@@ -516,7 +517,7 @@ describe("sortMoves", () => {
 describe("ojeSequenceToMoves", () => {
     test("bad sequence", () => {
         expect(() => {
-            GoMathFunction.ojeSequenceToMoves("nonsense");
+            GoMath.ojeSequenceToMoves("nonsense");
         }).toThrow("root");
     });
 
@@ -532,6 +533,6 @@ describe("ojeSequenceToMoves", () => {
             ],
         ],
     ])("id of %s", (sequence, id) => {
-        expect(GoMathFunction.ojeSequenceToMoves(sequence)).toStrictEqual(id);
+        expect(GoMath.ojeSequenceToMoves(sequence)).toStrictEqual(id);
     });
 });

--- a/src/__tests__/GoMath_GoStoneGroup.test.ts
+++ b/src/__tests__/GoMath_GoStoneGroup.test.ts
@@ -1,4 +1,5 @@
-import { GoMath } from "../GoMath";
+import * as GoMath from "../GoMath";
+import { GoStoneGroups } from "../GoStoneGroups";
 
 // Here is a board displaying many of the features GoStoneGroup cares about.
 
@@ -26,7 +27,7 @@ const FEATURE_BOARD = [
 const REMOVAL = GoMath.makeMatrix(5, 5);
 
 function makeGoMathWithFeatureBoard() {
-    return new GoMath({
+    return new GoStoneGroups({
         board: FEATURE_BOARD,
         removal: REMOVAL,
         width: 5,

--- a/src/__tests__/GoMath_positionId.test.ts
+++ b/src/__tests__/GoMath_positionId.test.ts
@@ -1,4 +1,4 @@
-import { GoMath } from "../GoMath";
+import * as GoMath from "../GoMath";
 import { JGOFNumericPlayerColor } from "../JGOF";
 
 type Testcase = {

--- a/src/__tests__/GobanCanvas.test.ts
+++ b/src/__tests__/GobanCanvas.test.ts
@@ -6,7 +6,7 @@
 
 import { GobanCanvas, GobanCanvasConfig } from "../GobanCanvas";
 import { AUTOSCORE_TOLERANCE, AUTOSCORE_TRIALS } from "../GoEngine";
-import { GoMath } from "../GoMath";
+import * as GoMath from "../GoMath";
 
 let board_div: HTMLDivElement;
 let mock_socket: {

--- a/src/goban.ts
+++ b/src/goban.ts
@@ -21,6 +21,7 @@ export * from "./GoEngine";
 export * from "./GobanError";
 export * from "./GoMath";
 export * from "./GoStoneGroup";
+export * from "./GoStoneGroups";
 export * from "./GoTheme";
 export * from "./GoThemes";
 export * from "./GoUtil";

--- a/src/goban.ts
+++ b/src/goban.ts
@@ -19,7 +19,6 @@ export * from "./GobanCanvas";
 export * from "./GoConditionalMove";
 export * from "./GoEngine";
 export * from "./GobanError";
-export * from "./GoMath";
 export * from "./GoStoneGroup";
 export * from "./GoStoneGroups";
 export * from "./GoTheme";
@@ -33,6 +32,8 @@ export * from "./JGOF";
 export * from "./AIReview";
 export * from "./AdHocFormat";
 export * from "./TestGoban";
+
+export * as GoMath from "./GoMath";
 export { placeRenderedImageStone, preRenderImageStone } from "./themes/image_stones";
 export { GobanCanvas as Goban, GobanCanvasConfig as GobanConfig } from "./GobanCanvas";
 


### PR DESCRIPTION
This refactor makes most of the member function of the old `GoMath` class into plain exported functions, and factors the `GoMath` object out into a new class `GoStoneGroups` (who's only method is `forEachGroup`).

It means that clients of GoMath now have to do the GoMath function imports by refering to GoMath module specifically, either by named-symbol-import or `import * as GoMath from "goban/src/GoMath"`

The latter makes existing calls to GoMath methods work unchanged.
