### PR TITLE
Fix ScoreEstimator bug for Japanese scoring

### DIFF
--- a/src/ScoreEstimator.ts
+++ b/src/ScoreEstimator.ts
@@ -531,12 +531,12 @@ export function adjust_estimate(
                 }
             }
         }
+    }
 
-        // Account for already-captured prisoners in Japanese rules.
-        if (territory_counting) {
-            adjusted_score += engine.getBlackPrisoners();
-            adjusted_score -= engine.getWhitePrisoners();
-        }
+    // Account for already-captured prisoners in Japanese rules.
+    if (territory_counting) {
+        adjusted_score += engine.getBlackPrisoners();
+        adjusted_score -= engine.getWhitePrisoners();
     }
 
     return { score: adjusted_score, ownership };

--- a/src/__tests__/ScoreEstimator.test.ts
+++ b/src/__tests__/ScoreEstimator.test.ts
@@ -363,4 +363,38 @@ describe("ScoreEstimator", () => {
             [0, 0, 0, 0],
         ]);
     });
+
+    test("score() with captures", async () => {
+        // A board that is split down the middle between black and white
+        const engine = new GoEngine({
+            width: 8,
+            height: 8,
+            initial_state: { black: "dadbdcdddedfdgdh", white: "eaebecedeeefegeh" },
+            komi: 0,
+        });
+
+        // Capture a stone in the corner
+        engine.place(7, 0);
+        engine.place(7, 1);
+        engine.place(-1, -1);
+        engine.place(6, 0);
+
+        //   A B C D E F G H
+        // 8 . . . X O . O{.}
+        // 7 . . . X O . . O
+        // 6 . . . X O . . .
+        // 5 . . . X O . . .
+        // 4 . . . X O . . .
+        // 3 . . . X O . . .
+        // 2 . . . X O . . .
+        // 1 . . . X O . . .
+
+        const se = new ScoreEstimator(undefined, engine, 10, 0.5, false);
+        await se.when_ready;
+
+        se.score();
+
+        expect(se.amount).toBe(1);
+        expect(se.winner).toBe("Black");
+    });
 });


### PR DESCRIPTION
This bug was introduced in d6194f4c46fdf90b8a12de091b038939230b8ca1 and caused captures to be multiplied by a factor of `height`.

https://forums.online-go.com/t/in-game-score-estimator-bugged/50046

---

Testing: I added a unit test based on [stone_defender's demo board](https://online-go.com/review/1190037).  8x8 instead of 20x20.

