### PR TITLE
Choose Your Scorer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,7 +107,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ["src/test.tsx", "*/__tests__/*"],
+            files: ["src/test.tsx", "**/__tests__/*"],
             // since test files are not part of tsconfig.json,
             // parserOptions.project must be unset
             parserOptions: {

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -58,6 +58,27 @@ export function set_remote_scorer(
     remote_scorer = scorer;
 }
 
+/**
+ * The interface that local estimators should follow.
+ *
+ * @param board representation of the board with any dead stones already
+ *              removed (black = 1, empty = 0, white = -1)
+ * @param color_to_move the player whose turn it is
+ * @param trials number of playouts.  Not applicable to all estimators, but
+ *               higher generally means higher accuracy and higher compute cost
+ * @param tolerance (0.0-1.0) confidence required to mark an intersection not neutral.
+ */
+type LocalEstimator = (
+    board: number[][],
+    color_to_move: "black" | "white",
+    trials: number,
+    tolerance: number,
+) => { ownership: GoMath.NumberMatrix; estimated_score: number };
+let local_scorer = estimateScoreWasm;
+export function set_local_scorer(scorer: LocalEstimator) {
+    local_scorer = scorer;
+}
+
 interface SEPoint {
     x: number;
     y: number;
@@ -315,7 +336,7 @@ export class ScoreEstimator {
             }
         }
 
-        const { ownership, estimated_score } = estimateScoreWasm(
+        const { ownership, estimated_score } = local_scorer(
             board,
             this.engine.colorToMove(),
             trials,

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -25,7 +25,8 @@ import { JGOFNumericPlayerColor } from "./JGOF";
 import { _ } from "./translate";
 import { estimateScoreWasm } from "./local_estimators/wasm_estimator";
 
-export { init_score_estimator } from "./local_estimators/wasm_estimator";
+export { init_score_estimator, estimateScoreWasm } from "./local_estimators/wasm_estimator";
+export { estimateScoreVoronoi } from "./local_estimators/voronoi";
 
 /* In addition to the local estimators, we have a RemoteScoring system
  * which needs to be initialized by either the client or the server if we want

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -254,13 +254,13 @@ export class ScoreEstimator {
 
     public estimateScore(trials: number, tolerance: number): Promise<void> {
         if (!this.prefer_remote || this.height > 19 || this.width > 19) {
-            return this.estimateScoreWASM(trials, tolerance);
+            return this.estimateScoreLocal(trials, tolerance);
         }
 
         if (remote_scorer) {
             return this.estimateScoreRemote();
         } else {
-            return this.estimateScoreWASM(trials, tolerance);
+            return this.estimateScoreLocal(trials, tolerance);
         }
     }
 
@@ -319,7 +319,7 @@ export class ScoreEstimator {
 
     /* Somewhat deprecated in-browser score estimator that utilizes our WASM compiled
      * OGSScoreEstimatorModule */
-    private estimateScoreWASM(trials: number, tolerance: number): Promise<void> {
+    private estimateScoreLocal(trials: number, tolerance: number): Promise<void> {
         if (!trials) {
             trials = 1000;
         }

--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -74,7 +74,7 @@ type LocalEstimator = (
     color_to_move: "black" | "white",
     trials: number,
     tolerance: number,
-) => { ownership: GoMath.NumberMatrix; estimated_score: number };
+) => GoMath.NumberMatrix;
 let local_scorer = estimateScoreWasm;
 export function set_local_scorer(scorer: LocalEstimator) {
     local_scorer = scorer;
@@ -337,13 +337,9 @@ export class ScoreEstimator {
             }
         }
 
-        const { ownership, estimated_score } = local_scorer(
-            board,
-            this.engine.colorToMove(),
-            trials,
-            tolerance,
-        );
+        const ownership = local_scorer(board, this.engine.colorToMove(), trials, tolerance);
 
+        const estimated_score = sum_board(ownership);
         const adjusted = adjust_estimate(this.engine, this.board, ownership, estimated_score);
 
         this.updateEstimate(adjusted.score, adjusted.ownership);
@@ -680,6 +676,17 @@ export function adjust_estimate(
 
 function get_dimensions(board: Array<Array<unknown>>) {
     return { width: board[0].length, height: board.length };
+}
+
+function sum_board(board: GoMath.NumberMatrix) {
+    const { width, height } = get_dimensions(board);
+    let sum = 0;
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            sum += board[y][x];
+        }
+    }
+    return sum;
 }
 
 /**

--- a/src/__tests__/ScoreEstimator.test.ts
+++ b/src/__tests__/ScoreEstimator.test.ts
@@ -146,8 +146,8 @@ describe("ScoreEstimator", () => {
         const se = new ScoreEstimator(undefined, engine, 10, 0.5, false);
 
         expect(se.ownership).toEqual([
-            [0, 0, 0, -1, 1, 1, 1, 1, 1],
-            [0, 0, 0, -1, 1, 1, 1, 1, 1],
+            [1, 0, -1, -1, 1, 1, 1, 1, 1],
+            [1, 1, 0, -1, 1, 1, 1, 1, 1],
             [1, 1, 1, -1, 0, 1, 1, 1, 1],
             [0, 0, 0, -1, 0, 1, 1, 1, 1],
             [-1, -1, -1, 0, 1, 1, 1, 1, 1],

--- a/src/local_estimators/__tests__/voronoi.test.ts
+++ b/src/local_estimators/__tests__/voronoi.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { distanceMap, estimateScoreVoronoi } from "../voronoi";
+
+test("distanceMap", async () => {
+    const board = [
+        [0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 0],
+        [0, 0, 0, 0, 0],
+    ];
+
+    expect(distanceMap(board, 1)).toEqual([
+        [2, 1, 2, 3, 4],
+        [1, 0, 1, 2, 3],
+        [2, 1, 0, 1, 2],
+        [3, 2, 1, 2, 3],
+    ]);
+});
+
+test("one color only scores board for that color", () => {
+    const board = [
+        [0, 0, 0],
+        [0, 1, 0],
+        [0, 0, 0],
+    ];
+
+    expect(estimateScoreVoronoi(board).ownership).toEqual([
+        [1, 1, 1],
+        [1, 1, 1],
+        [1, 1, 1],
+    ]);
+});

--- a/src/local_estimators/__tests__/voronoi.test.ts
+++ b/src/local_estimators/__tests__/voronoi.test.ts
@@ -14,23 +14,7 @@
  * limitations under the License.
  */
 
-import { distanceMap, estimateScoreVoronoi } from "../voronoi";
-
-test("distanceMap", async () => {
-    const board = [
-        [0, 0, 0, 0, 0],
-        [0, 1, 0, 0, 0],
-        [0, 0, 1, 0, 0],
-        [0, 0, 0, 0, 0],
-    ];
-
-    expect(distanceMap(board, 1)).toEqual([
-        [2, 1, 2, 3, 4],
-        [1, 0, 1, 2, 3],
-        [2, 1, 0, 1, 2],
-        [3, 2, 1, 2, 3],
-    ]);
-});
+import { estimateScoreVoronoi } from "../voronoi";
 
 test("one color only scores board for that color", () => {
     const board = [
@@ -43,5 +27,25 @@ test("one color only scores board for that color", () => {
         [1, 1, 1],
         [1, 1, 1],
         [1, 1, 1],
+    ]);
+});
+
+test("border is one stone wide", () => {
+    const board = [
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, 1, 0, 0, 0],
+        [0, 0, 0, -1, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0],
+    ];
+
+    expect(estimateScoreVoronoi(board)).toEqual([
+        [1, 1, 1, 1, 1, 0],
+        [1, 1, 1, 1, 0, -1],
+        [1, 1, 1, 0, -1, -1],
+        [1, 1, 0, -1, -1, -1],
+        [1, 0, -1, -1, -1, -1],
+        [0, -1, -1, -1, -1, -1],
     ]);
 });

--- a/src/local_estimators/__tests__/voronoi.test.ts
+++ b/src/local_estimators/__tests__/voronoi.test.ts
@@ -39,7 +39,7 @@ test("one color only scores board for that color", () => {
         [0, 0, 0],
     ];
 
-    expect(estimateScoreVoronoi(board).ownership).toEqual([
+    expect(estimateScoreVoronoi(board)).toEqual([
         [1, 1, 1],
         [1, 1, 1],
         [1, 1, 1],

--- a/src/local_estimators/voronoi.ts
+++ b/src/local_estimators/voronoi.ts
@@ -16,12 +16,11 @@
 
 import { makeEmptyObjectMatrix, makeMatrix } from "../GoMath";
 
-/* The OGSScoreEstimator method is a wasm compiled C program that
- * does simple random playouts. On the client, the OGSScoreEstimator script
- * is loaded in an async fashion, so at some point that global variable
- * becomes not null and can be used.
+/**
+ * This estimator simply marks territory for whichever color has a
+ * closer stone (Manhattan distance).  See discussion at
+ * https://forums.online-go.com/t/weak-score-estimator-and-japanese-rules/41041/70
  */
-
 export function estimateScoreVoronoi(board: number[][]) {
     const black_distance_map = distanceMap(board, 1);
     const white_distance_map = distanceMap(board, -1);

--- a/src/local_estimators/voronoi.ts
+++ b/src/local_estimators/voronoi.ts
@@ -42,7 +42,7 @@ export function estimateScoreVoronoi(board: number[][]) {
         }
     }
 
-    return { ownership, estimated_score: 0 };
+    return ownership;
 }
 
 export function distanceMap(board: number[][], color: -1 | 1) {

--- a/src/local_estimators/voronoi.ts
+++ b/src/local_estimators/voronoi.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeEmptyObjectMatrix, makeMatrix } from "../GoMath";
+
+/* The OGSScoreEstimator method is a wasm compiled C program that
+ * does simple random playouts. On the client, the OGSScoreEstimator script
+ * is loaded in an async fashion, so at some point that global variable
+ * becomes not null and can be used.
+ */
+
+export function estimateScoreVoronoi(board: number[][]) {
+    const black_distance_map = distanceMap(board, 1);
+    const white_distance_map = distanceMap(board, -1);
+
+    const { width, height } = get_dims(board);
+
+    const ownership = makeMatrix(width, height);
+
+    for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+            if (white_distance_map[y][x] < black_distance_map[y][x]) {
+                ownership[y][x] = -1;
+            } else if (white_distance_map[y][x] > black_distance_map[y][x]) {
+                ownership[y][x] = 1;
+            } else {
+                ownership[y][x] = 0;
+            }
+        }
+    }
+
+    return { ownership, estimated_score: 0 };
+}
+
+export function distanceMap(board: number[][], color: -1 | 1) {
+    const { width, height } = get_dims(board);
+    let points = getPoints(board, (pt) => pt === color);
+    if (points.length === 0) {
+        return makeMatrix(width, height, Infinity);
+    }
+
+    let i = 0;
+    const distance_map = makeEmptyObjectMatrix<number>(width, height);
+    while (points.length) {
+        const next_points: Coordinate[] = [];
+        for (const pt of points) {
+            if (distance_map[pt.y][pt.x] !== undefined) {
+                continue;
+            }
+            distance_map[pt.y][pt.x] = i;
+            for (const n of getNeighbors(width, height, pt)) {
+                next_points.push(n);
+            }
+        }
+        points = next_points;
+        i++;
+    }
+    return distance_map;
+}
+
+type Coordinate = { x: number; y: number };
+function getPoints(board: number[][], f: (pt: number) => boolean): Coordinate[] {
+    const { width, height } = get_dims(board);
+    const points: Coordinate[] = [];
+    for (let y = 0; y < height; ++y) {
+        for (let x = 0; x < width; ++x) {
+            if (f(board[y][x])) {
+                points.push({ x, y });
+            }
+        }
+    }
+    return points;
+}
+function getNeighbors(width: number, height: number, { x, y }: Coordinate): Coordinate[] {
+    const neighbors: Coordinate[] = [];
+    if (x > 0) {
+        neighbors.push({ x: x - 1, y });
+    }
+    if (x < width - 1) {
+        neighbors.push({ x: x + 1, y });
+    }
+    if (y > 0) {
+        neighbors.push({ x, y: y - 1 });
+    }
+    if (y < height - 1) {
+        neighbors.push({ x, y: y + 1 });
+    }
+
+    return neighbors;
+}
+
+function get_dims(board: unknown[][]) {
+    return { width: board[0].length, height: board.length };
+}

--- a/src/local_estimators/wasm_estimator.ts
+++ b/src/local_estimators/wasm_estimator.ts
@@ -121,14 +121,7 @@ export function estimateScoreWasm(
         tr: number,
         to: number,
     ) => number;
-    const estimated_score = estimate(
-        width,
-        height,
-        ptr,
-        color_to_move === "black" ? 1 : -1,
-        trials,
-        tolerance,
-    );
+    estimate(width, height, ptr, color_to_move === "black" ? 1 : -1, trials, tolerance);
 
     const ownership = GoMath.makeMatrix(width, height, 0);
     i = 0;
@@ -141,5 +134,5 @@ export function estimateScoreWasm(
 
     OGSScoreEstimatorModule._free(ptr);
 
-    return { ownership, estimated_score };
+    return ownership;
 }

--- a/src/local_estimators/wasm_estimator.ts
+++ b/src/local_estimators/wasm_estimator.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* The OGSScoreEstimator method is a wasm compiled C program that
+ * does simple random playouts. On the client, the OGSScoreEstimator script
+ * is loaded in an async fashion, so at some point that global variable
+ * becomes not null and can be used.
+ */
+
+import * as GoMath from "../GoMath";
+
+declare const CLIENT: boolean;
+
+declare let OGSScoreEstimator: any;
+let OGSScoreEstimator_initialized = false;
+let OGSScoreEstimatorModule: any;
+
+let init_promise: Promise<boolean>;
+
+export function init_score_estimator(): Promise<boolean> {
+    if (!CLIENT) {
+        throw new Error("Only initialize WASM library on the client side");
+    }
+
+    if (OGSScoreEstimator_initialized) {
+        return Promise.resolve(true);
+    }
+
+    if (init_promise) {
+        return init_promise;
+    }
+
+    try {
+        if (
+            !OGSScoreEstimatorModule &&
+            (("OGSScoreEstimator" in window) as any) &&
+            ((window as any)["OGSScoreEstimator"] as any)
+        ) {
+            OGSScoreEstimatorModule = (window as any)["OGSScoreEstimator"] as any;
+        }
+    } catch (e) {
+        console.error(e);
+    }
+
+    if (OGSScoreEstimatorModule) {
+        OGSScoreEstimatorModule = OGSScoreEstimatorModule();
+        OGSScoreEstimator_initialized = true;
+        return Promise.resolve(true);
+    }
+
+    const script: HTMLScriptElement = document.getElementById(
+        "ogs_score_estimator_script",
+    ) as HTMLScriptElement;
+    if (script) {
+        let resolve: (tf: boolean) => void;
+        init_promise = new Promise<boolean>((_resolve, _reject) => {
+            resolve = _resolve;
+        });
+
+        script.onload = () => {
+            OGSScoreEstimatorModule = OGSScoreEstimator;
+            OGSScoreEstimatorModule = OGSScoreEstimatorModule();
+            OGSScoreEstimator_initialized = true;
+            resolve(true);
+        };
+
+        return init_promise;
+    } else {
+        return Promise.reject("score estimator not available");
+    }
+}
+
+export function estimateScoreWasm(
+    board: number[][],
+    color_to_move: "black" | "white",
+    trials: number,
+    tolerance: number,
+) {
+    if (!OGSScoreEstimator_initialized) {
+        throw new Error("Score estimator not intialized yet, uptime = " + performance.now());
+    }
+
+    const width = board[0].length;
+    const height = board.length;
+    const nbytes = 4 * width * height;
+    const ptr = OGSScoreEstimatorModule._malloc(nbytes);
+    const ints = new Int32Array(OGSScoreEstimatorModule.HEAP32.buffer, ptr, nbytes);
+    let i = 0;
+    for (let y = 0; y < height; ++y) {
+        for (let x = 0; x < width; ++x) {
+            ints[i] = board[y][x];
+            ++i;
+        }
+    }
+    const _estimate = OGSScoreEstimatorModule.cwrap("estimate", "number", [
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+    ]);
+    const estimate = _estimate as (
+        w: number,
+        h: number,
+        p: number,
+        c: number,
+        tr: number,
+        to: number,
+    ) => number;
+    const estimated_score = estimate(
+        width,
+        height,
+        ptr,
+        color_to_move === "black" ? 1 : -1,
+        trials,
+        tolerance,
+    );
+
+    const ownership = GoMath.makeMatrix(width, height, 0);
+    i = 0;
+    for (let y = 0; y < height; ++y) {
+        for (let x = 0; x < width; ++x) {
+            ownership[y][x] = ints[i];
+            ++i;
+        }
+    }
+
+    OGSScoreEstimatorModule._free(ptr);
+
+    return { ownership, estimated_score };
+}


### PR DESCRIPTION
This PR adds the ability to choose between the OGS WASM estimator and a ["Voronoi"](https://forums.online-go.com/t/weak-score-estimator-and-japanese-rules/41041/70) estimator... or even a user-defined function.

WASM is still the default, but one can change the estimator like so:

```
goban.set_local_scorer(goban.estimateScoreVoronoi);
```

This is very useful for testing, since it was difficult to load the `OGSScoreEstimator` module in the test environment or mock it.  This PR raises line coverage in ScoreEstimator.ts from 20% to 89%.

---

Incidentally, I believe the local scorer interface is compatible with [@sabaki/influence](https://npm.io/package/@sabaki/influence), though I haven't tested it:

```
const influence = require('@sabaki/influence');
goban.set_local_scorer(influence.areaMap);
```

---

Screenshots of Voronoi scorer:

<img width="575" alt="Screenshot 2023-11-07 at 10 54 49 PM" src="https://github.com/online-go/goban/assets/25233703/425cc761-0ea3-4c59-872a-da42c38ca858">

<img width="572" alt="Screenshot 2023-11-07 at 10 55 22 PM" src="https://github.com/online-go/goban/assets/25233703/01310f0c-111b-4d36-9dec-030bfbe1f84c">

<img width="577" alt="Screenshot 2023-11-07 at 10 57 31 PM" src="https://github.com/online-go/goban/assets/25233703/3f94a755-cc80-4a02-bd0d-74c0d0dbca0e">




