### PR TITLE
Add tests for computeScore()

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -44,7 +44,7 @@ export default {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     "global": {
-      "lines": 45
+      "lines": 50
     }
   },
 

--- a/src/__tests__/GoEngine_computeScore.test.ts
+++ b/src/__tests__/GoEngine_computeScore.test.ts
@@ -10,6 +10,7 @@
 (global as any).CLIENT = true;
 
 import { GoEngine } from "../GoEngine";
+import { movesFromBoardState } from "../test_utils";
 
 test("GoEngine defaults", () => {
     const engine = new GoEngine({});
@@ -92,4 +93,61 @@ test("AGA handicap - white is given compensation ", () => {
             total: 3.5,
         }),
     );
+});
+
+test("Both sides have territory", () => {
+    const board = [
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+    ];
+    const engine = new GoEngine({ width: 4, height: 4, moves: movesFromBoardState(board) });
+
+    expect(engine.computeScore()).toEqual({
+        black: expect.objectContaining({
+            scoring_positions: "aaabacad",
+            stones: 0,
+            territory: 4,
+            total: 4,
+        }),
+        white: expect.objectContaining({
+            komi: 6.5,
+            scoring_positions: "dadbdcdd",
+            stones: 0,
+            territory: 4,
+            total: 10.5,
+        }),
+    });
+});
+
+test("Both sides have territory (Chinese)", () => {
+    const board = [
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+    ];
+    const engine = new GoEngine({
+        width: 4,
+        height: 4,
+        moves: movesFromBoardState(board),
+        rules: "chinese",
+    });
+
+    expect(engine.computeScore()).toEqual({
+        black: expect.objectContaining({
+            scoring_positions: "aaabacadbabbbcbd",
+            stones: 4,
+            territory: 4,
+            total: 8,
+        }),
+        white: expect.objectContaining({
+            komi: 7.5,
+            scoring_positions: "dadbdcddcacbcccd",
+            stones: 4,
+            territory: 4,
+            total: 15.5,
+        }),
+    });
 });

--- a/src/__tests__/GoEngine_computeScore.test.ts
+++ b/src/__tests__/GoEngine_computeScore.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// ^^ jsdom environment is because getLocation() returns window.location.pathname
+// Same about CLIENT.
+//
+// TODO: move this into a setup-jest.ts file
+
+(global as any).CLIENT = true;
+
+import { GoEngine } from "../GoEngine";
+
+test("GoEngine defaults", () => {
+    const engine = new GoEngine({});
+    expect(engine.computeScore()).toEqual({
+        black: {
+            handicap: 0,
+            komi: 0,
+            prisoners: 0,
+            scoring_positions: "",
+            stones: 0,
+            territory: 0,
+            total: 0,
+        },
+        white: {
+            handicap: 0,
+            komi: 6.5,
+            prisoners: 0,
+            scoring_positions: "",
+            stones: 0,
+            territory: 0,
+            total: 6.5,
+        },
+    });
+});
+
+test("GoEngine defaults", () => {
+    const engine = new GoEngine({});
+    expect(engine.computeScore()).toEqual({
+        black: {
+            handicap: 0,
+            komi: 0,
+            prisoners: 0,
+            scoring_positions: "",
+            stones: 0,
+            territory: 0,
+            total: 0,
+        },
+        white: {
+            handicap: 0,
+            komi: 6.5,
+            prisoners: 0,
+            scoring_positions: "",
+            stones: 0,
+            territory: 0,
+            total: 6.5,
+        },
+    });
+});
+
+test("Japanese handicap", () => {
+    const engine = new GoEngine({ rules: "japanese", handicap: 4 });
+    expect(engine.computeScore()).toEqual({
+        black: expect.objectContaining({
+            handicap: 0,
+            komi: 0,
+            territory: 357,
+            total: 357,
+        }),
+        white: expect.objectContaining({
+            handicap: 4,
+            komi: 0.5,
+            territory: 0,
+            total: 0.5,
+        }),
+    });
+});
+
+test("AGA handicap - white is given compensation ", () => {
+    const engine = new GoEngine({ rules: "aga", handicap: 4 });
+
+    // From the AGA Concise rules of Go:
+    //
+    // If the players have agreed to use area counting to score the game,
+    // White receives an additional point of compensation for each Black
+    // handicap stone after the first.
+    expect(engine.computeScore().white).toEqual(
+        expect.objectContaining({
+            komi: 0.5,
+            handicap: 3,
+            total: 3.5,
+        }),
+    );
+});

--- a/src/__tests__/GoEngine_computeScore.test.ts
+++ b/src/__tests__/GoEngine_computeScore.test.ts
@@ -151,3 +151,37 @@ test("Both sides have territory (Chinese)", () => {
         }),
     });
 });
+
+test("Removed stones", () => {
+    const board = [
+        [2, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 1],
+    ];
+    const engine = new GoEngine({
+        width: 4,
+        height: 4,
+        moves: movesFromBoardState(board),
+        rules: "chinese",
+        removed: "aadd",
+    });
+
+    expect(engine.computeScore()).toEqual({
+        black: expect.objectContaining({
+            prisoners: 0,
+            scoring_positions: "aaabacadbabbbcbd",
+            stones: 4,
+            territory: 4,
+            total: 8,
+        }),
+        white: expect.objectContaining({
+            prisoners: 0,
+            komi: 7.5,
+            scoring_positions: "dadbdcddcacbcccd",
+            stones: 4,
+            territory: 4,
+            total: 15.5,
+        }),
+    });
+});

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -26,6 +26,7 @@ export * from "./JGOF";
 export * from "./AdHocFormat";
 export * from "./AIReview";
 export * from "./Misc";
+export * from "./test_utils";
 
 export * from "./GoMath";
 export * as GoMath from "./GoMath";

--- a/src/goban.ts
+++ b/src/goban.ts
@@ -32,6 +32,7 @@ export * from "./JGOF";
 export * from "./AIReview";
 export * from "./AdHocFormat";
 export * from "./TestGoban";
+export * from "./test_utils";
 
 export * as GoMath from "./GoMath";
 export { placeRenderedImageStone, preRenderImageStone } from "./themes/image_stones";

--- a/src/test_utils.ts
+++ b/src/test_utils.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) Benjamin P. Jones
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AdHocPackedMove } from "./AdHocFormat";
+import { JGOFNumericPlayerColor } from "./JGOF";
+
+type Coordinate = { x: number; y: number };
+
+function forEach2D<T>(grid: T[][], callbackfn: (val: T, index: Coordinate) => void) {
+    for (let y = 0; y < grid.length; ++y) {
+        for (let x = 0; x < grid[y].length; ++x) {
+            callbackfn(grid[y][x], { x, y });
+        }
+    }
+}
+
+function getStonePositions(board: JGOFNumericPlayerColor[][], color: JGOFNumericPlayerColor) {
+    const ret: Coordinate[] = [];
+
+    forEach2D(board, (val, index) => {
+        if (val === color) {
+            ret.push(index);
+        }
+    });
+
+    return ret;
+}
+
+function isPass([x, y]: AdHocPackedMove) {
+    return x === -1 && y === -1;
+}
+
+/**
+ * Returns a list of moves such that the board state would be equivalent to `board`.
+ * @param board The desired board state.
+ */
+export function movesFromBoardState(board: JGOFNumericPlayerColor[][]): AdHocPackedMove[] {
+    const black_pos: Coordinate[] = getStonePositions(board, JGOFNumericPlayerColor.BLACK);
+    const white_pos: Coordinate[] = getStonePositions(board, JGOFNumericPlayerColor.WHITE);
+
+    const ret: AdHocPackedMove[] = [];
+
+    while (black_pos.length || white_pos.length) {
+        const b = black_pos.pop();
+        const w = white_pos.pop();
+        ret.push(b ? [b.x, b.y] : [-1, -1]);
+        ret.push(w ? [w.x, w.y] : [-1, -1]);
+    }
+
+    // We clear out trailing passes to prevent ambiguity about whether the
+    // game is about to end
+    while (isPass(ret[ret.length - 1])) {
+        ret.pop();
+    }
+
+    return ret;
+}


### PR DESCRIPTION
This adds coverage for "happy paths".  There are a few patches of code that are uncovered ([AGA scoring bug remediation](https://github.com/online-go/goban/blob/16481d6b1b678766d18c248c66f689e28a548e7e/src/GoEngine.ts#L1882-L1897) & some mostly dead code [1](https://github.com/online-go/goban/blob/16481d6b1b678766d18c248c66f689e28a548e7e/src/GoEngine.ts#L1830-L1838), [2](https://github.com/online-go/goban/blob/16481d6b1b678766d18c248c66f689e28a548e7e/src/GoEngine.ts#L1792-L1800)).