### PR TITLE
Add the area handicap scoring bonus in Ing rules

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -2073,6 +2073,24 @@ export class GoEngine extends EventEmitter<Events> {
                 defaults.superko_algorithm = "ing";
                 defaults.free_handicap_placement = true;
                 defaults.allow_self_capture = true;
+
+                // https://www.cs.cmu.edu/~wjh/go/rules/KSS.html
+                //
+                // 2. Playing the game:
+                //
+                // Counting:
+                //
+                //     5. In handicap games of N-stone handicap, White must
+                //     receive N-point compensation to make the result
+                //     equivalent to territory counting. [...] In handicap
+                //     games, White wins ties.
+                //
+                // Note that Black giving compensation in handicap games is not
+                // found in any official documentation of the Ing rules. AGA
+                // President Phil Straus has requested this convention so that
+                // territory and area counting can give the same result in
+                // handicap games.
+                defaults.score_handicap = true;
                 break;
 
             case "nz":


### PR DESCRIPTION
Based on <https://www.cs.cmu.edu/~wjh/go/rules/KSS.html>, white should get an N-point handicap bonus in handicap games.  This is not from the official documentation of the Ing rules, but was requested by the AGA president.