### PR TITLE
Update internal links to use @link syntax [Fixes #201]

### DIFF
--- a/src/engine/protocol/index.ts
+++ b/src/engine/protocol/index.ts
@@ -27,7 +27,7 @@
  *
  *    `[command: string, data: any, id?: number]`
  *
- * where command is one of the commands listed in the [[ClientToServer]] protocol,
+ * where command is one of the commands listed in the {@link ClientToServer} protocol,
  * data is the data associated with that command, and id is an optional
  * request id that will be echoed in a response if a response is requested.
  *
@@ -39,7 +39,7 @@
  *
  *    `[id: number, data?: any, error?: {code: string, message: string}]`
  *
- * where event_name/data is listed in the [[ServerToClient]] protocol, or if
+ * where event_name/data is listed in the {@link ServerToClient} protocol, or if
  * the message is a response to a command sent by the client, the id
  * and the data for the response. Exactly one response will be sent for
  * a given command if an id was sent with the request. If no id was sent,


### PR DESCRIPTION
https://docs.online-go.com/goban/modules/protocol.html contains the text `[[ClientToServer]]` and `[[ServerToClient]]`, which are presumably intended to be hyperlinks to the relevant docs pages. However, that syntax is no longer supported in typedoc 0.25, which this project is currently using, so instead of links we have plaintext in awkward brackets.

See https://typedoc.org/documents/Changelog.html#breaking-changes-4:
> Dropped support for legacy [[link]]s, removed deprecated Reflection.findReflectionByName.

This migrates those two links to the modern `{@link ClientToServer}` syntax. A brief projectwide search for `[[` suggests these two instances are the only two `[[links]]` in the docs.

Tested changes locally with `yarn typedoc`. Test suite and prettier are also clean, although that's naturally expected for a two-word docs change.

Cheers!

