### PR TITLE
Ing rules dictate effectively 7.5 komi for even games

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -2067,7 +2067,13 @@ export class GoEngine extends EventEmitter<Events> {
                 break;
 
             case "ing":
-                defaults.komi = 8;
+                // https://www.usgo-archive.org/sites/default/files/pdf/IngRules2006.pdf
+                //
+                // pg. 26:
+                //
+                // Fixed compensation: Mandatory eight points handicap, black
+                // wins in case of drawn games.
+                defaults.komi = 7.5;
                 defaults.score_prisoners = false;
                 defaults.allow_superko = false;
                 defaults.superko_algorithm = "ing";


### PR DESCRIPTION
[Ing rules] officially state a komi of 8 for even games, with black winning drawn games.  As far as computer Go is concerned, that means komi is effectively 7.5.

[Ing rules]: https://www.usgo-archive.org/sites/default/files/pdf/IngRules2006.pdf