### PR TITLE
Give `GoEngineConfig.moves` a specific type that is exported.

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -94,6 +94,9 @@ export interface GoEnginePlayerEntry {
     pro?: boolean;
 }
 
+// The word "array" is deliberately included in the type name to differentiate from a move tree.
+export type GobanMovesArray = Array<AdHocPackedMove> | Array<JGOFMove>;
+
 export interface GoEngineConfig {
     game_id?: number | string;
     review_id?: number;
@@ -129,7 +132,7 @@ export interface GoEngineConfig {
     };
 
     time_control?: JGOFTimeControl;
-    moves?: Array<AdHocPackedMove> | Array<JGOFMove>;
+    moves?: GobanMovesArray;
     move_tree?: MoveTreeJson;
     ranked?: boolean;
     original_disable_analysis?: boolean;


### PR DESCRIPTION
... clients shouldn't have to worry about what composite type this is, unless they really care.