### PR TITLE
Increase test timeout to 1s

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -221,5 +221,5 @@ export default {
     // Whether to use watchman for file crawling
     // watchman: true,
 
-    testTimeout: 200,
+    testTimeout: 1000,
 };


### PR DESCRIPTION
I noticed on #167 the GobanSVG onTap tests were flaky due to timeout.  The SVG tests usually complete in <50ms, but one onTap test jumps over the 200ms threshold on occasion.

While the SVG tests run noticeably slower than Canvas tests (1-10ms vs 20-50ms on average), I wasn't able to determine whether there is a real perf issue.  At any rate, I think it's reasonable to increase the timeout parameter since Jest's default is a whopping 5s.

## Test Plan

I stress tested with this command:

```
for i in {1..10}; do yarn test || {echo "Failed after $i attempts" && break}; done
```

10 runs is more than enough to trigger the timeout at 200 ms, but we get no timeouts at the 1s threshold.

## Alternative considered

We could alternatively increase timeout on a per-test basis.  This would be fine too IMO, just takes more thought about which tests need it.