### PR TITLE
findBranchesWithWrongAnswer() method addition

### DIFF
--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -490,9 +490,6 @@ export abstract class GobanInteractive extends GobanBase {
     }
     */
     protected getShowVariationMoveNumbers(): boolean {
-        if (this.mode === "puzzle") {
-            return false;
-        }
         if (callbacks.getShowVariationMoveNumbers) {
             return callbacks.getShowVariationMoveNumbers();
         }

--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -490,6 +490,9 @@ export abstract class GobanInteractive extends GobanBase {
     }
     */
     protected getShowVariationMoveNumbers(): boolean {
+        if (this.mode === "puzzle") {
+            return false;
+        }
         if (callbacks.getShowVariationMoveNumbers) {
             return callbacks.getShowVariationMoveNumbers();
         }

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -1059,6 +1059,17 @@ export class MoveTree {
         return branch.branches.some((item) => this.isBranchWithCorrectAnswer(item));
     }
 
+    private isBranchWithWrongAnswer(branch: MoveTree): boolean {
+        if (branch.wrong_answer) {
+            return true;
+        }
+        if (!branch.branches || branch.branches.length === 0) {
+            return false;
+        }
+
+        return branch.branches.some((item) => this.isBranchWithWrongAnswer(item));
+    }
+
     public hoistFirstBranchToTrunk(): void {
         if (this.trunk_next) {
             this.trunk_next.hoistFirstBranchToTrunk();
@@ -1080,6 +1091,13 @@ export class MoveTree {
      */
     findBranchesWithCorrectAnswer(): Array<MoveTree> {
         return this.branches.filter((branch) => this.isBranchWithCorrectAnswer(branch));
+    }
+
+    /**
+     * Find branches containing node with wrong_answer === true
+     */
+    findBranchesWithWrongAnswer(): Array<MoveTree> {
+        return this.branches.filter((branch) => this.isBranchWithWrongAnswer(branch));
     }
 
     public clearBranchesExceptFor(node: MoveTree): void {


### PR DESCRIPTION
- Added a method "findBranchesWithWrongAnswer()" so that kidsgo can draw red squares for wrong move paths when clicking the hint button
- The logic mimics the logic for the existing method "findBranchesWithCorrectAnswer()", but instead uses the wrong_answer property instead of the correct_answer property