### PR TITLE
Deprecate SEGroup

### DIFF
--- a/src/GoStoneGroup.ts
+++ b/src/GoStoneGroup.ts
@@ -41,11 +41,15 @@ export class GoStoneGroup {
     is_territory_in_seki: boolean = false;
 
     private __added_neighbors: { [group_id: number]: boolean };
+    private neighboring_space: GoStoneGroup[];
+    private neighboring_enemy: GoStoneGroup[];
 
     constructor(board_state: BoardState, id: number, color: JGOFNumericPlayerColor) {
         this.board_state = board_state;
         this.points = [];
         this.neighbors = [];
+        this.neighboring_space = [];
+        this.neighboring_enemy = [];
         this.id = id;
         this.color = color;
         this.is_strong_eye = false;
@@ -60,6 +64,14 @@ export class GoStoneGroup {
         if (!(group.id in this.__added_neighbors)) {
             this.neighbors.push(group);
             this.__added_neighbors[group.id] = true;
+
+            if (group.color !== this.color) {
+                if (group.color === JGOFNumericPlayerColor.EMPTY) {
+                    this.neighboring_space.push(group);
+                } else {
+                    this.neighboring_enemy.push(group);
+                }
+            }
         }
     }
     addCornerGroup(x: number, y: number, group: GoStoneGroup): void {
@@ -76,6 +88,16 @@ export class GoStoneGroup {
     foreachNeighborGroup(fn: (group: GoStoneGroup) => void): void {
         for (let i = 0; i < this.neighbors.length; ++i) {
             fn(this.neighbors[i]);
+        }
+    }
+    foreachNeighborSpaceGroup(fn: (group: GoStoneGroup) => void): void {
+        for (let i = 0; i < this.neighboring_space.length; ++i) {
+            fn(this.neighboring_space[i]);
+        }
+    }
+    foreachNeighborEnemyGroup(fn: (group: GoStoneGroup) => void): void {
+        for (let i = 0; i < this.neighbors.length; ++i) {
+            fn(this.neighboring_enemy[i]);
         }
     }
     computeIsEye(): void {

--- a/src/__tests__/ScoreEstimator.test.ts
+++ b/src/__tests__/ScoreEstimator.test.ts
@@ -58,10 +58,6 @@ describe("ScoreEstimator", () => {
     engine.place(1, 1);
     engine.place(2, 1);
 
-    // It might seem weird to set prefer_remote = true just to test
-    // resetGroups, but is a necessary hack to bypass initialization of
-    // the OGSScoreEstimation library
-    const prefer_remote = true;
     const trials = 10;
     const tolerance = 0.25;
 
@@ -75,33 +71,6 @@ describe("ScoreEstimator", () => {
 
     afterEach(() => {
         set_remote_scorer(undefined as any);
-    });
-
-    test("resetGroups", async () => {
-        const se = new ScoreEstimator(undefined, engine, trials, tolerance, prefer_remote);
-
-        await se.when_ready;
-
-        expect(se.group_list).toHaveLength(4);
-        expect(se.group_list.map((group) => group.points)).toEqual([
-            [
-                { x: 0, y: 0 },
-                { x: 0, y: 1 },
-            ],
-            [
-                { x: 1, y: 0 },
-                { x: 1, y: 1 },
-            ],
-            [
-                { x: 2, y: 0 },
-                { x: 2, y: 1 },
-            ],
-            [
-                { x: 3, y: 0 },
-                { x: 3, y: 1 },
-            ],
-        ]);
-        expect(se.group_list.map((group) => group.color)).toEqual([0, 1, 2, 0]);
     });
 
     test("amount and winner", async () => {


### PR DESCRIPTION
With some minor additions, `GoStoneGroup` can completely replace the `SEGroup` in the score estimator.