### PR TITLE
Add ScoreEstimator tests and raise threshold

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -49,7 +49,7 @@ export default {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     "global": {
-      "lines": 55
+      "lines": 60
     }
   },
 


### PR DESCRIPTION
Coverage for the file is 91% and global coverage is now 60%.

The remaining 10% is mostly some unused functions in SEGroup which I think we can get rid of (#139).