### PR TITLE
Remove stone numbers for kidsgoserver.com

### DIFF
--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -490,6 +490,9 @@ export abstract class GobanInteractive extends GobanBase {
     }
     */
     protected getShowVariationMoveNumbers(): boolean {
+        if (this.mode === "puzzle") {
+            return false;
+        }
         if (callbacks.getShowVariationMoveNumbers) {
             return callbacks.getShowVariationMoveNumbers();
         }


### PR DESCRIPTION
- In puzzle mode on kidsgoserver.com, stones were showing numbers after being placed

![image](https://github.com/user-attachments/assets/a3756f3e-faf2-40cd-9af9-ecf1d9c3e286)

- With this PR, the numbering is now gone

- In the following commit from 10 months ago, the exact same changes in this PR were made:
https://github.com/online-go/goban/commit/4542b8a4f753f209c1fe28114a8a3ea1323552f2

- However, in the commit right after, this block of code was removed, so I'm hoping adding these changes back in doesn't break anything:
https://github.com/online-go/goban/commit/b1126dd9c30d6c2de1d6e23a3dd443612d525c64