### PR TITLE
Adds a rapid speed

### DIFF
--- a/src/engine/formats/JGOF.ts
+++ b/src/engine/formats/JGOF.ts
@@ -200,7 +200,7 @@ export interface JGOFPauseState {
     moderator?: string;
 }
 
-export type JGOFTimeControlSpeed = "blitz" | "live" | "correspondence";
+export type JGOFTimeControlSpeed = "blitz" | "rapid" | "live" | "correspondence";
 export type JGOFTimeControlSystem =
     | "fischer"
     | "byoyomi"

--- a/src/engine/protocol/ClientToServer.ts
+++ b/src/engine/protocol/ClientToServer.ts
@@ -600,7 +600,7 @@ export interface ClientToServer extends ClientToServerBase {
     }) => void;
 }
 
-export type Speed = "blitz" | "live" | "correspondence";
+export type Speed = "blitz" | "rapid" | "live" | "correspondence";
 export type Size = "9x9" | "13x13" | "19x19";
 export type AutomatchCondition = "required" | "preferred" | "no-preference";
 export type RuleSet = "japanese" | "chinese" | "aga" | "korean" | "nz" | "ing";


### PR DESCRIPTION
[Based on this forum post](https://forums.online-go.com/t/revisiting-automatch-time-settings-data-backed-proposal-for-new-automatch-settings-on-ogs/52303?u=elforo)
This PR sets up for[ the automatch box changes](https://github.com/online-go/online-go.com/pull/2749)
These changes add a rapid time control speed.
This requires server changes for the auto-matching.