### PR TITLE
Add support for opt-in fuzzy stone placement

### DIFF
--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -96,6 +96,19 @@ export abstract class Goban extends OGSConnectivity {
     private _evaluation: number = 0.5;
     private _evaluation_bar_width: number = 8;
 
+    private prng(seed: number, irrational: number): number {
+        return (((seed + irrational) % 1) - 0.5) * 2;
+    }
+
+    public getStonePlacementOffset(i: number, j: number): { x: number; y: number } {
+        const max_shift = 0.05 * this.square_size;
+        const seed = ((this.game_id || 0) % 1000) / 1000;
+        const stone_index = i * this.width + j;
+        const dx = this.prng(seed, stone_index * Math.sqrt(2)) * max_shift;
+        const dy = this.prng(seed, stone_index * Math.sqrt(3)) * max_shift;
+        return { x: dx, y: dy };
+    }
+
     constructor(config: GobanConfig, preloaded_data?: GobanConfig) {
         super(config, preloaded_data);
 

--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -103,7 +103,7 @@ export abstract class Goban extends OGSConnectivity {
     public getStonePlacementOffset(i: number, j: number): { x: number; y: number } {
         const max_shift = 0.05 * this.square_size;
         const seed = ((this.game_id || 0) % 1000) / 1000;
-        const stone_index = i * this.width + j;
+        const stone_index = 1 + i * this.width + j;
         const dx = this.prng(seed, stone_index * Math.sqrt(2)) * max_shift;
         const dy = this.prng(seed, stone_index * Math.sqrt(3)) * max_shift;
         return { x: dx, y: dy };

--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -489,6 +489,12 @@ export abstract class GobanInteractive extends GobanBase {
         }
         return false;
     }
+    protected getFuzzyPlacementEnabled(): boolean {
+        if (callbacks.getFuzzyPlacementEnabled) {
+            return callbacks.getFuzzyPlacementEnabled();
+        }
+        return false;
+    }
     // scale relative to the "OGS default"
     protected getStoneFontScale(): number {
         if (callbacks.getStoneFontScale) {

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -2034,6 +2034,10 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             cell.clearScoreEstimate();
         }
 
+        if (stone_color && this.getFuzzyPlacementEnabled()) {
+            const offset = this.getStonePlacementOffset(i, j);
+            transform += ` translate(${offset.x},${offset.y})`;
+        }
         cell.transform = transform;
         //this.__draw_state[j][i] = this.drawingHash(i, j);
     }
@@ -3873,8 +3877,8 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     }
 
     protected computeThemeStoneRadius(): number {
-        const r = this.square_size * 0.5;
-        return Math.max(1, r);
+        const scale = this.getFuzzyPlacementEnabled() ? 0.45 : 0.5;
+        return Math.max(1, this.square_size * scale);
     }
 
     public redraw(force_clear?: boolean): void {

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -3877,7 +3877,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     }
 
     protected computeThemeStoneRadius(): number {
-        const scale = this.getFuzzyPlacementEnabled() ? 0.45 : 0.5;
+        const scale = this.getFuzzyPlacementEnabled() ? 0.49 : 0.5;
         return Math.max(1, this.square_size * scale);
     }
 

--- a/src/Goban/callbacks.ts
+++ b/src/Goban/callbacks.ts
@@ -28,6 +28,7 @@ export interface GobanCallbacks {
     // getShowMoveNumbers?: () => boolean;
     getShowVariationMoveNumbers?: () => boolean;
     getStoneFontScale?: () => number;
+    getFuzzyPlacementEnabled?: () => boolean;
     getShowUndoRequestIndicator?: () => boolean;
     getMoveTreeNumbering?: () => "move-coordinates" | "none" | "move-number";
     getCDNReleaseBase?: () => string;


### PR DESCRIPTION
This PR adds support for fuzzy stone placement. The Sabaki implementation is pretty complex. It adjusts stones post-hoc if they're too close to each other. I think that's likely more effort than you would want to maintain here. So instead for this implementation:

1. We have a user preference for `getFuzzyPlacementEnabled` which should default to false.
2. We decrease the stone size to 90% when the setting is enabled
3. We generate a (not actually very random, see below) offset deterministically based on seed and stone position. Scale it to 5% of the square size so stones can't overlap even in the worst case scenario.
4. Finally add `transform` to the svg in src/Goban/SVGRenderer.ts with that offset. This moves the stones and annotations to stay on the stones. It also might move analysis colors and the star points if they're below the stones according to Claude? Everything looked ok to me on visual inspection.

This seems to work pretty nicely and should not impact users unless they explicitly opt into this. That being said, I'd appreciate another set of eyes since these files are big and I know even less about them than I know about the main OGS code.


*Note on the "prng":*
Definitely not actually random. We take gameid mod 1000 / 1000 (some fixed number between 0 and 1), a stone index (fixed integer between 0 and number of squares-1), and whichever irrational number we want (I used sqrt(2) and sqrt(3). Then truncate to [0. 1) and move values to (-1., 1). There's **absolutely no reason** to use this function or this function signature instead of another function. Was just looking for something deterministic and quick to compute. 

example image on demo board
<img width="845" height="836" alt="image" src="https://github.com/user-attachments/assets/c78db49a-df18-4985-8732-642fe93b100f" />

example image for the liveplay games
<img width="737" height="362" alt="image" src="https://github.com/user-attachments/assets/23f18eb7-1336-4364-b6e9-0c2d98c701e7" />
