### PR TITLE
GobanCore: round square size to device pixels instead of arbitrary px units

### DIFF
--- a/src/GobanCanvas.ts
+++ b/src/GobanCanvas.ts
@@ -1361,10 +1361,14 @@ export class GobanCanvas extends GobanCore implements GobanCanvasInterface {
             }
             ctx.lineCap = "butt";
             ctx.beginPath();
-            ctx.moveTo(Math.floor(sx), my);
-            ctx.lineTo(Math.floor(ex), my);
-            ctx.moveTo(mx, Math.floor(sy));
-            ctx.lineTo(mx, Math.floor(ey));
+
+            const dpr = window.devicePixelRatio || 1;
+            let round = function(x: number): number { return Math.round(dpr * (x-0.5))/dpr + 0.5; }
+            console.log(round(my));
+            ctx.moveTo(round(sx), round(my));
+            ctx.lineTo(round(ex), round(my));
+            ctx.moveTo(round(mx), round(sy));
+            ctx.lineTo(round(mx), round(ey));
             ctx.stroke();
         }
 

--- a/src/GobanCore.ts
+++ b/src/GobanCore.ts
@@ -1928,7 +1928,11 @@ export abstract class GobanCore extends EventEmitter<Events> {
             n_squares = 19;
         }
 
-        this.setSquareSize(Math.floor(this.display_width / n_squares), suppress_redraw);
+        const devicePixelRatio = window.devicePixelRatio || 1;
+        const idealSquareSize = this.display_width / n_squares;
+        const deviceSquareSize = Math.floor(devicePixelRatio * idealSquareSize) / devicePixelRatio;
+        this.setSquareSize(deviceSquareSize, suppress_redraw);
+        console.log("Square size: " + deviceSquareSize);
     }
 
     public setCoordinates(label_position: LabelPosition) {


### PR DESCRIPTION
This uses the device resolution to round "squareSize" to the nearest units in device pixels.  For example, on my 14" laptop screen, with a devicePixelRatio of 1.25, 1 pixel is actually 0.8px. So I get square sizes of 60, 60.8, 61.6, etc.

I have not looked into what the size is used for, so I don't really know if it's okay for it not to be an integer. But here is an example screenshot on Pixel 7 showing that it at least works in some sense:

![Screenshot_20240217-183543](https://github.com/online-go/goban/assets/466760/cb5d6d4b-9880-4d57-809d-355c19720cec)

Here's what it looks like before the change, maybe there are slightly fewer artifacts but that could be an accident:

![image](https://github.com/online-go/goban/assets/466760/1cffb051-c59b-4b54-8c40-960b8b716e3e)
