### PR TITLE
Add test for parenthesis in MoveTree.toSgf

### DIFF
--- a/test/unit_tests/GoEngine_sgf.test.ts
+++ b/test/unit_tests/GoEngine_sgf.test.ts
@@ -180,3 +180,21 @@ test("test for comments being attached to right nodes", () => {
     goban2.engine.jumpToOfficialMoveNumber(2);
     expect(goban2.engine.cur_move.text).toBe("second comment");
 });
+
+// See https://github.com/online-go/online-go.com/issues/2005
+test("MoveTree.toSgf() does not emit parentheses for linear sequence", () => {
+    // Create a goban with just a few moves in the main trunk
+    const goban = new TestGoban({ moves: [] });
+
+    // Play a sequence of moves
+    goban.engine.place(3, 3); // Black [dd]
+    goban.engine.place(15, 15); // White [pp]
+    goban.engine.place(3, 15); // Black [dp]
+    goban.engine.place(15, 3); // White [pd]
+
+    // Get the SGF output from the move tree
+    const sgf = goban.engine.move_tree.toSGF();
+
+    expect(sgf.includes("(")).toBe(false);
+    expect(sgf.includes(")")).toBe(false);
+});


### PR DESCRIPTION
While attempting to fix https://github.com/online-go/online-go.com/issues/2005, I wrote a test which would expose the issue if it was in Goban.  It looks like it's already working as intended.

It looks like Goban's piece of the code is correct, so the error would be on the back end: either there is an alternate implementation not using Goban, or perhaps the moves are placed in `branches` instead of `trunk_next`.