### PR TITLE
Updated game sound logic for case when game ends in a Tie #2958

### DIFF
--- a/src/Goban/OGSConnectivity.ts
+++ b/src/Goban/OGSConnectivity.ts
@@ -288,7 +288,7 @@ export abstract class OGSConnectivity extends GobanInteractive {
                             }
                         }
 
-                        if (winner_color){
+                        if (winner_color) {
                             this.emit("audio-game-ended", winner_color);
                         }
                     }

--- a/src/Goban/OGSConnectivity.ts
+++ b/src/Goban/OGSConnectivity.ts
@@ -269,17 +269,26 @@ export abstract class OGSConnectivity extends GobanInteractive {
                         this.last_phase !== "finished" &&
                         obj.phase === "finished"
                     ) {
-                        const winner = obj.winner;
-                        let winner_color: "black" | "white" | undefined;
-                        if (typeof winner === "number") {
-                            winner_color = winner === obj.black_player_id ? "black" : "white";
-                        } else if (winner === "black" || winner === "white") {
+                       const winner = obj.winner;
+                        let winner_color: "black" | "white" | "tie" | undefined;
+
+                        if (typeof winner === "string") {
                             winner_color = winner;
+                        } else if (typeof winner === "number") {
+                            switch (winner) {
+                                case 0:
+                                    winner_color = "tie";
+                                    break;
+                                case obj.black_player_id:
+                                    winner_color = "black";
+                                    break;
+                                case obj.white_player_id:
+                                    winner_color = "white";
+                                    break;
+                            }
                         }
 
-                        if (winner_color) {
-                            this.emit("audio-game-ended", winner_color);
-                        }
+                        if (winner_color) this.emit("audio-game-ended", winner_color);
                     }
                     if (obj.phase) {
                         this.last_phase = obj.phase;

--- a/src/Goban/OGSConnectivity.ts
+++ b/src/Goban/OGSConnectivity.ts
@@ -269,7 +269,7 @@ export abstract class OGSConnectivity extends GobanInteractive {
                         this.last_phase !== "finished" &&
                         obj.phase === "finished"
                     ) {
-                       const winner = obj.winner;
+                        const winner = obj.winner;
                         let winner_color: "black" | "white" | "tie" | undefined;
 
                         if (typeof winner === "string") {
@@ -288,8 +288,8 @@ export abstract class OGSConnectivity extends GobanInteractive {
                             }
                         }
 
-                        if (winner_color) { 
-                            this.emit("audio-game-ended", winner_color); 
+                        if (winner_color){
+                            this.emit("audio-game-ended", winner_color);
                         }
                     }
                     if (obj.phase) {

--- a/src/Goban/OGSConnectivity.ts
+++ b/src/Goban/OGSConnectivity.ts
@@ -288,7 +288,9 @@ export abstract class OGSConnectivity extends GobanInteractive {
                             }
                         }
 
-                        if (winner_color) this.emit("audio-game-ended", winner_color);
+                        if (winner_color) { 
+                            this.emit("audio-game-ended", winner_color); 
+                        }
                     }
                     if (obj.phase) {
                         this.last_phase = obj.phase;

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -138,7 +138,7 @@ export interface GobanEngineConfig extends BoardConfig {
     free_handicap_placement?: boolean;
     score?: Score;
     outcome?: string;
-    winner?: number | "black" | "white"; // Player ID of the winner
+    winner?: number | "black" | "white" | "tie"; // Player ID of the winner
 
     start_time?: number;
     end_time?: number;


### PR DESCRIPTION
Fixes #2791

## Proposed Changes

  -Add a case when game ends in a tie (returns `0` instead of a player number)
  -updates `winner` interface prop with `tie` as an option
  
### Concerns
- should `winner` interface prop be number or string? Where would it be set to be a string? I only saw numbers returned (for player id) but not sure when a string is set. 
- I didn't see any jest tests for this. If we don't need it its fine, just want to make sure i'm not missing it somewhere.
