### PR TITLE
Keep track of which annotations were added by AI

### DIFF
--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -1368,12 +1368,12 @@ export abstract class GobanInteractive extends GobanBase {
     }
     */
 
-    public setMarks(marks: { [mark: string]: string }, dont_draw?: boolean): void {
+    public setMarks(marks: { [mark: string]: string }, dont_draw?: boolean, ai_annotation?: boolean): void {
         for (const key in marks) {
             const locations = this.engine.decodeMoves(marks[key]);
             for (let i = 0; i < locations.length; ++i) {
                 const pt = locations[i];
-                this.setMark(pt.x, pt.y, key, dont_draw);
+                this.setMark(pt.x, pt.y, key, dont_draw, ai_annotation);
             }
         }
     }
@@ -1422,7 +1422,10 @@ export abstract class GobanInteractive extends GobanBase {
             this.drawSquare(x, y);
         }
     }
-    public setSubscriptMark(x: number, y: number, mark: string, drawSquare: boolean = true): void {
+    public setSubscriptMark(x: number, y: number, mark: string, drawSquare: boolean = true, ai_annotation: boolean = true): void {
+        if (ai_annotation) {
+            this.savePreAIMarks(this.getMarks(x, y));
+        }
         this.engine.cur_move.getMarks(x, y).subscript = mark;
         if (drawSquare) {
             this.drawSquare(x, y);
@@ -1482,11 +1485,15 @@ export abstract class GobanInteractive extends GobanBase {
             this.setMark(mv.x, mv.y, mark, dont_draw);
         }
     }
-    public setMark(x: number, y: number, mark: number | string, dont_draw?: boolean): void {
+    public setMark(x: number, y: number, mark: number | string, dont_draw?: boolean, ai_annotation?: boolean): void {
         try {
             if (x >= 0 && y >= 0) {
                 if (typeof mark === "number") {
                     mark = "" + mark;
+                }
+
+                if (ai_annotation) {
+                    this.savePreAIMarks(this.getMarks(x, y));
                 }
 
                 if (mark.startsWith("score-")) {
@@ -1744,6 +1751,13 @@ export abstract class GobanInteractive extends GobanBase {
                 this.emit("captured-stones", { removed_stones });
             }
         }
+    }
+
+    private savePreAIMarks(marks: MarkInterface): void {
+        if (marks.before_ai !== undefined) {
+            return
+        }
+        marks.before_ai = JSON.stringify(marks!);
     }
 }
 

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -48,6 +48,7 @@ export interface MarkInterface {
     white?: boolean;
     color?: string;
     needs_sealing?: boolean;
+    before_ai?: string;
 
     [label: string]: string | boolean | undefined;
 }
@@ -604,6 +605,23 @@ export class MoveTree {
     }
     setAllMarks(marks: MarkInterface[][]): void {
         this.marks = marks;
+    }
+    clearAIMarks(): MarkInterface[][] {
+        let marks: MarkInterface[][];
+        if (this.marks === undefined) {
+            marks = makeObjectMatrix<MarkInterface>(this.engine.width, this.engine.height);
+            this.marks = marks;
+        } else {
+            marks = this.marks;
+        }
+        for (var i = 0; i < this.engine.height; i++) {
+            for (var j = 0; j < this.engine.width; j++) {
+                if (marks[i][j].before_ai !== undefined) {
+                    marks[i][j] = JSON.parse(marks[i][j].before_ai!);
+                }
+            }
+        }
+        return this.marks;
     }
     clearMarks(): MarkInterface[][] {
         this.marks = makeObjectMatrix<MarkInterface>(this.engine.width, this.engine.height);


### PR DESCRIPTION
This PR relates to online-go/online-go.com#2874. Every time an AI annotation is added, such as a move number in a sequence or a point gain/loss, the goban will now track the old state of the current cell before the annotation. This way, if we disable AI analysis, we can restore from that backup.