### PR TITLE
Clean up ScoreEstimator.ts

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -681,28 +681,6 @@ export class GoEngine extends EventEmitter<Events> {
         if (config.removed) {
             removed = this.decodeMoves(config.removed);
         }
-        if (
-            CLIENT &&
-            !this.territory_included_in_sgf &&
-            typeof config.removed === "undefined" &&
-            config.original_sgf &&
-            /[0-9.]+/.test(self.outcome)
-        ) {
-            // Game data for SGF uploaded games don't always include removed stones, so we use score
-            // estimator to find probably dead stones to get a closer approximation of what
-            // territories should be marked in the final board position.
-            //
-            // NOTE: Some Go clients (not OGS, at least for now) do include dead stones in their
-            // SGFs, which we respect if present and skip using the score estimator.
-            const se = new ScoreEstimator(
-                this.goban_callback,
-                this,
-                AUTOSCORE_TRIALS,
-                AUTOSCORE_TOLERANCE,
-                true,
-            );
-            removed = this.decodeMoves(se.getProbablyDead());
-        }
         if (removed) {
             for (let i = 0; i < removed.length; ++i) {
                 this.setRemoved(removed[i].x, removed[i].y, true, false);

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -2100,7 +2100,7 @@ export class GobanCanvas extends GobanCore {
 
         if (this.scoring_mode && this.score_estimate) {
             const se = this.score_estimate;
-            const est = se.heat[j][i];
+            const est = se.ownership[j][i];
 
             ctx.beginPath();
 

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -256,7 +256,6 @@ export class ScoreEstimator {
     tolerance: number;
     group_list: Array<SEGroup>;
     amount: number = NaN;
-    amount_fractional: string = "[unset]";
     ownership: Array<Array<number>>;
     territory: Array<Array<number>>;
     trials: number;
@@ -442,11 +441,9 @@ export class ScoreEstimator {
         if (typeof score === "undefined") {
             this.winner = this.estimated_hard_score > 0 ? _("Black") : _("White");
             this.amount = Math.abs(this.estimated_hard_score);
-            this.amount_fractional = Math.abs(this.estimated_hard_score).toFixed(1);
         } else {
             this.winner = score > 0 ? _("Black") : _("White");
             this.amount = Math.abs(score);
-            this.amount_fractional = Math.abs(score).toFixed(1);
         }
 
         if (this.goban_callback && this.goban_callback.updateScoreEstimation) {

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -134,8 +134,6 @@ class SEGroup {
     id: number;
     color: JGOFNumericPlayerColor;
     removed: boolean;
-    estimated_score: number;
-    estimated_hard_score: number;
     neighbors: Array<SEGroup>;
     neighbor_map: { [group_id: string]: boolean };
     liberties: number = 0;
@@ -150,8 +148,6 @@ class SEGroup {
         this.neighboring_enemy = [];
         this.neighbor_map = {};
         this.removed = false;
-        this.estimated_score = 0.0;
-        this.estimated_hard_score = 0.0;
 
         // this.liberties is set by ScoreEstimator.resetGroups */
     }

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -135,7 +135,6 @@ class SEGroup {
     removed: boolean;
     neighbors: Array<SEGroup>;
     neighbor_map: { [group_id: string]: boolean };
-    liberties: number = 0;
 
     constructor(se: ScoreEstimator, color: JGOFNumericPlayerColor, id: number) {
         this.points = [];
@@ -147,8 +146,6 @@ class SEGroup {
         this.neighboring_enemy = [];
         this.neighbor_map = {};
         this.removed = false;
-
-        // this.liberties is set by ScoreEstimator.resetGroups */
     }
     add(i: number, j: number) {
         this.points.push({ x: i, y: j });
@@ -502,19 +499,6 @@ export class ScoreEstimator {
                 grp.addNeighbor(this.group_list[gs_neighbor.id - 1]);
             }
         }
-
-        /* compute liberties */
-        this.foreachGroup((g: SEGroup) => {
-            if (g.color) {
-                let liberties = 0;
-                g.foreachNeighboringPoint((pt) => {
-                    if (this.board[pt.y][pt.x] === 0 || this.removal[pt.y][pt.x]) {
-                        ++liberties;
-                    }
-                });
-                g.liberties = liberties;
-            }
-        });
     }
     foreachGroup(fn: (group: SEGroup) => void): void {
         for (let i = 0; i < this.group_list.length; ++i) {

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -271,11 +271,9 @@ export class ScoreEstimator {
     amount: number = NaN;
     amount_fractional: string = "[unset]";
     ownership: Array<Array<number>>;
-    area: Array<Array<number>>; // hard numeric values
     territory: Array<Array<number>>;
     trials: number;
     winner: string = "";
-    heat: Array<Array<number>>;
     color_to_move: "black" | "white";
     estimated_score: number;
     estimated_hard_score: number;
@@ -299,9 +297,7 @@ export class ScoreEstimator {
         this.board = dup(engine.board);
         this.removal = GoMath.makeMatrix(this.width, this.height, 0);
         this.marks = GoMath.makeMatrix(this.width, this.height, 0);
-        this.area = GoMath.makeMatrix(this.width, this.height, 0);
         this.ownership = GoMath.makeMatrix(this.width, this.height, 0);
-        this.heat = GoMath.makeMatrix(this.width, this.height, 0.0);
         this.groups = GoMath.makeEmptyObjectMatrix(this.width, this.height);
         this.territory = GoMath.makeMatrix(this.width, this.height, 0);
         this.estimated_score = 0.0;
@@ -457,12 +453,6 @@ export class ScoreEstimator {
         /* Build up our heat map and ownership */
         /* negative for black, 0 for neutral, positive for white */
         this.ownership = ownership;
-        for (let y = 0; y < this.height; ++y) {
-            for (let x = 0; x < this.width; ++x) {
-                this.heat[y][x] = ownership[y][x];
-                this.area[y][x] = ownership[y][x] < 0 ? 2 : ownership[y][x];
-            }
-        }
         this.estimated_score = estimated_score - this.engine.komi;
         this.estimated_hard_score = estimated_score - this.engine.komi;
 

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -47,6 +47,8 @@ export interface ScoreEstimateRequest {
     height: number;
     board_state: Array<Array<number>>;
     rules: GoEngineRules;
+    black_prisoners?: number;
+    white_prisoners?: number;
     komi?: number;
     jwt: string;
 }

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -285,7 +285,6 @@ export class ScoreEstimator {
     //score_prisoners:boolean;
     //score_territory:boolean;
     //score_territory_in_seki:boolean;
-    removed: Array<Array<number>>;
     white: PlayerScore = {
         total: 0,
         stones: 0,
@@ -308,7 +307,7 @@ export class ScoreEstimator {
     engine: GoEngine;
     groups: Array<Array<SEGroup>>;
     currentMarker: number;
-    removal: Array<Array<number>>; // TODO: This is defined to be a dup of this.removed, can we remove that?
+    removal: Array<Array<number>>;
     goban_callback?: GobanCore;
     tolerance: number;
     group_list: Array<SEGroup>;
@@ -343,7 +342,7 @@ export class ScoreEstimator {
         this.height = engine.height;
         this.color_to_move = engine.colorToMove();
         this.board = dup(engine.board);
-        this.removal = this.removed = GoMath.makeMatrix(this.width, this.height, 0);
+        this.removal = GoMath.makeMatrix(this.width, this.height, 0);
         this.marks = GoMath.makeMatrix(this.width, this.height, 0);
         this.area = GoMath.makeMatrix(this.width, this.height, 0);
         this.ownership = GoMath.makeMatrix(this.width, this.height, 0);
@@ -625,7 +624,7 @@ export class ScoreEstimator {
                             continue;
                         }
                         this.marks[yy][xx] = this.currentMarker;
-                        if (this.board[yy][xx] === color || (color === 0 && this.removed[yy][xx])) {
+                        if (this.board[yy][xx] === color || (color === 0 && this.removal[yy][xx])) {
                             this.groups[yy][xx] = g;
                             g.add(xx, yy, color);
                             this.foreachNeighbor({ x: xx, y: yy }, push_on_stack);
@@ -657,7 +656,7 @@ export class ScoreEstimator {
             if (g.color) {
                 let liberties = 0;
                 g.foreachNeighboringPoint((pt) => {
-                    if (this.board[pt.y][pt.x] === 0 || this.removed[pt.y][pt.x]) {
+                    if (this.board[pt.y][pt.x] === 0 || this.removal[pt.y][pt.x]) {
                         ++liberties;
                     }
                 });
@@ -799,7 +798,7 @@ export class ScoreEstimator {
         /* clear removed */
         for (let y = 0; y < this.height; ++y) {
             for (let x = 0; x < this.width; ++x) {
-                if (this.removed[y][x]) {
+                if (this.removal[y][x]) {
                     if (this.board[y][x] === 1) {
                         ++removed_black;
                     }

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -275,7 +275,6 @@ export class ScoreEstimator {
     trials: number;
     winner: string = "";
     color_to_move: "black" | "white";
-    estimated_score: number;
     estimated_hard_score: number;
     when_ready: Promise<void>;
     prefer_remote: boolean;
@@ -300,7 +299,6 @@ export class ScoreEstimator {
         this.ownership = GoMath.makeMatrix(this.width, this.height, 0);
         this.groups = GoMath.makeEmptyObjectMatrix(this.width, this.height);
         this.territory = GoMath.makeMatrix(this.width, this.height, 0);
-        this.estimated_score = 0.0;
         this.estimated_hard_score = 0.0;
         this.group_list = [];
         this.trials = trials;
@@ -453,13 +451,12 @@ export class ScoreEstimator {
         /* Build up our heat map and ownership */
         /* negative for black, 0 for neutral, positive for white */
         this.ownership = ownership;
-        this.estimated_score = estimated_score - this.engine.komi;
         this.estimated_hard_score = estimated_score - this.engine.komi;
 
         if (typeof score === "undefined") {
             this.winner = this.estimated_hard_score > 0 ? _("Black") : _("White");
             this.amount = Math.abs(this.estimated_hard_score);
-            this.amount_fractional = Math.abs(this.estimated_score).toFixed(1);
+            this.amount_fractional = Math.abs(this.estimated_hard_score).toFixed(1);
         } else {
             this.winner = score > 0 ? _("Black") : _("White");
             this.amount = Math.abs(score);

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -250,7 +250,6 @@ export class ScoreEstimator {
 
     engine: GoEngine;
     groups: Array<Array<SEGroup>>;
-    currentMarker: number;
     removal: Array<Array<number>>;
     goban_callback?: GobanCore;
     tolerance: number;
@@ -274,7 +273,6 @@ export class ScoreEstimator {
     ) {
         this.goban_callback = goban_callback;
 
-        this.currentMarker = 1;
         this.engine = engine;
         this.width = engine.width;
         this.height = engine.height;
@@ -594,9 +592,6 @@ export class ScoreEstimator {
     }
     getGroup(x: number, y: number): SEGroup {
         return this.groups[y][x];
-    }
-    incrementCurrentMarker(): void {
-        ++this.currentMarker;
     }
 
     /**

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -85,19 +85,11 @@ let init_promise: Promise<boolean>;
 
 export function init_score_estimator(): Promise<boolean> {
     if (CLIENT) {
-        /*
-        if (remote_scorer) {
-            return Promise.resolve(true);
-        }
-        */
-
         if (OGSScoreEstimator_initialized) {
-            //console.log("Already initialized");
             return Promise.resolve(true);
         }
 
         if (init_promise) {
-            //console.log("An existing promise");
             return init_promise;
         }
 
@@ -114,22 +106,18 @@ export function init_score_estimator(): Promise<boolean> {
         }
 
         if (OGSScoreEstimatorModule) {
-            //console.log("Already loaded");
             OGSScoreEstimatorModule = OGSScoreEstimatorModule();
             OGSScoreEstimator_initialized = true;
             return Promise.resolve(true);
         }
 
-        //console.log("Sync script");
         const script: HTMLScriptElement = document.getElementById(
             "ogs_score_estimator_script",
         ) as HTMLScriptElement;
         if (script) {
             let resolve: (tf: boolean) => void;
-            //let reject;
             init_promise = new Promise<boolean>((_resolve, _reject) => {
                 resolve = _resolve;
-                //reject  = _reject;
             });
 
             script.onload = () => {
@@ -247,23 +235,17 @@ class SEGroup {
     }
     foreachNeighborGroup(fn: (group: SEGroup) => void): void {
         for (let i = 0; i < this.neighbors.length; ++i) {
-            //if (!this.neighbors[i].removed) {
             fn(this.neighbors[i]);
-            //}
         }
     }
     foreachNeighborSpaceGroup(fn: (group: SEGroup) => void): void {
         for (let i = 0; i < this.neighboring_space.length; ++i) {
-            //if (!this.neighboring_space[i].removed) {
             fn(this.neighboring_space[i]);
-            //}
         }
     }
     foreachNeighborEnemyGroup(fn: (group: SEGroup) => void): void {
         for (let i = 0; i < this.neighboring_enemy.length; ++i) {
-            //if (!this.neighboring_enemy[i].removed) {
             fn(this.neighboring_enemy[i]);
-            //}
         }
     }
     setRemoved(removed: boolean): void {
@@ -281,10 +263,6 @@ export class ScoreEstimator {
     board: Array<Array<JGOFNumericPlayerColor>>;
     white_prisoners: number = 0;
     black_prisoners: number = 0;
-    //score_stones:boolean;
-    //score_prisoners:boolean;
-    //score_territory:boolean;
-    //score_territory_in_seki:boolean;
     white: PlayerScore = {
         total: 0,
         stones: 0,
@@ -359,7 +337,6 @@ export class ScoreEstimator {
 
         this.resetGroups();
         this.when_ready = this.estimateScore(this.trials, this.tolerance);
-        //this.sealDame();
     }
 
     public estimateScore(trials: number, tolerance: number): Promise<void> {
@@ -494,7 +471,6 @@ export class ScoreEstimator {
         i = 0;
         for (let y = 0; y < this.height; ++y) {
             for (let x = 0; x < this.width; ++x) {
-                //ownership[y][x] = ints[i] < 0 ? 2 : ints[i];
                 ownership[y][x] = ints[i];
                 ++i;
 
@@ -541,13 +517,11 @@ export class ScoreEstimator {
     updateEstimate(estimated_score: number, ownership: Array<Array<number>>, score?: number) {
         /* Build up our heat map and ownership */
         /* negative for black, 0 for neutral, positive for white */
-        //this.heat = GoMath.makeMatrix(this.width, this.height, 0.0);
         this.ownership = ownership;
         for (let y = 0; y < this.height; ++y) {
             for (let x = 0; x < this.width; ++x) {
                 this.heat[y][x] = ownership[y][x];
                 this.area[y][x] = ownership[y][x] < 0 ? 2 : ownership[y][x];
-                //this.area[y][x] = ownership[y][x];
                 this.estimated_area[y][x] = this.area[y][x];
             }
         }
@@ -564,11 +538,6 @@ export class ScoreEstimator {
             this.amount_fractional = Math.abs(score).toFixed(1);
         }
 
-        /*
-        if (this.goban_callback && this.goban_callback.heatmapUpdated) {
-            this.goban_callback.heatmapUpdated();
-        }
-        */
         if (this.goban_callback && this.goban_callback.updateScoreEstimation) {
             this.goban_callback.updateScoreEstimation();
         }
@@ -679,7 +648,6 @@ export class ScoreEstimator {
         this.estimateScore(this.trials, this.tolerance).catch(() => {
             /* empty */
         });
-        //this.resetGroups();
     }
     toggleMetaGroupRemoval(x: number, y: number): void {
         const already_done: { [k: string]: boolean } = {};
@@ -810,14 +778,11 @@ export class ScoreEstimator {
             }
         }
 
-        //if (this.phase !== "play") {
         if (this.engine.score_territory) {
             const groups = new GoStoneGroups(this);
-            //console.log(gm);
 
             groups.foreachGroup((gr) => {
                 if (gr.is_territory) {
-                    //console.log(gr);
                     if (!this.engine.score_territory_in_seki && gr.is_territory_in_seki) {
                         return;
                     }
@@ -831,7 +796,6 @@ export class ScoreEstimator {
                         "What should be unreached code is running, should probably be running " +
                             "this[color].territory += markScored(gr.points, false);",
                     );
-                    //this[color].territory += markScored(gr.points, false);
                 }
             });
         }
@@ -851,7 +815,6 @@ export class ScoreEstimator {
                 }
             }
         }
-        //}
 
         if (this.engine.score_prisoners) {
             this.black.prisoners = this.black_prisoners + removed_white;

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -274,7 +274,6 @@ export class ScoreEstimator {
     area: Array<Array<number>>; // hard numeric values
     territory: Array<Array<number>>;
     trials: number;
-    estimated_area: Array<Array<number>>;
     winner: string = "";
     heat: Array<Array<number>>;
     color_to_move: "black" | "white";
@@ -303,7 +302,6 @@ export class ScoreEstimator {
         this.area = GoMath.makeMatrix(this.width, this.height, 0);
         this.ownership = GoMath.makeMatrix(this.width, this.height, 0);
         this.heat = GoMath.makeMatrix(this.width, this.height, 0.0);
-        this.estimated_area = GoMath.makeMatrix(this.width, this.height, 0.0);
         this.groups = GoMath.makeEmptyObjectMatrix(this.width, this.height);
         this.territory = GoMath.makeMatrix(this.width, this.height, 0);
         this.estimated_score = 0.0;
@@ -500,7 +498,6 @@ export class ScoreEstimator {
             for (let x = 0; x < this.width; ++x) {
                 this.heat[y][x] = ownership[y][x];
                 this.area[y][x] = ownership[y][x] < 0 ? 2 : ownership[y][x];
-                this.estimated_area[y][x] = this.area[y][x];
             }
         }
         this.estimated_score = estimated_score - this.engine.komi;

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -47,8 +47,6 @@ export interface ScoreEstimateRequest {
     height: number;
     board_state: Array<Array<number>>;
     rules: GoEngineRules;
-    black_prisoners?: number;
-    white_prisoners?: number;
     komi?: number;
     jwt: string;
 }
@@ -239,8 +237,6 @@ export class ScoreEstimator {
     width: number;
     height: number;
     board: Array<Array<JGOFNumericPlayerColor>>;
-    white_prisoners: number = 0;
-    black_prisoners: number = 0;
     white: PlayerScore = {
         total: 0,
         stones: 0,
@@ -742,8 +738,8 @@ export class ScoreEstimator {
         }
 
         if (this.engine.score_prisoners) {
-            this.black.prisoners = this.black_prisoners + removed_white;
-            this.white.prisoners = this.white_prisoners + removed_black;
+            this.black.prisoners = removed_white;
+            this.white.prisoners = removed_black;
         }
 
         this.black.total =

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -315,13 +315,13 @@ export class ScoreEstimator {
         }
 
         if (remote_scorer) {
-            return this.estimateScoreRemote(tolerance);
+            return this.estimateScoreRemote();
         } else {
             return this.estimateScoreWASM(trials, tolerance);
         }
     }
 
-    private estimateScoreRemote(tolerance: number = 0.25): Promise<void> {
+    private estimateScoreRemote(): Promise<void> {
         const komi = this.engine.komi;
         const captures_delta = this.engine.score_prisoners
             ? this.engine.getBlackPrisoners() - this.engine.getWhitePrisoners()

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -579,34 +579,17 @@ export class ScoreEstimator {
         let ret = "";
         const arr = [];
 
-        if (remote_scorer) {
-            for (let y = 0; y < this.height; ++y) {
-                for (let x = 0; x < this.width; ++x) {
-                    const current = this.board[y][x];
-                    const estimated =
-                        this.ownership[y][x] < -this.tolerance
-                            ? 2 // white
-                            : this.ownership[y][x] > this.tolerance
-                            ? 1 // black
-                            : 0; // unclear
-                    if (estimated === 0 /* dame */ || (current !== 0 && current !== estimated)) {
-                        arr.push(encodeMove(x, y));
-                    }
-                }
-            }
-        } else {
-            // Old WASM
-            for (let y = 0; y < this.height; ++y) {
-                for (let x = 0; x < this.width; ++x) {
-                    if (
-                        //(this.board[y][x] === 0 && this.area[y][x] === 0) /* dame */
-                        //||
-                        //(this.board[y][x] !== 0 && this.area[y][x] !== this.board[y][x]) /* captured */
-                        this.area[y][x] === 0 ||
-                        (this.board[y][x] !== 0 && this.area[y][x] !== this.board[y][x])
-                    ) {
-                        arr.push(encodeMove(x, y));
-                    }
+        for (let y = 0; y < this.height; ++y) {
+            for (let x = 0; x < this.width; ++x) {
+                const current = this.board[y][x];
+                const estimated =
+                    this.ownership[y][x] < -this.tolerance
+                        ? 2 // white
+                        : this.ownership[y][x] > this.tolerance
+                        ? 1 // black
+                        : 0; // unclear
+                if (estimated === 0 /* dame */ || (current !== 0 && current !== estimated)) {
+                    arr.push(encodeMove(x, y));
                 }
             }
         }

--- a/src/__tests__/GobanCanvas.test.ts
+++ b/src/__tests__/GobanCanvas.test.ts
@@ -411,7 +411,7 @@ describe("onTap", () => {
             board: GoMath.makeMatrix(4, 2),
             removal: GoMath.makeMatrix(4, 2),
             territory: GoMath.makeMatrix(4, 2),
-            heat: GoMath.makeMatrix(4, 2),
+            ownership: GoMath.makeMatrix(4, 2),
         };
         goban.engine.estimateScore = jest.fn().mockReturnValue(mock_score_estimate);
 

--- a/src/__tests__/ScoreEstimator.test.ts
+++ b/src/__tests__/ScoreEstimator.test.ts
@@ -1,0 +1,41 @@
+import { GoEngine } from "../GoEngine";
+import { adjust_estimate } from "../ScoreEstimator";
+
+describe("adjust_estimate", () => {
+    const BOARD = [
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+        [0, 1, 2, 0],
+    ];
+    const OWNERSHIP = [
+        [1, 1, -1, -1],
+        [1, 1, -1, -1],
+        [1, 1, -1, -1],
+        [1, 1, -1, -1],
+    ];
+    const SCORE = -0.5;
+    const KOMI = 0.5;
+
+    test("adjust_estimate area", () => {
+        const engine = new GoEngine({ komi: KOMI, rules: "chinese" });
+        expect(adjust_estimate(engine, BOARD, OWNERSHIP, SCORE)).toEqual({
+            score: -0.5,
+            ownership: OWNERSHIP,
+        });
+    });
+
+    test("adjust_estimate area", () => {
+        const ADJUSTED_OWNERSHIP = [
+            [1, 0, 0, -1],
+            [1, 0, 0, -1],
+            [1, 0, 0, -1],
+            [1, 0, 0, -1],
+        ];
+        const engine = new GoEngine({ komi: KOMI, rules: "japanese" });
+        expect(adjust_estimate(engine, BOARD, OWNERSHIP, SCORE)).toEqual({
+            score: -0.5,
+            ownership: ADJUSTED_OWNERSHIP,
+        });
+    });
+});

--- a/src/__tests__/ScoreEstimator.test.ts
+++ b/src/__tests__/ScoreEstimator.test.ts
@@ -1,5 +1,5 @@
 import { GoEngine } from "../GoEngine";
-import { adjust_estimate } from "../ScoreEstimator";
+import { ScoreEstimator, adjust_estimate, set_remote_scorer } from "../ScoreEstimator";
 
 describe("adjust_estimate", () => {
     const BOARD = [
@@ -37,5 +37,60 @@ describe("adjust_estimate", () => {
             score: -0.5,
             ownership: ADJUSTED_OWNERSHIP,
         });
+    });
+});
+
+describe("ScoreEstimator", () => {
+    const OWNERSHIP = [
+        [1, 1, -1, -1],
+        [1, 1, -1, -1],
+    ];
+    const KOMI = 0.5;
+
+    beforeEach(() => {
+        set_remote_scorer(async () => {
+            return { ownership: OWNERSHIP };
+        });
+    });
+
+    afterEach(() => {
+        set_remote_scorer(undefined as any);
+    });
+
+    test("resetGroups", async () => {
+        const engine = new GoEngine({ komi: KOMI, width: 4, height: 2 });
+        engine.place(1, 0);
+        engine.place(2, 0);
+        engine.place(1, 1);
+        engine.place(2, 1);
+
+        // It might seem weird to set prefer_remote = true just to test
+        // resetGroups, but is a necessary hack to bypass initialization of
+        // the OGSScoreEstimation library
+        const prefer_remote = true;
+        const se = new ScoreEstimator(undefined, engine, 10, 0.5, prefer_remote);
+
+        await se.when_ready;
+
+        expect(se.group_list).toHaveLength(4);
+        expect(se.group_list.map((group) => group.points)).toEqual([
+            [
+                { x: 0, y: 0 },
+                { x: 0, y: 1 },
+            ],
+            [
+                { x: 1, y: 0 },
+                { x: 1, y: 1 },
+            ],
+            [
+                { x: 2, y: 0 },
+                { x: 2, y: 1 },
+            ],
+            [
+                { x: 3, y: 0 },
+                { x: 3, y: 1 },
+            ],
+        ]);
+        expect(se.group_list.map((group) => group.color)).toEqual([0, 1, 2, 0]);
     });
 });


### PR DESCRIPTION
I've wanted to play with ScoreEstimator for a while, but there is a lot going on in there, and it's not easy to test due to external dependencies on OGSScoreEstimator (c++ WASM lib) and the remote AI scorer. I figured the best way to approach this is to clean it up as much as I can in one pass and manually test all changes together.  That said, let me know if there are commits that aren't desired, it shouldn't be too hard for me to remove them.

## Motivations

- Make score estimator more approachable so we can experiment:
    - interest in a new scoring tool expressed [here](https://forums.online-go.com/t/counting-tool-instead-of-score-estimator/49528)
    - I'd like to try a less aggressive metagroup algorithm (https://github.com/online-go/online-go.com/issues/1670)
- As a follow-up, I'd like to make the local estimator replaceable
   - This will make testing easier
   - Will allow experimentation with JS-only implementations 

## Observations

- There is duplicate code for calculating groups (see GoMath.GoStoneGroups)
- Score estimator is mostly used indirectly through methods in GoEngine/GobanCore
    - The methods construct the estimator, then call a single method
    - exception: the estimator is emitted, and the UI Game class accesses the winner and amount
- Many properties appear to be unused

## Assumptions

Please let me know if these are invalid.  If you have code snippets on external usages,  I can create additional unit tests to help capture the behavior (similar to the "amount and winner" test).

- Server is not using WASM anymore
- Server uses GoEngine functions to access the ScoreEstimator, not accessing the estimator directly

## Changes

See individual commit messages - I tried to make these as atomic and self-explanatory as possible.

## Testing

- Manual client testing
    - [remote] Click estimate score on the current user's finished game
    - [local] Click estimate score on the current user's ongoing game
    - [remote] Click estimate score on an ongoing game (as an observer)
    - [remote] Finish a game, mis-score, auto-score
- Unit tests
    - created ScoreEstimator.test.ts
    - 25% increase in line coverage for ScoreEstimator.ts