### PR TITLE
Remove unused fields in GoStoneGroup.

### DIFF
--- a/src/GoStoneGroup.ts
+++ b/src/GoStoneGroup.ts
@@ -27,20 +27,14 @@ export interface BoardState {
 }
 
 export class GoStoneGroup {
-    probable_color: JGOFNumericPlayerColor;
-    dame: boolean;
     corner_groups: { [y: string]: { [x: string]: GoStoneGroup } };
     points: Array<Intersection>;
     neighbors: Array<GoStoneGroup>;
     is_territory: boolean = false;
     color: JGOFNumericPlayerColor;
-    is_probably_dead: boolean = false;
-    is_probably_dame: boolean = false;
     board_state: BoardState;
     id: number;
     is_strong_eye: boolean;
-    adjacent_white: number;
-    adjacent_black: number;
     is_eye: boolean = false;
     is_strong_string: boolean = false;
     territory_color: JGOFNumericPlayerColor = 0;
@@ -48,17 +42,13 @@ export class GoStoneGroup {
 
     private __added_neighbors: { [group_id: number]: boolean };
 
-    constructor(board_state: BoardState, id: number, color: JGOFNumericPlayerColor, dame: boolean) {
+    constructor(board_state: BoardState, id: number, color: JGOFNumericPlayerColor) {
         this.board_state = board_state;
         this.points = [];
         this.neighbors = [];
         this.id = id;
         this.color = color;
         this.is_strong_eye = false;
-        this.adjacent_black = 0;
-        this.adjacent_white = 0;
-        this.probable_color = 0;
-        this.dame = dame;
 
         this.__added_neighbors = {};
         this.corner_groups = {};

--- a/src/GoStoneGroups.ts
+++ b/src/GoStoneGroups.ts
@@ -77,16 +77,7 @@ export class GoStoneGroups {
 
                 if (!(group_id_map[y][x] in groups)) {
                     groups.push(
-                        new GoStoneGroup(
-                            this.state,
-                            group_id_map[y][x],
-                            this.state.board[y][x],
-                            !!(
-                                original_board &&
-                                this.state.removal[y][x] &&
-                                original_board[y][x] === 0
-                            ),
-                        ),
+                        new GoStoneGroup(this.state, group_id_map[y][x], this.state.board[y][x]),
                     );
                 }
                 groups[group_id_map[y][x]].addStone(x, y);


### PR DESCRIPTION
Supercedes  #113 and #114

The internals of `GoStoneGroup` do not use the following fields:

- `probable_color`
- `dame`
- `is_probably_dead`
- `is_probably_dame`
- `adjacent_white`
- `adjacent_black`

Because the fields are public, it's a little difficult to verify they aren't used, but `GoStoneGroup` is only constructed in `GoStoneGroups` and `GoStoneGroups` is only constructed in two places ([GoEngine](https://github.com/online-go/goban/blob/16481d6b1b678766d18c248c66f689e28a548e7e/src/GoEngine.ts#L1810), [ScoreEstimator](https://github.com/online-go/goban/blob/b1313e44a143e5903f58699614d231ada6800d71/src/ScoreEstimator.ts#L830)). Both scopes are short and the type checker should catch any erroneously removed fields.

Tested: `yarn build-debug`, `yarn test`