### PR TITLE
Add set last move opacity to goban canvas interface

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -72,6 +72,7 @@ interface GobanCanvasInterface {
     enablePen(): void;
     disablePen(): void;
     setByoYomiLabel(label: string): void;
+    setLastMoveOpacity(opacity: number): void;
 
     move_tree_bindCanvasEvents(canvas: HTMLCanvasElement): void;
     move_tree_redraw(no_warp?: boolean): void;

--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -62,7 +62,33 @@ interface ViewPortInterface {
 
 const HOT_PINK = "#ff69b4";
 
-export class GobanCanvas extends GobanCore {
+interface GobanCanvasInterface {
+    engine: GoEngine;
+    move_tree_container?: HTMLElement;
+
+    clearAnalysisDrawing(): void;
+    drawPenMarks(pen_marks: MoveTreePenMarks): void;
+    enablePen(): void;
+    disablePen(): void;
+    setByoYomiLabel(label: string): void;
+
+    move_tree_bindCanvasEvents(canvas: HTMLCanvasElement): void;
+    move_tree_redraw(no_warp?: boolean): void;
+    setMoveTreeContainer(container: HTMLElement): void;
+
+    showMessage(
+        message_id_or_error: MessageID,
+        parameters?: { [key: string]: any },
+        timeout?: number,
+    ): void;
+    clearMessage(): void;
+
+    drawSquare(i: number, j: number): void;
+
+    destroy(): void;
+}
+
+export class GobanCanvas extends GobanCore implements GobanCanvasInterface {
     public engine: GoEngine;
     private parent: HTMLElement;
     //private board_div: HTMLElement;


### PR DESCRIPTION
This goes on top of #148 , after #150  is in  :)

If you don't like #148, you don't need this.

If you do like #148, then you should do this if you've done #150 :)

