### PR TITLE
A few type updates to match the actual wire format

### DIFF
--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -134,6 +134,7 @@ export interface GobanEngineConfig extends BoardConfig {
     moves?: GobanMovesArray;
     move_tree?: MoveTreeJson;
     ranked?: boolean;
+    private?: boolean;
     original_disable_analysis?: boolean;
     original_sgf?: string;
     free_handicap_placement?: boolean;

--- a/src/engine/protocol/ServerToClient.ts
+++ b/src/engine/protocol/ServerToClient.ts
@@ -20,8 +20,9 @@ import type {
     AutomatchPreferences,
     RemoteStorageReplication,
     BotConfig,
+    RuleSet,
 } from "./ClientToServer";
-import type { JGOFTimeControl } from "../formats/JGOF";
+import type { JGOFTimeControl, JGOFTimeControlSystem } from "../formats/JGOF";
 import type { ConditionalMoveResponse } from "../ConditionalMoveTree";
 import type { GobanEngineConfig, Score, ReviewMessage } from "../GobanEngine";
 import type { AdHocPackedMove } from "../formats/AdHocFormat";
@@ -707,18 +708,20 @@ export interface SeekgraphChallengeMessage {
     handicap: number | null;
     /** Komi */
     komi: number | null;
+    /** Whether komi is automatic or custom */
+    komi_auto: "automatic" | "custom";
     /** Rules being used */
-    rules: string;
+    rules: RuleSet;
     /** Board width */
     width: number;
     /** Board height */
     height: number;
     /** Color the accepting player will be */
-    challenger_color: "black" | "white" | "automatic";
+    challenger_color: "black" | "white" | "automatic" | "random";
     /** If analysis is disabled */
     disable_analysis: boolean;
     /** Time control system type */
-    time_control: string;
+    time_control: JGOFTimeControlSystem;
     /** Time control parameters */
     time_control_parameters: JGOFTimeControl;
     /** Average time per move */


### PR DESCRIPTION
Two small things!

- In practice, GobanEngineConfig objects contain a `private` flag that isn't reflected in `GobanEngineConfig`. I don't have the cleanest sense of the divide between `GobanEngineConfig` and `BoardConfig`, but it should definitely exist on one of them, and my gut instinct was this belongs alongside e.g. `ranked`
- The challenge payload structure is both missing `komi_auto`, and has a bunch of fields that are currently just typed as `string` where the actual possible input is narrower and known (and in the case of challenger_color, we have a dedicated type, but it's missing an option the client sends today!)

Should be no practical runtime changes, just trying to help other folks by getting the types to match the actual wire format whenever I notice discrepancies.

Cheers!