### PR TITLE
Handle Fox SGF komi value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ or whenever dependencies are updated)
 
 ## 2. Using local fork of `goban` while working on online-go.com
 
-The online-go.com repo uses a goban submodule (in `submodules/goban`). To configure this to use your fork/branch, you can do the following from within your online-go.com repo clone:
+The online-go.com repo uses a goban submodule (in `submodules/goban`). To configure this to use your fork/branch, you can do the following from within your online-go.com repo clone root:
 ```
 cd submodules/goban
 git remote add myFork https://github.com/<your_username>/goban.git
@@ -50,6 +50,11 @@ git checkout -b <local_branch_name> myFork/<remote_branch_name>
 ```
 
 Once done, your online-go.com development environment will use your goban fork's `goban` code.
+
+To reset the submodule, run from online-go.com repo clone root:
+```
+git submodule update --force --checkout submodules/goban
+```
 
 # Before PR
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,17 @@ yarn run dev
 (`yarn install` is only necessary the first time you start working on the project,
 or whenever dependencies are updated)
 
-## 2. Using local clone of `goban` while working on online-go.com
+## 2. Using local fork of `goban` while working on online-go.com
 
-From your `goban` directory run
+The online-go.com repo uses a goban submodule (in `submodules/goban`). To configure this to use your fork/branch, you can do the following from within your online-go.com repo clone:
+```
+cd submodules/goban
+git remote add myFork https://github.com/<your_username>/goban.git
+git fetch myFork
+git checkout -b <local_branch_name> myFork/<remote_branch_name>
+```
 
-`yarn link`
-
-From the `online-go.com` directory run
-
-`yarn link goban`
-
-Once done, your online-go.com development environment will use your development
-`goban` code.
+Once done, your online-go.com development environment will use your goban fork's `goban` code.
 
 # Before PR
 

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -1609,6 +1609,13 @@ export class GobanEngine extends BoardState {
             }
         }
 
+        // Handle non-standard Fox SGF komi value of 375. This value represents 3.75 in half-point
+        // counting which is equivalent to 7.5 in standard counting. An actual komi value of 375 is
+        // so nonsensical that always forcing this conversion is likely safe.
+        if (config.komi === 375) {
+            config.komi = 7.5;
+        }
+
         return config;
     }
     /**


### PR DESCRIPTION
Fox SGFs use a non-standard komi value, affecting the score estimation feature.

Also updated the README with how to use this with the new Vite/submodules setup (let me know if there's a better way to do this, as the approach I'm using is annoying. I much preferred the yarn link approach, but that's broken now).

Before:
<img width="155" height="53" alt="image" src="https://github.com/user-attachments/assets/2625b649-5e9e-4d08-af8f-0221eeeeb8d7" />
<img width="659" height="498" alt="image" src="https://github.com/user-attachments/assets/6afac407-c5df-4e63-a06b-2fff8252618f" />

After:
<img width="130" height="53" alt="image" src="https://github.com/user-attachments/assets/b1c8505d-d720-4582-b9b7-2cff7674292f" />
<img width="653" height="477" alt="image" src="https://github.com/user-attachments/assets/2c0fbdbd-48aa-4682-9ef9-e8a47d4fa033" />
