### PR TITLE
feat: parse SGF time properties for clock display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ lint:
 
 test:
 	yarn run test
+
+prettier:
+	npm run prettier
 	
 detect-duplicate-code duplicate-code-detection:
 	yarn run detect-duplicate-code

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "jest-websocket-mock": "^2.5.0",
         "jscpd": "^4.0.1",
         "lint-staged": "^16.2.6",
-        "prettier": "3.6.2",
+        "prettier": "3.8.2",
         "prettier-eslint": "^16.4.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",

--- a/src/engine/ConditionalMoveTree.ts
+++ b/src/engine/ConditionalMoveTree.ts
@@ -17,8 +17,10 @@
 /** A branch in the conditional move tree, consists of the response move and
  *  the sub-tree of the next possible moves */
 export type ConditionalMoveResponse = [
-    /** response_move */
-    string | null,
+    (
+        /** response_move */
+        string | null
+    ),
 
     /** next move tree */
     ConditionalMoveResponseTree,

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2584,8 +2584,7 @@ export class GobanEngine extends BoardState {
                     case "OT":
                         {
                             const existing_main_time =
-                                self.sgf_time_settings &&
-                                "main_time" in self.sgf_time_settings
+                                self.sgf_time_settings && "main_time" in self.sgf_time_settings
                                     ? self.sgf_time_settings.main_time
                                     : self.sgf_time_settings &&
                                         "total_time" in self.sgf_time_settings

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -23,6 +23,7 @@ import {
     encodeMove,
     encodeMoves,
     makeMatrix,
+    parseSGFOvertime,
     positionId,
     prettyCoordinates,
     sortMoves,
@@ -344,6 +345,7 @@ export class GobanEngine extends BoardState {
         speed: "correspondence",
         pause_on_weekends: true,
     };
+    public sgf_time_settings?: JGOFTimeControl;
     public game_id: number = NaN;
     public review_id?: number;
     public decoded_moves: Array<JGOFMove> = [];
@@ -2547,6 +2549,117 @@ export class GobanEngine extends BoardState {
                                         white_territory_point.y,
                                         true,
                                     );
+                                }
+                            });
+                        }
+                        break;
+
+                    case "TM":
+                        {
+                            const main_time_ms = parseFloat(val) * 1000;
+                            if (!isNaN(main_time_ms)) {
+                                if (!self.sgf_time_settings) {
+                                    self.sgf_time_settings = {
+                                        system: "absolute",
+                                        speed: "live",
+                                        total_time: main_time_ms,
+                                        pause_on_weekends: false,
+                                    };
+                                } else if ("main_time" in self.sgf_time_settings) {
+                                    self.sgf_time_settings.main_time = main_time_ms;
+                                } else if ("total_time" in self.sgf_time_settings) {
+                                    self.sgf_time_settings.total_time = main_time_ms;
+                                } else if ("initial_time" in self.sgf_time_settings) {
+                                    self.sgf_time_settings.initial_time = main_time_ms;
+                                    if ("max_time" in self.sgf_time_settings) {
+                                        self.sgf_time_settings.max_time =
+                                            main_time_ms * 2 ||
+                                            self.sgf_time_settings.time_increment * 20;
+                                    }
+                                }
+                            }
+                        }
+                        break;
+
+                    case "OT":
+                        {
+                            const existing_main_time =
+                                self.sgf_time_settings &&
+                                "main_time" in self.sgf_time_settings
+                                    ? self.sgf_time_settings.main_time
+                                    : self.sgf_time_settings &&
+                                        "total_time" in self.sgf_time_settings
+                                      ? self.sgf_time_settings.total_time
+                                      : self.sgf_time_settings &&
+                                          "initial_time" in self.sgf_time_settings
+                                        ? self.sgf_time_settings.initial_time
+                                        : 0;
+                            const parsed = parseSGFOvertime(val, existing_main_time);
+                            if (parsed) {
+                                self.sgf_time_settings = parsed;
+                            }
+                        }
+                        break;
+
+                    case "BL":
+                        {
+                            instructions.push(() => {
+                                const time_left = parseFloat(val) * 1000;
+                                if (!isNaN(time_left)) {
+                                    if (!self.cur_move.black_clock) {
+                                        self.cur_move.black_clock = { main_time: 0 };
+                                    }
+                                    self.cur_move.black_clock.main_time = time_left;
+                                }
+                            });
+                        }
+                        break;
+
+                    case "WL":
+                        {
+                            instructions.push(() => {
+                                const time_left = parseFloat(val) * 1000;
+                                if (!isNaN(time_left)) {
+                                    if (!self.cur_move.white_clock) {
+                                        self.cur_move.white_clock = { main_time: 0 };
+                                    }
+                                    self.cur_move.white_clock.main_time = time_left;
+                                }
+                            });
+                        }
+                        break;
+
+                    case "OB":
+                        {
+                            instructions.push(() => {
+                                const count = parseInt(val);
+                                if (!isNaN(count)) {
+                                    if (!self.cur_move.black_clock) {
+                                        self.cur_move.black_clock = { main_time: 0 };
+                                    }
+                                    if (self.sgf_time_settings?.system === "canadian") {
+                                        self.cur_move.black_clock.moves_left = count;
+                                    } else {
+                                        self.cur_move.black_clock.periods_left = count;
+                                    }
+                                }
+                            });
+                        }
+                        break;
+
+                    case "OW":
+                        {
+                            instructions.push(() => {
+                                const count = parseInt(val);
+                                if (!isNaN(count)) {
+                                    if (!self.cur_move.white_clock) {
+                                        self.cur_move.white_clock = { main_time: 0 };
+                                    }
+                                    if (self.sgf_time_settings?.system === "canadian") {
+                                        self.cur_move.white_clock.moves_left = count;
+                                    } else {
+                                        self.cur_move.white_clock.periods_left = count;
+                                    }
                                 }
                             });
                         }

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -24,7 +24,12 @@ import {
     prettyCoordinates,
 } from "./util";
 import { AdHocPackedMove } from "./formats/AdHocFormat";
-import { JGOFMove, JGOFNumericPlayerColor, JGOFPlayerClock, JGOFPlayerSummary } from "./formats/JGOF";
+import {
+    JGOFMove,
+    JGOFNumericPlayerColor,
+    JGOFPlayerClock,
+    JGOFPlayerSummary,
+} from "./formats/JGOF";
 import { escapeSGFText, newlines_to_spaces } from "./util";
 
 export interface MarkInterface {

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -24,7 +24,7 @@ import {
     prettyCoordinates,
 } from "./util";
 import { AdHocPackedMove } from "./formats/AdHocFormat";
-import { JGOFMove, JGOFNumericPlayerColor, JGOFPlayerSummary } from "./formats/JGOF";
+import { JGOFMove, JGOFNumericPlayerColor, JGOFPlayerClock, JGOFPlayerSummary } from "./formats/JGOF";
 import { escapeSGFText, newlines_to_spaces } from "./util";
 
 export interface MarkInterface {
@@ -124,6 +124,8 @@ export class MoveTree {
     public pen_marks: MoveTreePenMarks = [];
     public player_update: JGOFPlayerSummary | undefined;
     public played_by: number | undefined;
+    public black_clock?: JGOFPlayerClock;
+    public white_clock?: JGOFPlayerClock;
 
     /* public for use by renderers when drawing move trees  */
     public active_path_number: number = 0;

--- a/src/engine/util/index.ts
+++ b/src/engine/util/index.ts
@@ -27,3 +27,4 @@ export * from "./sortMoves";
 export * from "./getRandomInt";
 export * from "./object_utils";
 export * from "./ai_review_utils";
+export * from "./sgfTime";

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -30,10 +30,7 @@ import { JGOFTimeControl, JGOFTimeControlSpeed } from "../formats/JGOF";
  *                     populate required fields on the time control object
  * @returns A JGOFTimeControl if the format is recognized, or null otherwise
  */
-export function parseSGFOvertime(
-    ot: string,
-    main_time_ms: number = 0,
-): JGOFTimeControl | null {
+export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTimeControl | null {
     const speed: JGOFTimeControlSpeed = estimateSpeed(main_time_ms);
 
     // Canadian: "15/300 Canadian" — stones_per_period/period_time

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JGOFTimeControl, JGOFTimeControlSpeed } from "../formats/JGOF";
+
+/**
+ * Parses an SGF OT (overtime) property string into a partial JGOFTimeControl.
+ *
+ * Recognized formats:
+ *   Canadian:  "15/300 Canadian"
+ *   Fischer:   "30 Fischer"
+ *   Byoyomi:   "5x30 byo-yomi"
+ *   Simple:    "60 simple"
+ *
+ * @param ot The OT property value from an SGF file
+ * @param main_time_ms Main time in milliseconds (from TM property), used to
+ *                     populate required fields on the time control object
+ * @returns A JGOFTimeControl if the format is recognized, or null otherwise
+ */
+export function parseSGFOvertime(
+    ot: string,
+    main_time_ms: number = 0,
+): JGOFTimeControl | null {
+    const speed: JGOFTimeControlSpeed = estimateSpeed(main_time_ms);
+
+    // Canadian: "15/300 Canadian" — stones_per_period/period_time
+    const canadian = ot.match(/^(\d+)\/(\d+(?:\.\d+)?)\s+canadian$/i);
+    if (canadian) {
+        return {
+            system: "canadian",
+            speed,
+            main_time: main_time_ms,
+            stones_per_period: parseInt(canadian[1]),
+            period_time: parseFloat(canadian[2]) * 1000,
+            pause_on_weekends: false,
+        };
+    }
+
+    // Fischer: "30 Fischer" — time_increment in seconds
+    const fischer = ot.match(/^(\d+(?:\.\d+)?)\s+fischer$/i);
+    if (fischer) {
+        const increment = parseFloat(fischer[1]) * 1000;
+        return {
+            system: "fischer",
+            speed,
+            initial_time: main_time_ms,
+            time_increment: increment,
+            max_time: main_time_ms * 2 || increment * 20,
+            pause_on_weekends: false,
+        };
+    }
+
+    // Byoyomi: "5x30 byo-yomi" — periods x period_time
+    const byoyomi = ot.match(/^(\d+)x(\d+(?:\.\d+)?)\s+byo-?yomi$/i);
+    if (byoyomi) {
+        return {
+            system: "byoyomi",
+            speed,
+            main_time: main_time_ms,
+            periods: parseInt(byoyomi[1]),
+            period_time: parseFloat(byoyomi[2]) * 1000,
+            pause_on_weekends: false,
+        };
+    }
+
+    // Simple: "60 simple" — per_move in seconds
+    const simple = ot.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
+    if (simple) {
+        return {
+            system: "simple",
+            speed,
+            per_move: parseFloat(simple[1]) * 1000,
+            pause_on_weekends: false,
+        };
+    }
+
+    return null;
+}
+
+function estimateSpeed(main_time_ms: number): JGOFTimeControlSpeed {
+    if (main_time_ms <= 5 * 60 * 1000) {
+        return "blitz";
+    }
+    if (main_time_ms <= 15 * 60 * 1000) {
+        return "live";
+    }
+    if (main_time_ms <= 3600 * 1000) {
+        return "rapid";
+    }
+    return "correspondence";
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6114,7 +6114,12 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@3.6.2, prettier@^3.5.3:
+prettier@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.2.tgz#4f52e502193c9aa5b384c3d00852003e551bbd9f"
+  integrity sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==
+
+prettier@^3.5.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==


### PR DESCRIPTION
Add support for parsing SGF time-related properties and storing per-move clock data on the move tree:

- MoveTree: add black_clock/white_clock (JGOFPlayerClock) fields
- GobanEngine: add sgf_time_settings (JGOFTimeControl) field
- parseSGF(): extract TM, OT, BL, WL, OB, OW properties
- parseSGFOvertime(): parse OT strings for Canadian, Fischer, Byoyomi, Simple time controls
- TM/OT handle any property ordering
- OB/OW write to moves_left (Canadian) or periods_left (Byoyomi)