### PR TITLE
Set 'handicap' from GoEngine.computeScore to the handicap bonus

### DIFF
--- a/src/GoEngine.ts
+++ b/src/GoEngine.ts
@@ -1757,7 +1757,7 @@ export class GoEngine extends EventEmitter<Events> {
                 territory: 0,
                 prisoners: 0,
                 scoring_positions: "",
-                handicap: this.handicap,
+                handicap: this.getHandicapPointAdjustmentForWhite(),
                 komi: this.komi,
             },
             black: {
@@ -1770,10 +1770,6 @@ export class GoEngine extends EventEmitter<Events> {
                 komi: 0,
             },
         };
-
-        if (this.aga_handicap_scoring && ret.white.handicap > 0) {
-            ret.white.handicap -= 1;
-        }
 
         let removed_black = 0;
         let removed_white = 0;
@@ -1892,18 +1888,14 @@ export class GoEngine extends EventEmitter<Events> {
             ret["black"].stones +
             ret["black"].territory +
             ret["black"].prisoners +
+            ret["black"].handicap +
             ret["black"].komi;
-        if (this.score_handicap) {
-            ret["black"].total += ret["black"].handicap;
-        }
         ret["white"].total =
             ret["white"].stones +
             ret["white"].territory +
             ret["white"].prisoners +
+            ret["white"].handicap +
             ret["white"].komi;
-        if (this.score_handicap) {
-            ret["white"].total += ret["white"].handicap;
-        }
 
         try {
             if (this.outcome && this.aga_handicap_scoring) {


### PR DESCRIPTION
This commit changes `GoEngine.computeScore()` to return `0` for `handicap` when it does not contribute to the score.  Indirectly, this changes the scoring summary in the web-client to not show the handicap in this case.

This fixes an inconsistency in the API/return, which forwarded to the web-client and caused user confusion.

Previously it was neither consistently equal to the handicap (see AGA) nor the handicap scoring bonus (see Japanese/Korean/New Zealand).

- For Chinese/Ing, it was both the handicap scoring bonus and the handicap, which happen to be equal.
- For AGA, it was the handicap scoring bonus, which is `handicap-1`.
- For Japanese/Korean/New Zealand, it was the handicap (scoring bonus is 0).

Now, for all rulesets, it's the handicap scoring bonus (if any).  For a client computing the score, this is what's relevant.  This is similar to how `stones` is returned for rulesets where it's relevant to the score.

It might be nice for the web-client to show the number of handicap stones somewhere in the main view, but (a) it wasn't doing that previously and (b) `computeScore()` isn't the right way to get that info.

Fixes https://github.com/online-go/online-go.com/issues/1469