### PR TITLE
VIBE: Implement stone shadow themes

### DIFF
--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -137,7 +137,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         "white": "Plain",
         "removal-graphic": "x",
         "removal-scale": 1.0,
-        "disable-stone-shadows": false,
+        "stone-shadows": "default",
     };
     private theme_black!: GobanTheme;
     private theme_black_stones: Array<any> = [];

--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -23,13 +23,27 @@ import { getRelativeEventPosition } from "./canvas_utils";
 import { THEMES, THEMES_SORTED } from "./themes";
 
 export const GOBAN_FONT = "Verdana,Arial,sans-serif";
+export type ShadowTheme = "none" | "low" | "mid" | "high" | "custom" | "default" | "anime";
+
+export interface CustomShadowConfig {
+    black?: {
+        gradientTransform?: string;
+        shadow_color?: string;
+    };
+    white?: {
+        gradientTransform?: string;
+        shadow_color?: string;
+    };
+}
+
 export interface GobanSelectedThemes {
     "board": string;
     "white": string;
     "black": string;
     "removal-graphic": "square" | "x";
     "removal-scale": number;
-    "disable-stone-shadows"?: boolean;
+    "stone-shadows"?: ShadowTheme;
+    "custom-shadow-config"?: CustomShadowConfig;
 }
 export type LabelPosition =
     | "all"
@@ -94,7 +108,7 @@ export abstract class Goban extends OGSConnectivity {
             "board": "Kaya",
             "removal-graphic": "square",
             "removal-scale": 1.0,
-            "disable-stone-shadows": false,
+            "stone-shadows": "default",
         };
     }
 

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -17,6 +17,7 @@
 import { GobanTheme } from "./GobanTheme";
 import { ThemesInterface } from "./";
 import { _ } from "../../engine/translate";
+import { ShadowTheme } from "../Goban";
 import { deviceCanvasScalingRatio, allocateCanvasOrError } from "../canvas_utils";
 import { renderShadow } from "./rendered_stones";
 import { renderPlainStone } from "./plain_stones";
@@ -236,30 +237,8 @@ export default function (THEMES: ThemesInterface) {
             return "#000000";
         }
 
-        public override placeStoneShadowSVG(
-            shadow_cell: SVGGraphicsElement | undefined,
-            cx: number,
-            cy: number,
-            radius: number,
-        ): SVGElement | undefined {
-            if (!shadow_cell) {
-                return;
-            }
-
-            const shadow = document.createElementNS("http://www.w3.org/2000/svg", "image");
-            shadow.setAttribute("class", "stone");
-            shadow.setAttribute("x", `${cx - radius * 0.98}`);
-            shadow.setAttribute("y", `${cy - radius * 1.05}`);
-            shadow.setAttribute("width", `${radius * 2 * 1.05}`);
-            shadow.setAttribute("height", `${radius * 2 * 1.14}`);
-            shadow.setAttributeNS(
-                "http://www.w3.org/1999/xlink",
-                "href",
-                getCDNReleaseBase() + "/img/anime_shadow.svg",
-            );
-            shadow_cell.appendChild(shadow);
-
-            return shadow;
+        override getPreferredShadowTheme(): ShadowTheme {
+            return "anime";
         }
 
         public override preRenderBlackSVG(


### PR DESCRIPTION
Adds support for selecting the style of shadow you want for your stones. Current options are none, low, mid, high, anime, and custom.