### PR TITLE
Parse SGF time properties for clock display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ lint:
 
 test:
 	yarn run test
+
+prettier:
+	npm run prettier
 	
 detect-duplicate-code duplicate-code-detection:
 	yarn run detect-duplicate-code

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test:
 	yarn run test
 
 prettier:
-	npm run prettier
+	yarn run prettier
 	
 detect-duplicate-code duplicate-code-detection:
 	yarn run detect-duplicate-code

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "jest-websocket-mock": "^2.5.0",
         "jscpd": "^4.0.1",
         "lint-staged": "^16.2.6",
-        "prettier": "3.6.2",
+        "prettier": "3.8.2",
         "prettier-eslint": "^16.4.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",

--- a/src/engine/ConditionalMoveTree.ts
+++ b/src/engine/ConditionalMoveTree.ts
@@ -17,10 +17,8 @@
 /** A branch in the conditional move tree, consists of the response move and
  *  the sub-tree of the next possible moves */
 export type ConditionalMoveResponse = [
-    (
-        /** response_move */
-        string | null
-    ),
+    /** response_move */
+    string | null,
 
     /** next move tree */
     ConditionalMoveResponseTree,

--- a/src/engine/ConditionalMoveTree.ts
+++ b/src/engine/ConditionalMoveTree.ts
@@ -17,8 +17,10 @@
 /** A branch in the conditional move tree, consists of the response move and
  *  the sub-tree of the next possible moves */
 export type ConditionalMoveResponse = [
-    /** response_move */
-    string | null,
+    (
+        /** response_move */
+        string | null
+    ),
 
     /** next move tree */
     ConditionalMoveResponseTree,

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2581,8 +2581,9 @@ export class GobanEngine extends BoardState {
                                             );
                                         }
                                     }
-                                    self.sgf_time_settings.speed =
-                                        computeTimeControlSpeed(self.sgf_time_settings);
+                                    self.sgf_time_settings.speed = computeTimeControlSpeed(
+                                        self.sgf_time_settings,
+                                    );
                                 }
                             }
                         }

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2567,8 +2567,7 @@ export class GobanEngine extends BoardState {
                                         pause_on_weekends: false,
                                     };
                                 } else {
-                                    self.sgf_time_settings.speed =
-                                        estimateSpeed(main_time_ms);
+                                    self.sgf_time_settings.speed = estimateSpeed(main_time_ms);
                                     if ("main_time" in self.sgf_time_settings) {
                                         self.sgf_time_settings.main_time = main_time_ms;
                                     } else if ("total_time" in self.sgf_time_settings) {

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2575,9 +2575,10 @@ export class GobanEngine extends BoardState {
                                     } else if ("initial_time" in self.sgf_time_settings) {
                                         self.sgf_time_settings.initial_time = main_time_ms;
                                         if ("max_time" in self.sgf_time_settings) {
-                                            self.sgf_time_settings.max_time =
-                                                main_time_ms * 2 ||
-                                                self.sgf_time_settings.time_increment * 20;
+                                            self.sgf_time_settings.max_time = Math.max(
+                                                main_time_ms * 2,
+                                                self.sgf_time_settings.time_increment * 20,
+                                            );
                                         }
                                     }
                                 }

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2559,7 +2559,7 @@ export class GobanEngine extends BoardState {
                     case "TM":
                         {
                             const main_time_ms = parseFloat(val) * 1000;
-                            if (!isNaN(main_time_ms)) {
+                            if (!isNaN(main_time_ms) && main_time_ms >= 0) {
                                 if (!self.sgf_time_settings) {
                                     self.sgf_time_settings = {
                                         system: "absolute",
@@ -2612,12 +2612,13 @@ export class GobanEngine extends BoardState {
                         {
                             instructions.push(() => {
                                 const time_left = parseFloat(val) * 1000;
-                                if (!isNaN(time_left)) {
-                                    if (!self.cur_move.black_clock) {
-                                        self.cur_move.black_clock = { main_time: 0 };
-                                    }
-                                    self.cur_move.black_clock.main_time = time_left;
+                                if (isNaN(time_left) || time_left < 0) {
+                                    return;
                                 }
+                                if (!self.cur_move.black_clock) {
+                                    self.cur_move.black_clock = { main_time: 0 };
+                                }
+                                self.cur_move.black_clock.main_time = time_left;
                             });
                         }
                         break;
@@ -2626,12 +2627,13 @@ export class GobanEngine extends BoardState {
                         {
                             instructions.push(() => {
                                 const time_left = parseFloat(val) * 1000;
-                                if (!isNaN(time_left)) {
-                                    if (!self.cur_move.white_clock) {
-                                        self.cur_move.white_clock = { main_time: 0 };
-                                    }
-                                    self.cur_move.white_clock.main_time = time_left;
+                                if (isNaN(time_left) || time_left < 0) {
+                                    return;
                                 }
+                                if (!self.cur_move.white_clock) {
+                                    self.cur_move.white_clock = { main_time: 0 };
+                                }
+                                self.cur_move.white_clock.main_time = time_left;
                             });
                         }
                         break;
@@ -2640,7 +2642,7 @@ export class GobanEngine extends BoardState {
                         {
                             instructions.push(() => {
                                 const count = parseInt(val);
-                                if (isNaN(count)) {
+                                if (isNaN(count) || count < 0) {
                                     return;
                                 }
                                 const system = self.sgf_time_settings?.system;
@@ -2663,7 +2665,7 @@ export class GobanEngine extends BoardState {
                         {
                             instructions.push(() => {
                                 const count = parseInt(val);
-                                if (isNaN(count)) {
+                                if (isNaN(count) || count < 0) {
                                     return;
                                 }
                                 const system = self.sgf_time_settings?.system;

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -22,7 +22,9 @@ import {
     decodePrettyCoordinates,
     encodeMove,
     encodeMoves,
+    estimateSpeed,
     makeMatrix,
+    parseSGFOvertime,
     positionId,
     prettyCoordinates,
     sortMoves,
@@ -344,6 +346,7 @@ export class GobanEngine extends BoardState {
         speed: "correspondence",
         pause_on_weekends: true,
     };
+    public sgf_time_settings?: JGOFTimeControl;
     public game_id: number = NaN;
     public review_id?: number;
     public decoded_moves: Array<JGOFMove> = [];
@@ -2547,6 +2550,120 @@ export class GobanEngine extends BoardState {
                                         white_territory_point.y,
                                         true,
                                     );
+                                }
+                            });
+                        }
+                        break;
+
+                    case "TM":
+                        {
+                            const main_time_ms = parseFloat(val) * 1000;
+                            if (!isNaN(main_time_ms)) {
+                                if (!self.sgf_time_settings) {
+                                    self.sgf_time_settings = {
+                                        system: "absolute",
+                                        speed: estimateSpeed(main_time_ms),
+                                        total_time: main_time_ms,
+                                        pause_on_weekends: false,
+                                    };
+                                } else {
+                                    self.sgf_time_settings.speed =
+                                        estimateSpeed(main_time_ms);
+                                    if ("main_time" in self.sgf_time_settings) {
+                                        self.sgf_time_settings.main_time = main_time_ms;
+                                    } else if ("total_time" in self.sgf_time_settings) {
+                                        self.sgf_time_settings.total_time = main_time_ms;
+                                    } else if ("initial_time" in self.sgf_time_settings) {
+                                        self.sgf_time_settings.initial_time = main_time_ms;
+                                        if ("max_time" in self.sgf_time_settings) {
+                                            self.sgf_time_settings.max_time =
+                                                main_time_ms * 2 ||
+                                                self.sgf_time_settings.time_increment * 20;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        break;
+
+                    case "OT":
+                        {
+                            const existing_main_time =
+                                self.sgf_time_settings && "main_time" in self.sgf_time_settings
+                                    ? self.sgf_time_settings.main_time
+                                    : self.sgf_time_settings &&
+                                        "total_time" in self.sgf_time_settings
+                                      ? self.sgf_time_settings.total_time
+                                      : self.sgf_time_settings &&
+                                          "initial_time" in self.sgf_time_settings
+                                        ? self.sgf_time_settings.initial_time
+                                        : 0;
+                            const parsed = parseSGFOvertime(val, existing_main_time);
+                            if (parsed) {
+                                self.sgf_time_settings = parsed;
+                            }
+                        }
+                        break;
+
+                    case "BL":
+                        {
+                            instructions.push(() => {
+                                const time_left = parseFloat(val) * 1000;
+                                if (!isNaN(time_left)) {
+                                    if (!self.cur_move.black_clock) {
+                                        self.cur_move.black_clock = { main_time: 0 };
+                                    }
+                                    self.cur_move.black_clock.main_time = time_left;
+                                }
+                            });
+                        }
+                        break;
+
+                    case "WL":
+                        {
+                            instructions.push(() => {
+                                const time_left = parseFloat(val) * 1000;
+                                if (!isNaN(time_left)) {
+                                    if (!self.cur_move.white_clock) {
+                                        self.cur_move.white_clock = { main_time: 0 };
+                                    }
+                                    self.cur_move.white_clock.main_time = time_left;
+                                }
+                            });
+                        }
+                        break;
+
+                    case "OB":
+                        {
+                            instructions.push(() => {
+                                const count = parseInt(val);
+                                if (!isNaN(count)) {
+                                    if (!self.cur_move.black_clock) {
+                                        self.cur_move.black_clock = { main_time: 0 };
+                                    }
+                                    if (self.sgf_time_settings?.system === "canadian") {
+                                        self.cur_move.black_clock.moves_left = count;
+                                    } else {
+                                        self.cur_move.black_clock.periods_left = count;
+                                    }
+                                }
+                            });
+                        }
+                        break;
+
+                    case "OW":
+                        {
+                            instructions.push(() => {
+                                const count = parseInt(val);
+                                if (!isNaN(count)) {
+                                    if (!self.cur_move.white_clock) {
+                                        self.cur_move.white_clock = { main_time: 0 };
+                                    }
+                                    if (self.sgf_time_settings?.system === "canadian") {
+                                        self.cur_move.white_clock.moves_left = count;
+                                    } else {
+                                        self.cur_move.white_clock.periods_left = count;
+                                    }
                                 }
                             });
                         }

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2640,15 +2640,20 @@ export class GobanEngine extends BoardState {
                         {
                             instructions.push(() => {
                                 const count = parseInt(val);
-                                if (!isNaN(count)) {
-                                    if (!self.cur_move.black_clock) {
-                                        self.cur_move.black_clock = { main_time: 0 };
-                                    }
-                                    if (self.sgf_time_settings?.system === "canadian") {
-                                        self.cur_move.black_clock.moves_left = count;
-                                    } else {
-                                        self.cur_move.black_clock.periods_left = count;
-                                    }
+                                if (isNaN(count)) {
+                                    return;
+                                }
+                                const system = self.sgf_time_settings?.system;
+                                if (system !== "canadian" && system !== "byoyomi") {
+                                    return;
+                                }
+                                if (!self.cur_move.black_clock) {
+                                    self.cur_move.black_clock = { main_time: 0 };
+                                }
+                                if (system === "canadian") {
+                                    self.cur_move.black_clock.moves_left = count;
+                                } else {
+                                    self.cur_move.black_clock.periods_left = count;
                                 }
                             });
                         }
@@ -2658,15 +2663,20 @@ export class GobanEngine extends BoardState {
                         {
                             instructions.push(() => {
                                 const count = parseInt(val);
-                                if (!isNaN(count)) {
-                                    if (!self.cur_move.white_clock) {
-                                        self.cur_move.white_clock = { main_time: 0 };
-                                    }
-                                    if (self.sgf_time_settings?.system === "canadian") {
-                                        self.cur_move.white_clock.moves_left = count;
-                                    } else {
-                                        self.cur_move.white_clock.periods_left = count;
-                                    }
+                                if (isNaN(count)) {
+                                    return;
+                                }
+                                const system = self.sgf_time_settings?.system;
+                                if (system !== "canadian" && system !== "byoyomi") {
+                                    return;
+                                }
+                                if (!self.cur_move.white_clock) {
+                                    self.cur_move.white_clock = { main_time: 0 };
+                                }
+                                if (system === "canadian") {
+                                    self.cur_move.white_clock.moves_left = count;
+                                } else {
+                                    self.cur_move.white_clock.periods_left = count;
                                 }
                             });
                         }

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -37,6 +37,7 @@ import {
     JGOFTimeControl,
     JGOFNumericPlayerColor,
     JGOFMove,
+    JGOFPlayerClock,
     JGOFPlayerSummary,
     JGOFIntersection,
     JGOFSealingIntersection,
@@ -49,6 +50,20 @@ import * as goscorer from "goscorer";
 
 declare const CLIENT: boolean;
 declare const SERVER: boolean;
+
+function findAncestorClock(
+    move: MoveTree,
+    field: "black_clock" | "white_clock",
+): JGOFPlayerClock | undefined {
+    let cur: MoveTree | null = move.parent;
+    while (cur) {
+        if (cur[field]) {
+            return cur[field];
+        }
+        cur = cur.parent;
+    }
+    return undefined;
+}
 
 export const AUTOSCORE_TRIALS = 1000;
 export const AUTOSCORE_TOLERANCE = 0.1;
@@ -2655,7 +2670,23 @@ export class GobanEngine extends BoardState {
                                     return;
                                 }
                                 if (!self.cur_move.black_clock) {
-                                    self.cur_move.black_clock = { main_time: 0 };
+                                    // No BL on this node. Inherit from the nearest
+                                    // ancestor's clock rather than fabricating
+                                    // main_time: 0 (which would be misread as
+                                    // "flagged"). Some SGF writers emit BL only
+                                    // during main time and then just OB/OW once in
+                                    // byo-yomi, so the nearest BL may be several
+                                    // nodes back. If no ancestor clock exists,
+                                    // skip — a bare count with no time baseline
+                                    // is ambiguous.
+                                    const inherited = findAncestorClock(
+                                        self.cur_move,
+                                        "black_clock",
+                                    );
+                                    if (!inherited) {
+                                        return;
+                                    }
+                                    self.cur_move.black_clock = { ...inherited };
                                 }
                                 if (system === "canadian") {
                                     self.cur_move.black_clock.moves_left = count;
@@ -2678,7 +2709,14 @@ export class GobanEngine extends BoardState {
                                     return;
                                 }
                                 if (!self.cur_move.white_clock) {
-                                    self.cur_move.white_clock = { main_time: 0 };
+                                    const inherited = findAncestorClock(
+                                        self.cur_move,
+                                        "white_clock",
+                                    );
+                                    if (!inherited) {
+                                        return;
+                                    }
+                                    self.cur_move.white_clock = { ...inherited };
                                 }
                                 if (system === "canadian") {
                                     self.cur_move.white_clock.moves_left = count;

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -18,6 +18,7 @@ import { BoardState, BoardConfig } from "./BoardState";
 import { GobanMoveError } from "./GobanError";
 import { MoveTree, MoveTreeJson } from "./MoveTree";
 import {
+    computeTimeControlSpeed,
     decodeMoves,
     decodePrettyCoordinates,
     encodeMove,
@@ -2567,7 +2568,6 @@ export class GobanEngine extends BoardState {
                                         pause_on_weekends: false,
                                     };
                                 } else {
-                                    self.sgf_time_settings.speed = estimateSpeed(main_time_ms);
                                     if ("main_time" in self.sgf_time_settings) {
                                         self.sgf_time_settings.main_time = main_time_ms;
                                     } else if ("total_time" in self.sgf_time_settings) {
@@ -2581,6 +2581,8 @@ export class GobanEngine extends BoardState {
                                             );
                                         }
                                     }
+                                    self.sgf_time_settings.speed =
+                                        computeTimeControlSpeed(self.sgf_time_settings);
                                 }
                             }
                         }

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -2568,6 +2568,9 @@ export class GobanEngine extends BoardState {
                                         pause_on_weekends: false,
                                     };
                                 } else {
+                                    // No arm for "simple": JGOFSimpleTimeControl has no
+                                    // main_time field, so TM cannot be preserved when
+                                    // OT is simple — consistent with parseSGFOvertime.
                                     if ("main_time" in self.sgf_time_settings) {
                                         self.sgf_time_settings.main_time = main_time_ms;
                                     } else if ("total_time" in self.sgf_time_settings) {
@@ -2575,6 +2578,8 @@ export class GobanEngine extends BoardState {
                                     } else if ("initial_time" in self.sgf_time_settings) {
                                         self.sgf_time_settings.initial_time = main_time_ms;
                                         if ("max_time" in self.sgf_time_settings) {
+                                            // See Fischer branch of parseSGFOvertime for
+                                            // the rationale behind max(main*2, inc*20).
                                             self.sgf_time_settings.max_time = Math.max(
                                                 main_time_ms * 2,
                                                 self.sgf_time_settings.time_increment * 20,

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -24,7 +24,12 @@ import {
     prettyCoordinates,
 } from "./util";
 import { AdHocPackedMove } from "./formats/AdHocFormat";
-import { JGOFMove, JGOFNumericPlayerColor, JGOFPlayerSummary } from "./formats/JGOF";
+import {
+    JGOFMove,
+    JGOFNumericPlayerColor,
+    JGOFPlayerClock,
+    JGOFPlayerSummary,
+} from "./formats/JGOF";
 import { escapeSGFText, newlines_to_spaces } from "./util";
 
 export interface MarkInterface {
@@ -124,6 +129,8 @@ export class MoveTree {
     public pen_marks: MoveTreePenMarks = [];
     public player_update: JGOFPlayerSummary | undefined;
     public played_by: number | undefined;
+    public black_clock?: JGOFPlayerClock;
+    public white_clock?: JGOFPlayerClock;
 
     /* public for use by renderers when drawing move trees  */
     public active_path_number: number = 0;

--- a/src/engine/util/index.ts
+++ b/src/engine/util/index.ts
@@ -27,3 +27,4 @@ export * from "./sortMoves";
 export * from "./getRandomInt";
 export * from "./object_utils";
 export * from "./ai_review_utils";
+export * from "./sgfTime";

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -58,6 +58,8 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
         if (increment <= 0) {
             return null;
         }
+        // SGF doesn't specify a max_time cap; use the larger of 2x main time
+        // or ~20 moves of increments as a reasonable playable ceiling.
         return {
             system: "fischer",
             speed: estimateSpeed(main_time_ms + increment),
@@ -86,7 +88,9 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
         };
     }
 
-    // Simple: "60 simple" — per_move in seconds
+    // Simple: "60 simple" — per_move in seconds.
+    // JGOFSimpleTimeControl has no main_time field, so main_time_ms is
+    // intentionally discarded here and by the TM handler's ordering logic.
     const simple = cleaned.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
     if (simple) {
         const per_move = parseFloat(simple[1]) * 1000;

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -31,17 +31,16 @@ import { JGOFTimeControl, JGOFTimeControlSpeed } from "../formats/JGOF";
  * @returns A JGOFTimeControl if the format is recognized, or null otherwise
  */
 export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTimeControl | null {
-    const speed: JGOFTimeControlSpeed = estimateSpeed(main_time_ms);
-
     // Canadian: "15/300 Canadian" — stones_per_period/period_time
     const canadian = ot.match(/^(\d+)\/(\d+(?:\.\d+)?)\s+canadian$/i);
     if (canadian) {
+        const period_time = parseFloat(canadian[2]) * 1000;
         return {
             system: "canadian",
-            speed,
+            speed: estimateSpeed(main_time_ms + period_time),
             main_time: main_time_ms,
             stones_per_period: parseInt(canadian[1]),
-            period_time: parseFloat(canadian[2]) * 1000,
+            period_time,
             pause_on_weekends: false,
         };
     }
@@ -52,10 +51,10 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
         const increment = parseFloat(fischer[1]) * 1000;
         return {
             system: "fischer",
-            speed,
+            speed: estimateSpeed(main_time_ms + increment),
             initial_time: main_time_ms,
             time_increment: increment,
-            max_time: main_time_ms * 2 || increment * 20,
+            max_time: Math.max(main_time_ms * 2, increment * 20),
             pause_on_weekends: false,
         };
     }
@@ -63,12 +62,14 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     // Byoyomi: "5x30 byo-yomi" — periods x period_time
     const byoyomi = ot.match(/^(\d+)x(\d+(?:\.\d+)?)\s+byo-?yomi$/i);
     if (byoyomi) {
+        const periods = parseInt(byoyomi[1]);
+        const period_time = parseFloat(byoyomi[2]) * 1000;
         return {
             system: "byoyomi",
-            speed,
+            speed: estimateSpeed(main_time_ms + periods * period_time),
             main_time: main_time_ms,
-            periods: parseInt(byoyomi[1]),
-            period_time: parseFloat(byoyomi[2]) * 1000,
+            periods,
+            period_time,
             pause_on_weekends: false,
         };
     }
@@ -76,10 +77,11 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     // Simple: "60 simple" — per_move in seconds
     const simple = ot.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
     if (simple) {
+        const per_move = parseFloat(simple[1]) * 1000;
         return {
             system: "simple",
-            speed,
-            per_move: parseFloat(simple[1]) * 1000,
+            speed: estimateSpeed(per_move),
+            per_move,
             pause_on_weekends: false,
         };
     }

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -70,6 +70,9 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     if (byoyomi) {
         const periods = parseInt(byoyomi[1]);
         const period_time = parseFloat(byoyomi[2]) * 1000;
+        if (periods <= 0) {
+            return null;
+        }
         return {
             system: "byoyomi",
             speed: estimateSpeed(main_time_ms + period_time),

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -31,22 +31,28 @@ import { JGOFTimeControl, JGOFTimeControlSpeed } from "../formats/JGOF";
  * @returns A JGOFTimeControl if the format is recognized, or null otherwise
  */
 export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTimeControl | null {
+    const cleaned = ot.trim();
+
     // Canadian: "15/300 Canadian" — stones_per_period/period_time
-    const canadian = ot.match(/^(\d+)\/(\d+(?:\.\d+)?)\s+canadian$/i);
+    const canadian = cleaned.match(/^(\d+)\/(\d+(?:\.\d+)?)\s+canadian$/i);
     if (canadian) {
+        const stones_per_period = parseInt(canadian[1]);
         const period_time = parseFloat(canadian[2]) * 1000;
+        if (stones_per_period <= 0) {
+            return null;
+        }
         return {
             system: "canadian",
-            speed: estimateSpeed(main_time_ms + period_time),
+            speed: estimateSpeed(main_time_ms + period_time / stones_per_period),
             main_time: main_time_ms,
-            stones_per_period: parseInt(canadian[1]),
+            stones_per_period,
             period_time,
             pause_on_weekends: false,
         };
     }
 
     // Fischer: "30 Fischer" — time_increment in seconds
-    const fischer = ot.match(/^(\d+(?:\.\d+)?)\s+fischer$/i);
+    const fischer = cleaned.match(/^(\d+(?:\.\d+)?)\s+fischer$/i);
     if (fischer) {
         const increment = parseFloat(fischer[1]) * 1000;
         return {
@@ -60,7 +66,7 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     }
 
     // Byoyomi: "5x30 byo-yomi" — periods x period_time
-    const byoyomi = ot.match(/^(\d+)x(\d+(?:\.\d+)?)\s+byo-?yomi$/i);
+    const byoyomi = cleaned.match(/^(\d+)\s*x\s*(\d+(?:\.\d+)?)\s+byo-?yomi$/i);
     if (byoyomi) {
         const periods = parseInt(byoyomi[1]);
         const period_time = parseFloat(byoyomi[2]) * 1000;
@@ -75,7 +81,7 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     }
 
     // Simple: "60 simple" — per_move in seconds
-    const simple = ot.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
+    const simple = cleaned.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
     if (simple) {
         const per_move = parseFloat(simple[1]) * 1000;
         return {
@@ -111,8 +117,11 @@ export function estimateSpeed(total_time_ms: number): JGOFTimeControlSpeed {
  */
 export function computeTimeControlSpeed(tc: JGOFTimeControl): JGOFTimeControlSpeed {
     switch (tc.system) {
-        case "canadian":
-            return estimateSpeed(tc.main_time + tc.period_time);
+        case "canadian": {
+            const per_move =
+                tc.stones_per_period > 0 ? tc.period_time / tc.stones_per_period : tc.period_time;
+            return estimateSpeed(tc.main_time + per_move);
+        }
         case "fischer":
             return estimateSpeed(tc.initial_time + tc.time_increment);
         case "byoyomi":

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -72,7 +72,7 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
         const period_time = parseFloat(byoyomi[2]) * 1000;
         return {
             system: "byoyomi",
-            speed: estimateSpeed(main_time_ms + periods * period_time),
+            speed: estimateSpeed(main_time_ms + period_time),
             main_time: main_time_ms,
             periods,
             period_time,
@@ -125,7 +125,7 @@ export function computeTimeControlSpeed(tc: JGOFTimeControl): JGOFTimeControlSpe
         case "fischer":
             return estimateSpeed(tc.initial_time + tc.time_increment);
         case "byoyomi":
-            return estimateSpeed(tc.main_time + tc.periods * tc.period_time);
+            return estimateSpeed(tc.main_time + tc.period_time);
         case "simple":
             return estimateSpeed(tc.per_move);
         case "absolute":

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JGOFTimeControl, JGOFTimeControlSpeed } from "../formats/JGOF";
+
+/**
+ * Parses an SGF OT (overtime) property string into a partial JGOFTimeControl.
+ *
+ * Recognized formats:
+ *   Canadian:  "15/300 Canadian"
+ *   Fischer:   "30 Fischer"
+ *   Byoyomi:   "5x30 byo-yomi"
+ *   Simple:    "60 simple"
+ *
+ * @param ot The OT property value from an SGF file
+ * @param main_time_ms Main time in milliseconds (from TM property), used to
+ *                     populate required fields on the time control object
+ * @returns A JGOFTimeControl if the format is recognized, or null otherwise
+ */
+export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTimeControl | null {
+    const speed: JGOFTimeControlSpeed = estimateSpeed(main_time_ms);
+
+    // Canadian: "15/300 Canadian" — stones_per_period/period_time
+    const canadian = ot.match(/^(\d+)\/(\d+(?:\.\d+)?)\s+canadian$/i);
+    if (canadian) {
+        return {
+            system: "canadian",
+            speed,
+            main_time: main_time_ms,
+            stones_per_period: parseInt(canadian[1]),
+            period_time: parseFloat(canadian[2]) * 1000,
+            pause_on_weekends: false,
+        };
+    }
+
+    // Fischer: "30 Fischer" — time_increment in seconds
+    const fischer = ot.match(/^(\d+(?:\.\d+)?)\s+fischer$/i);
+    if (fischer) {
+        const increment = parseFloat(fischer[1]) * 1000;
+        return {
+            system: "fischer",
+            speed,
+            initial_time: main_time_ms,
+            time_increment: increment,
+            max_time: main_time_ms * 2 || increment * 20,
+            pause_on_weekends: false,
+        };
+    }
+
+    // Byoyomi: "5x30 byo-yomi" — periods x period_time
+    const byoyomi = ot.match(/^(\d+)x(\d+(?:\.\d+)?)\s+byo-?yomi$/i);
+    if (byoyomi) {
+        return {
+            system: "byoyomi",
+            speed,
+            main_time: main_time_ms,
+            periods: parseInt(byoyomi[1]),
+            period_time: parseFloat(byoyomi[2]) * 1000,
+            pause_on_weekends: false,
+        };
+    }
+
+    // Simple: "60 simple" — per_move in seconds
+    const simple = ot.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
+    if (simple) {
+        return {
+            system: "simple",
+            speed,
+            per_move: parseFloat(simple[1]) * 1000,
+            pause_on_weekends: false,
+        };
+    }
+
+    return null;
+}
+
+export function estimateSpeed(main_time_ms: number): JGOFTimeControlSpeed {
+    if (main_time_ms <= 5 * 60 * 1000) {
+        return "blitz";
+    }
+    if (main_time_ms <= 15 * 60 * 1000) {
+        return "live";
+    }
+    if (main_time_ms <= 3600 * 1000) {
+        return "rapid";
+    }
+    return "correspondence";
+}

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -38,7 +38,7 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     if (canadian) {
         const stones_per_period = parseInt(canadian[1]);
         const period_time = parseFloat(canadian[2]) * 1000;
-        if (stones_per_period <= 0) {
+        if (stones_per_period <= 0 || period_time <= 0) {
             return null;
         }
         return {
@@ -55,6 +55,9 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     const fischer = cleaned.match(/^(\d+(?:\.\d+)?)\s+fischer$/i);
     if (fischer) {
         const increment = parseFloat(fischer[1]) * 1000;
+        if (increment <= 0) {
+            return null;
+        }
         return {
             system: "fischer",
             speed: estimateSpeed(main_time_ms + increment),
@@ -70,7 +73,7 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     if (byoyomi) {
         const periods = parseInt(byoyomi[1]);
         const period_time = parseFloat(byoyomi[2]) * 1000;
-        if (periods <= 0) {
+        if (periods <= 0 || period_time <= 0) {
             return null;
         }
         return {
@@ -87,6 +90,9 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     const simple = cleaned.match(/^(\d+(?:\.\d+)?)\s+simple$/i);
     if (simple) {
         const per_move = parseFloat(simple[1]) * 1000;
+        if (per_move <= 0) {
+            return null;
+        }
         return {
             system: "simple",
             speed: estimateSpeed(per_move),

--- a/src/engine/util/sgfTime.ts
+++ b/src/engine/util/sgfTime.ts
@@ -89,15 +89,39 @@ export function parseSGFOvertime(ot: string, main_time_ms: number = 0): JGOFTime
     return null;
 }
 
-export function estimateSpeed(main_time_ms: number): JGOFTimeControlSpeed {
-    if (main_time_ms <= 5 * 60 * 1000) {
+/**
+ * Estimate the speed category from total available time in milliseconds.
+ */
+export function estimateSpeed(total_time_ms: number): JGOFTimeControlSpeed {
+    if (total_time_ms <= 5 * 60 * 1000) {
         return "blitz";
     }
-    if (main_time_ms <= 15 * 60 * 1000) {
-        return "live";
-    }
-    if (main_time_ms <= 3600 * 1000) {
+    if (total_time_ms <= 15 * 60 * 1000) {
         return "rapid";
     }
+    if (total_time_ms <= 3600 * 1000) {
+        return "live";
+    }
     return "correspondence";
+}
+
+/**
+ * Compute the speed category from a complete JGOFTimeControl object,
+ * considering both main time and overtime components.
+ */
+export function computeTimeControlSpeed(tc: JGOFTimeControl): JGOFTimeControlSpeed {
+    switch (tc.system) {
+        case "canadian":
+            return estimateSpeed(tc.main_time + tc.period_time);
+        case "fischer":
+            return estimateSpeed(tc.initial_time + tc.time_increment);
+        case "byoyomi":
+            return estimateSpeed(tc.main_time + tc.periods * tc.period_time);
+        case "simple":
+            return estimateSpeed(tc.per_move);
+        case "absolute":
+            return estimateSpeed(tc.total_time);
+        case "none":
+            return "correspondence";
+    }
 }

--- a/test/unit_tests/GoEngine_sgf_time.test.ts
+++ b/test/unit_tests/GoEngine_sgf_time.test.ts
@@ -168,6 +168,26 @@ describe("GobanEngine SGF time parsing", () => {
         expect(move1.black_clock).toBeUndefined();
     });
 
+    test("OB without BL on same node inherits parent's main_time", () => {
+        // Some SGF writers stop emitting BL once the main clock expires and
+        // only track byo-yomi periods. Verify main_time is inherited rather
+        // than fabricated as 0.
+        const goban = loadSGF(
+            "(;GM[1]FF[4]SZ[19]TM[1800]OT[5x30 byo-yomi];B[pd]BL[30]OB[5];W[dp];B[pp]OB[4])",
+        );
+        const move3 = nth(goban.engine.move_tree, 3);
+        expect(move3.black_clock).toMatchObject({
+            main_time: 30 * 1000,
+            periods_left: 4,
+        });
+    });
+
+    test("OB without BL and no parent clock is skipped", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800]OT[5x30 byo-yomi];B[pd]OB[5])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.black_clock).toBeUndefined();
+    });
+
     test("OB with negative value is ignored", () => {
         const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800]OT[5x30 byo-yomi];B[pd]BL[30]OB[-1])");
         const move1 = nth(goban.engine.move_tree, 1);

--- a/test/unit_tests/GoEngine_sgf_time.test.ts
+++ b/test/unit_tests/GoEngine_sgf_time.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ */
+// cspell: disable
+
+(global as any).CLIENT = true;
+
+import { TestGoban } from "../../src/Goban/TestGoban";
+import { MoveTree } from "engine";
+
+function nth(mt: MoveTree, n: number): MoveTree {
+    let cur: MoveTree = mt;
+    for (let i = 0; i < n; i++) {
+        if (!cur.trunk_next) {
+            throw new Error(`move ${n} not found (stopped at ${i})`);
+        }
+        cur = cur.trunk_next;
+    }
+    return cur;
+}
+
+function loadSGF(sgf: string): TestGoban {
+    return new TestGoban({ original_sgf: sgf, removed: "" });
+}
+
+describe("GobanEngine SGF time parsing", () => {
+    test("TM alone produces absolute sgf_time_settings", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "absolute",
+            total_time: 1800 * 1000,
+        });
+    });
+
+    test("TM + OT Canadian produces canadian settings with main_time", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[3600]OT[15/300 Canadian])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "canadian",
+            main_time: 3600 * 1000,
+            stones_per_period: 15,
+            period_time: 300 * 1000,
+        });
+    });
+
+    test("OT before TM still yields correct main_time", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]OT[15/300 Canadian]TM[3600])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "canadian",
+            main_time: 3600 * 1000,
+            stones_per_period: 15,
+            period_time: 300 * 1000,
+        });
+    });
+
+    test("TM + OT byo-yomi produces byoyomi settings", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800]OT[5x30 byo-yomi])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "byoyomi",
+            main_time: 1800 * 1000,
+            periods: 5,
+            period_time: 30 * 1000,
+        });
+    });
+
+    test("TM + OT Fischer produces fischer settings with initial_time", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[600]OT[10 Fischer])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "fischer",
+            initial_time: 600 * 1000,
+            time_increment: 10 * 1000,
+        });
+    });
+
+    test("OT before TM for Fischer recomputes max_time", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]OT[10 Fischer]TM[600])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "fischer",
+            initial_time: 600 * 1000,
+            time_increment: 10 * 1000,
+            // max = max(600*2, 10*20) = 1200
+            max_time: 1200 * 1000,
+        });
+    });
+
+    test("BL attaches per-move remaining time to black_clock", () => {
+        const goban = loadSGF(
+            "(;GM[1]FF[4]SZ[19]TM[3600]OT[15/300 Canadian];B[pd]BL[3590];W[dp]WL[3595])",
+        );
+        const root = goban.engine.move_tree;
+        const move1 = nth(root, 1);
+        const move2 = nth(root, 2);
+
+        expect(move1.black_clock).toMatchObject({ main_time: 3590 * 1000 });
+        expect(move2.white_clock).toMatchObject({ main_time: 3595 * 1000 });
+    });
+
+    test("BL and WL on same move populate separate clock fields", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[3600];B[pd]BL[3590]WL[3600])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.black_clock).toMatchObject({ main_time: 3590 * 1000 });
+        expect(move1.white_clock).toMatchObject({ main_time: 3600 * 1000 });
+    });
+
+    test("OB in byoyomi populates periods_left", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800]OT[5x30 byo-yomi];B[pd]BL[30]OB[3])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.black_clock).toMatchObject({
+            main_time: 30 * 1000,
+            periods_left: 3,
+        });
+        expect(move1.black_clock?.moves_left).toBeUndefined();
+    });
+
+    test("OB in Canadian populates moves_left", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[3600]OT[15/300 Canadian];B[pd]BL[300]OB[10])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.black_clock).toMatchObject({
+            main_time: 300 * 1000,
+            moves_left: 10,
+        });
+        expect(move1.black_clock?.periods_left).toBeUndefined();
+    });
+
+    test("OB in absolute system is ignored", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800];B[pd]BL[1790]OB[3])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        // main_time is populated by BL, but OB should not write periods_left
+        expect(move1.black_clock?.main_time).toBe(1790 * 1000);
+        expect(move1.black_clock?.periods_left).toBeUndefined();
+        expect(move1.black_clock?.moves_left).toBeUndefined();
+    });
+
+    test("OW in Fischer is ignored", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[600]OT[10 Fischer];W[pd]WL[590]OW[1])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.white_clock?.main_time).toBe(590 * 1000);
+        expect(move1.white_clock?.periods_left).toBeUndefined();
+        expect(move1.white_clock?.moves_left).toBeUndefined();
+    });
+
+    test("SGF with no time properties leaves sgf_time_settings undefined", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19];B[pd];W[dp])");
+        expect(goban.engine.sgf_time_settings).toBeUndefined();
+    });
+
+    test("Unrecognized OT format leaves sgf_time_settings absolute (from TM)", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800]OT[Mysterious])");
+        expect(goban.engine.sgf_time_settings).toMatchObject({
+            system: "absolute",
+            total_time: 1800 * 1000,
+        });
+    });
+});

--- a/test/unit_tests/GoEngine_sgf_time.test.ts
+++ b/test/unit_tests/GoEngine_sgf_time.test.ts
@@ -156,4 +156,22 @@ describe("GobanEngine SGF time parsing", () => {
             total_time: 1800 * 1000,
         });
     });
+
+    test("TM with negative value is ignored", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[-100])");
+        expect(goban.engine.sgf_time_settings).toBeUndefined();
+    });
+
+    test("BL with negative value does not create black_clock", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800];B[pd]BL[-50])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.black_clock).toBeUndefined();
+    });
+
+    test("OB with negative value is ignored", () => {
+        const goban = loadSGF("(;GM[1]FF[4]SZ[19]TM[1800]OT[5x30 byo-yomi];B[pd]BL[30]OB[-1])");
+        const move1 = nth(goban.engine.move_tree, 1);
+        expect(move1.black_clock?.main_time).toBe(30 * 1000);
+        expect(move1.black_clock?.periods_left).toBeUndefined();
+    });
 });

--- a/test/unit_tests/sgfTime.test.ts
+++ b/test/unit_tests/sgfTime.test.ts
@@ -84,6 +84,22 @@ describe("parseSGFOvertime", () => {
         expect(parseSGFOvertime("0x30 byo-yomi", 0)).toBeNull();
     });
 
+    test("rejects byoyomi with zero period_time", () => {
+        expect(parseSGFOvertime("5x0 byo-yomi", 0)).toBeNull();
+    });
+
+    test("rejects Canadian with zero period_time", () => {
+        expect(parseSGFOvertime("15/0 Canadian", 0)).toBeNull();
+    });
+
+    test("rejects Fischer with zero increment", () => {
+        expect(parseSGFOvertime("0 Fischer", 0)).toBeNull();
+    });
+
+    test("rejects Simple with zero per_move", () => {
+        expect(parseSGFOvertime("0 simple", 0)).toBeNull();
+    });
+
     test("parses byoyomi with spaces around x", () => {
         const result = parseSGFOvertime("5 x 30 byo-yomi", 0);
         expect(result?.system).toBe("byoyomi");

--- a/test/unit_tests/sgfTime.test.ts
+++ b/test/unit_tests/sgfTime.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { parseSGFOvertime, estimateSpeed, computeTimeControlSpeed } from "engine";
+import type { JGOFTimeControl } from "engine/formats/JGOF";
+
+describe("parseSGFOvertime", () => {
+    test("parses Canadian format", () => {
+        const result = parseSGFOvertime("15/300 Canadian", 3600 * 1000);
+        expect(result).toMatchObject({
+            system: "canadian",
+            main_time: 3600 * 1000,
+            stones_per_period: 15,
+            period_time: 300 * 1000,
+        });
+    });
+
+    test("parses Canadian case-insensitively", () => {
+        const result = parseSGFOvertime("10/600 CANADIAN", 0);
+        expect(result?.system).toBe("canadian");
+    });
+
+    test("parses Canadian with fractional period_time", () => {
+        const result = parseSGFOvertime("25/180.5 Canadian", 0);
+        expect(result).toMatchObject({
+            system: "canadian",
+            stones_per_period: 25,
+            period_time: 180500,
+        });
+    });
+
+    test("rejects Canadian with zero stones_per_period", () => {
+        expect(parseSGFOvertime("0/300 Canadian", 0)).toBeNull();
+    });
+
+    test("parses Fischer format", () => {
+        const result = parseSGFOvertime("30 Fischer", 600 * 1000);
+        expect(result).toMatchObject({
+            system: "fischer",
+            initial_time: 600 * 1000,
+            time_increment: 30 * 1000,
+        });
+    });
+
+    test("Fischer max_time uses increment * 20 when main_time is small", () => {
+        const result = parseSGFOvertime("60 Fischer", 1000);
+        expect(result).toMatchObject({
+            system: "fischer",
+            max_time: 60 * 1000 * 20,
+        });
+    });
+
+    test("Fischer max_time uses main_time * 2 when larger", () => {
+        const result = parseSGFOvertime("10 Fischer", 600 * 1000);
+        expect(result).toMatchObject({
+            system: "fischer",
+            max_time: 600 * 1000 * 2,
+        });
+    });
+
+    test("parses byo-yomi format", () => {
+        const result = parseSGFOvertime("5x30 byo-yomi", 1800 * 1000);
+        expect(result).toMatchObject({
+            system: "byoyomi",
+            main_time: 1800 * 1000,
+            periods: 5,
+            period_time: 30 * 1000,
+        });
+    });
+
+    test("parses byoyomi without hyphen", () => {
+        const result = parseSGFOvertime("3x60 byoyomi", 0);
+        expect(result?.system).toBe("byoyomi");
+    });
+
+    test("parses byoyomi with spaces around x", () => {
+        const result = parseSGFOvertime("5 x 30 byo-yomi", 0);
+        expect(result?.system).toBe("byoyomi");
+    });
+
+    test("parses Simple format", () => {
+        const result = parseSGFOvertime("60 simple", 0);
+        expect(result).toMatchObject({
+            system: "simple",
+            per_move: 60 * 1000,
+        });
+    });
+
+    test("trims surrounding whitespace", () => {
+        const result = parseSGFOvertime("  15/300 Canadian  ", 0);
+        expect(result?.system).toBe("canadian");
+    });
+
+    test("returns null for unrecognized format", () => {
+        expect(parseSGFOvertime("unknown format", 0)).toBeNull();
+    });
+
+    test("returns null for empty string", () => {
+        expect(parseSGFOvertime("", 0)).toBeNull();
+    });
+});
+
+describe("estimateSpeed", () => {
+    test("classifies blitz (<=5min)", () => {
+        expect(estimateSpeed(0)).toBe("blitz");
+        expect(estimateSpeed(5 * 60 * 1000)).toBe("blitz");
+    });
+
+    test("classifies rapid (5-15min)", () => {
+        expect(estimateSpeed(5 * 60 * 1000 + 1)).toBe("rapid");
+        expect(estimateSpeed(15 * 60 * 1000)).toBe("rapid");
+    });
+
+    test("classifies live (15-60min)", () => {
+        expect(estimateSpeed(15 * 60 * 1000 + 1)).toBe("live");
+        expect(estimateSpeed(3600 * 1000)).toBe("live");
+    });
+
+    test("classifies correspondence (>60min)", () => {
+        expect(estimateSpeed(3600 * 1000 + 1)).toBe("correspondence");
+        expect(estimateSpeed(86400 * 1000)).toBe("correspondence");
+    });
+});
+
+describe("computeTimeControlSpeed", () => {
+    test("Canadian divides period_time by stones_per_period", () => {
+        const tc: JGOFTimeControl = {
+            system: "canadian",
+            speed: "blitz",
+            main_time: 0,
+            stones_per_period: 25,
+            period_time: 600 * 1000,
+            pause_on_weekends: false,
+        };
+        // 600s / 25 = 24s per stone → blitz
+        expect(computeTimeControlSpeed(tc)).toBe("blitz");
+    });
+
+    test("Canadian 3600 main + 15/300 → live", () => {
+        const tc: JGOFTimeControl = {
+            system: "canadian",
+            speed: "blitz",
+            main_time: 3600 * 1000,
+            stones_per_period: 15,
+            period_time: 300 * 1000,
+            pause_on_weekends: false,
+        };
+        // 3600 + 20 = 3620s → live (since > 15min and <= 60min)
+        expect(computeTimeControlSpeed(tc)).toBe("correspondence");
+    });
+
+    test("Canadian handles zero stones_per_period without crashing", () => {
+        const tc: JGOFTimeControl = {
+            system: "canadian",
+            speed: "blitz",
+            main_time: 0,
+            stones_per_period: 0,
+            period_time: 300 * 1000,
+            pause_on_weekends: false,
+        };
+        expect(computeTimeControlSpeed(tc)).toBeDefined();
+    });
+
+    test("Fischer uses initial_time + time_increment", () => {
+        const tc: JGOFTimeControl = {
+            system: "fischer",
+            speed: "blitz",
+            initial_time: 600 * 1000,
+            time_increment: 10 * 1000,
+            max_time: 600 * 1000,
+            pause_on_weekends: false,
+        };
+        // 610s → rapid
+        expect(computeTimeControlSpeed(tc)).toBe("rapid");
+    });
+
+    test("byoyomi uses main + periods*period_time", () => {
+        const tc: JGOFTimeControl = {
+            system: "byoyomi",
+            speed: "blitz",
+            main_time: 1800 * 1000,
+            periods: 5,
+            period_time: 30 * 1000,
+            pause_on_weekends: false,
+        };
+        // 1800 + 150 = 1950s → live
+        expect(computeTimeControlSpeed(tc)).toBe("live");
+    });
+
+    test("simple uses per_move", () => {
+        const tc: JGOFTimeControl = {
+            system: "simple",
+            speed: "blitz",
+            per_move: 60 * 1000,
+            pause_on_weekends: false,
+        };
+        expect(computeTimeControlSpeed(tc)).toBe("blitz");
+    });
+
+    test("absolute uses total_time", () => {
+        const tc: JGOFTimeControl = {
+            system: "absolute",
+            speed: "blitz",
+            total_time: 3600 * 1000,
+            pause_on_weekends: false,
+        };
+        expect(computeTimeControlSpeed(tc)).toBe("live");
+    });
+
+    test("none maps to correspondence", () => {
+        const tc: JGOFTimeControl = {
+            system: "none",
+            speed: "correspondence",
+            pause_on_weekends: false,
+        };
+        expect(computeTimeControlSpeed(tc)).toBe("correspondence");
+    });
+});

--- a/test/unit_tests/sgfTime.test.ts
+++ b/test/unit_tests/sgfTime.test.ts
@@ -80,6 +80,10 @@ describe("parseSGFOvertime", () => {
         expect(result?.system).toBe("byoyomi");
     });
 
+    test("rejects byoyomi with zero periods", () => {
+        expect(parseSGFOvertime("0x30 byo-yomi", 0)).toBeNull();
+    });
+
     test("parses byoyomi with spaces around x", () => {
         const result = parseSGFOvertime("5 x 30 byo-yomi", 0);
         expect(result?.system).toBe("byoyomi");

--- a/test/unit_tests/sgfTime.test.ts
+++ b/test/unit_tests/sgfTime.test.ts
@@ -143,7 +143,7 @@ describe("computeTimeControlSpeed", () => {
         expect(computeTimeControlSpeed(tc)).toBe("blitz");
     });
 
-    test("Canadian 3600 main + 15/300 → live", () => {
+    test("Canadian 3600 main + 15/300 → correspondence", () => {
         const tc: JGOFTimeControl = {
             system: "canadian",
             speed: "blitz",
@@ -152,7 +152,7 @@ describe("computeTimeControlSpeed", () => {
             period_time: 300 * 1000,
             pause_on_weekends: false,
         };
-        // 3600 + 20 = 3620s → live (since > 15min and <= 60min)
+        // 3600 + 20 = 3620s → correspondence (> 60 min threshold)
         expect(computeTimeControlSpeed(tc)).toBe("correspondence");
     });
 
@@ -181,7 +181,7 @@ describe("computeTimeControlSpeed", () => {
         expect(computeTimeControlSpeed(tc)).toBe("rapid");
     });
 
-    test("byoyomi uses main + periods*period_time", () => {
+    test("byoyomi uses main + period_time (per-move pressure)", () => {
         const tc: JGOFTimeControl = {
             system: "byoyomi",
             speed: "blitz",
@@ -190,8 +190,22 @@ describe("computeTimeControlSpeed", () => {
             period_time: 30 * 1000,
             pause_on_weekends: false,
         };
-        // 1800 + 150 = 1950s → live
+        // 1800 + 30 = 1830s → live
         expect(computeTimeControlSpeed(tc)).toBe("live");
+    });
+
+    test("byoyomi with no main time uses period_time only", () => {
+        // 5x120s byo-yomi: per-move pressure is 120s, should classify as blitz,
+        // not rapid (which 5*120=600s would falsely yield).
+        const tc: JGOFTimeControl = {
+            system: "byoyomi",
+            speed: "rapid",
+            main_time: 0,
+            periods: 5,
+            period_time: 120 * 1000,
+            pause_on_weekends: false,
+        };
+        expect(computeTimeControlSpeed(tc)).toBe("blitz");
     });
 
     test("simple uses per_move", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6114,7 +6114,12 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@3.6.2, prettier@^3.5.3:
+prettier@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.2.tgz#4f52e502193c9aa5b384c3d00852003e551bbd9f"
+  integrity sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==
+
+prettier@^3.5.3:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==


### PR DESCRIPTION
Add support for parsing SGF time-related properties and storing per-move clock data on the move tree:

- MoveTree: add black_clock/white_clock (JGOFPlayerClock) fields
- GobanEngine: add sgf_time_settings (JGOFTimeControl) field
- parseSGF(): extract TM, OT, BL, WL, OB, OW properties
- parseSGFOvertime(): parse OT strings for Canadian, Fischer, Byoyomi, Simple time controls
- estimateSpeed(): exported for use by TM handler
- TM/OT handle any property ordering, speed always computed correctly
- OB/OW write to moves_left (Canadian) or periods_left (Byoyomi)