### PR TITLE
Use EventEmitter3 types

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -28,7 +28,8 @@ import {
 } from "./JGOF";
 import { AdHocPackedMove } from "./AdHocFormat";
 import { _ } from "./translate";
-import { TypedEventEmitter } from "./TypedEventEmitter";
+import { TypedEventEmitter, LegacyEventsShim } from "./TypedEventEmitter";
+import EventEmitter = require("eventemitter3");
 
 declare const CLIENT: boolean;
 declare const SERVER: boolean;
@@ -2819,10 +2820,13 @@ export class GoEngine extends TypedEventEmitter<Events> {
     }
 
     public parentEventEmitter?: TypedEventEmitter<Events>;
-    emit<K extends Extract<keyof Events, string>>(event: K, arg?: Events[K]): boolean {
-        let ret: boolean = super.emit(event, arg);
+    emit<K extends EventEmitter.EventNames<LegacyEventsShim<Events>>>(
+        event: K,
+        ...args: EventEmitter.EventArgs<LegacyEventsShim<Events>, K>
+    ): boolean {
+        let ret: boolean = super.emit(event, ...args);
         if (this.parentEventEmitter) {
-            ret ||= this.parentEventEmitter.emit(event, arg);
+            ret ||= this.parentEventEmitter.emit(event, ...args);
         }
         return ret;
     }

--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -287,6 +287,9 @@ export function encodeMoves(lst: Array<Move>) {
 
 export type PlayerColor = "black" | "white";
 
+type EventNames = EventEmitter.EventNames<Events>;
+type EventArgs<K extends EventNames> = EventEmitter.EventArgs<LegacyEventsShim<Events>, K>;
+
 export class GoEngine extends TypedEventEmitter<Events> {
     //public readonly players.black.id:number;
     //public readonly players.white.id:number;
@@ -2820,10 +2823,7 @@ export class GoEngine extends TypedEventEmitter<Events> {
     }
 
     public parentEventEmitter?: TypedEventEmitter<Events>;
-    emit<K extends EventEmitter.EventNames<LegacyEventsShim<Events>>>(
-        event: K,
-        ...args: EventEmitter.EventArgs<LegacyEventsShim<Events>, K>
-    ): boolean {
+    emit<K extends EventNames>(event: K, ...args: EventArgs<K>): boolean {
         let ret: boolean = super.emit(event, ...args);
         if (this.parentEventEmitter) {
             ret ||= this.parentEventEmitter.emit(event, ...args);


### PR DESCRIPTION
## Background

For testing, it would be helpful to have `goban.eventNames()` and `goban.listenerCount()`.  I looked at adding those methods similar to the existing ones, but I thought it might be good just to pull the interface from EventEmitter3 directly.  It looks like [they've had a d.ts file for many years now](https://github.com/primus/eventemitter3/issues/67#issuecomment-250670758).

## Notes

The type interface for the generic arg is a bit different - the values are function signatures instead of a single data object.  This is more flexible, supporting multiple arguments, but OGS doesn't really make use of that, so I made a type transformer `LegacyEventsShim` to convert our existing event interfaces to something EventEmitter3 can consume.