### PR TITLE
Remove GoStoneGroup.dame (unused)

### DIFF
--- a/src/GoStoneGroup.ts
+++ b/src/GoStoneGroup.ts
@@ -28,7 +28,6 @@ export interface BoardState {
 
 export class GoStoneGroup {
     probable_color: JGOFNumericPlayerColor;
-    dame: boolean;
     corner_groups: { [y: string]: { [x: string]: GoStoneGroup } };
     points: Array<Intersection>;
     neighbors: Array<GoStoneGroup>;
@@ -48,7 +47,7 @@ export class GoStoneGroup {
 
     private __added_neighbors: { [group_id: number]: boolean };
 
-    constructor(board_state: BoardState, id: number, color: JGOFNumericPlayerColor, dame: boolean) {
+    constructor(board_state: BoardState, id: number, color: JGOFNumericPlayerColor) {
         this.board_state = board_state;
         this.points = [];
         this.neighbors = [];
@@ -58,7 +57,6 @@ export class GoStoneGroup {
         this.adjacent_black = 0;
         this.adjacent_white = 0;
         this.probable_color = 0;
-        this.dame = dame;
 
         this.__added_neighbors = {};
         this.corner_groups = {};

--- a/src/GoStoneGroups.ts
+++ b/src/GoStoneGroups.ts
@@ -77,16 +77,7 @@ export class GoStoneGroups {
 
                 if (!(group_id_map[y][x] in groups)) {
                     groups.push(
-                        new GoStoneGroup(
-                            this.state,
-                            group_id_map[y][x],
-                            this.state.board[y][x],
-                            !!(
-                                original_board &&
-                                this.state.removal[y][x] &&
-                                original_board[y][x] === 0
-                            ),
-                        ),
+                        new GoStoneGroup(this.state, group_id_map[y][x], this.state.board[y][x]),
                     );
                 }
                 groups[group_id_map[y][x]].addStone(x, y);


### PR DESCRIPTION
I guess this is related to the `dame` parameter used in `floodFill()`, but it doesn't seem to be used in `GoStoneGroup`.

I searched around both of the downstream codebases.  Obviously there are mentions of *dame*, but I'm pretty sure they didn't involve GoStoneGroup.

Tested: `yarn test` `yarn build-debug`