### PR TITLE
Last-move accessibility crosshair

### DIFF
--- a/src/Goban.css
+++ b/src/Goban.css
@@ -63,7 +63,7 @@
 
     .CrosshairLayer {
         position: absolute;
-        z-index: var(--z-goban-crosshair-layer, 15);
+        z-index: var(--z-goban-crosshair-layer);
         left: 0;
         right: 0;
     }

--- a/src/Goban.css
+++ b/src/Goban.css
@@ -16,7 +16,7 @@
 
 .Goban {
     position: relative;
-    background-color: #DCB35C;
+    background-color: #dcb35c;
     display: inline-block;
     box-shadow: var(--goban-shadow);
 
@@ -61,6 +61,13 @@
         right: 0;
     }
 
+    .CrosshairLayer {
+        position: absolute;
+        z-index: var(--z-goban-crosshair-layer, 15);
+        left: 0;
+        right: 0;
+    }
+
     .GobanMessage table {
         position: relative;
         width: 100%;
@@ -75,10 +82,10 @@
     .GobanMessage table td div {
         border-radius: 3px;
         box-shadow: 5px 5px 3px rgba(0, 0, 0, 0.26);
-        color: #FF5500;
+        color: #ff5500;
         background-color: #262626;
-        padding: .3em;
-        margin: .4em;
+        padding: 0.3em;
+        margin: 0.4em;
     }
 
     .hidden {

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -2282,13 +2282,20 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
 
         /* Clear last move */
+        // Tracks whether the crosshair was already refreshed in this draw, so the
+        // "draw last move" block below doesn't redraw it a second time for the
+        // same cur_move.
+        let crosshair_synced = false;
         if (this.last_move && this.engine && !this.last_move.is(this.engine.cur_move)) {
             const m = this.last_move;
             delete this.last_move;
             this.drawSquare(m.x, m.y);
             // The last-move crosshair lives on its own canvas; refresh it whenever
             // the last move changes (live moves / navigation are targeted draws).
+            // This also clears it when navigating to a position with no last-move
+            // stone, which the "draw last move" block below cannot.
             this.drawLastMoveCrosshair();
+            crosshair_synced = true;
         }
 
         /* Draw last move */
@@ -2300,9 +2307,11 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 this.last_move = this.engine.cur_move;
-                // Keep the crosshair canvas in sync on the first move (no prior
-                // last move to trigger the "clear last move" path above).
-                this.drawLastMoveCrosshair();
+                // Sync the crosshair on the first move (no prior last move to
+                // trigger the "clear last move" path above); skip if already done.
+                if (!crosshair_synced) {
+                    this.drawLastMoveCrosshair();
+                }
 
                 if (i >= 0 && j >= 0) {
                     const color =

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -331,9 +331,10 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     console.error(e2);
                 }
             }
-            // Write-only layer (clearRect + stroke, never getImageData), so keep
-            // it GPU-accelerated — no willReadFrequently hint.
-            const ctx = this.crosshair_layer.getContext("2d");
+            // Match the other layers. (createDeviceScaledCanvas already locks the
+            // context in with willReadFrequently on its first getContext call, so
+            // we pass the same option here for consistency rather than effect.)
+            const ctx = this.crosshair_layer.getContext("2d", { willReadFrequently: true });
             if (ctx) {
                 this.crosshair_ctx = ctx;
             }
@@ -2879,8 +2880,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
                 if (this.crosshair_layer) {
                     resizeDeviceScaledCanvas(this.crosshair_layer, metrics.width, metrics.height);
-                    // Write-only layer — keep it GPU-accelerated (no willReadFrequently).
-                    const ctx = this.crosshair_layer.getContext("2d");
+                    // Consistent with the other layers (see attachCrosshairLayer).
+                    const ctx = this.crosshair_layer.getContext("2d", { willReadFrequently: true });
                     if (ctx) {
                         this.crosshair_ctx = ctx;
                     }

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -114,6 +114,11 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private handleShiftKey: (ev: KeyboardEvent) => void;
 
     private last_move_opacity: number = 1;
+    /* Dedicated canvas for the last-move accessibility crosshair. It sits
+     * behind the (transparent) stone canvas, so the full-board horizontal and
+     * vertical lines are drawn as single strokes under the stones. */
+    private crosshair_layer?: HTMLCanvasElement;
+    private crosshair_ctx?: CanvasRenderingContext2D;
     public move_tree_container?: HTMLElement;
     private move_tree_inner_container?: HTMLDivElement;
     private move_tree_canvas?: HTMLCanvasElement;
@@ -246,6 +251,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
         this.detachPenCanvas();
         this.detachShadowLayer();
+        this.detachCrosshairLayer();
 
         if (this.message_timeout) {
             clearTimeout(this.message_timeout);
@@ -306,6 +312,104 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             }
             this.bindPointerBindings(this.shadow_layer);
         }
+    }
+    private attachCrosshairLayer(): void {
+        if (!this.crosshair_layer && this.parent) {
+            this.crosshair_layer = createDeviceScaledCanvas(
+                this.metrics.width,
+                this.metrics.height,
+            );
+            this.crosshair_layer.setAttribute("id", "crosshair-canvas");
+            this.crosshair_layer.className = "CrosshairLayer";
+            try {
+                this.parent.insertBefore(this.crosshair_layer, this.board);
+            } catch (e) {
+                console.warn("Error inserting crosshair layer before board", e);
+                try {
+                    this.parent.appendChild(this.crosshair_layer);
+                } catch (e2) {
+                    console.error(e2);
+                }
+            }
+            const ctx = this.crosshair_layer.getContext("2d", { willReadFrequently: true });
+            if (ctx) {
+                this.crosshair_ctx = ctx;
+            }
+        }
+    }
+    private detachCrosshairLayer(): void {
+        if (this.crosshair_layer) {
+            if (this.crosshair_layer.parentNode) {
+                this.crosshair_layer.parentNode.removeChild(this.crosshair_layer);
+            }
+            delete this.crosshair_layer;
+            delete this.crosshair_ctx;
+        }
+    }
+    /* Draws (or clears) the last-move accessibility crosshair on its own canvas:
+     * two single full-board strokes through the last move, clamped to the edge
+     * intersections, sitting under the stones. The layer is attached lazily so
+     * boards never pay for it unless the setting is enabled. */
+    private drawLastMoveCrosshair(): void {
+        const ch = this.getLastMoveCrosshair();
+        const cur = this.engine?.cur_move;
+        const shows =
+            ch.enabled &&
+            !this.dont_draw_last_move &&
+            !this.dont_draw_last_move_crosshair &&
+            !!cur &&
+            cur.x >= 0 &&
+            cur.y >= 0 &&
+            (this.engine.phase === "play" || this.engine.phase === "finished");
+
+        if (!shows) {
+            if (this.crosshair_ctx && this.crosshair_layer) {
+                this.crosshair_ctx.clearRect(
+                    0,
+                    0,
+                    this.crosshair_layer.width,
+                    this.crosshair_layer.height,
+                );
+            }
+            return;
+        }
+
+        this.attachCrosshairLayer();
+        if (!this.crosshair_ctx || !this.crosshair_layer) {
+            return;
+        }
+
+        const ctx = this.crosshair_ctx;
+        ctx.clearRect(0, 0, this.crosshair_layer.width, this.crosshair_layer.height);
+
+        const s = this.square_size;
+        let ox = this.draw_left_labels ? s : 0;
+        let oy = this.draw_top_labels ? s : 0;
+        if (this.bounds.left > 0) {
+            ox = -s * this.bounds.left;
+        }
+        if (this.bounds.top > 0) {
+            oy = -s * this.bounds.top;
+        }
+        const mid = this.metrics.mid;
+        const cx = ox + cur.x * s + mid;
+        const cy = oy + cur.y * s + mid;
+        // span from the first to the last intersection centre
+        const x0 = ox + mid;
+        const x1 = ox + (this.width - 1) * s + mid;
+        const y0 = oy + mid;
+        const y1 = oy + (this.height - 1) * s + mid;
+
+        ctx.save();
+        ctx.strokeStyle = ch.color;
+        ctx.lineWidth = Math.max(1, s * ch.thickness);
+        ctx.beginPath();
+        ctx.moveTo(x0, cy);
+        ctx.lineTo(x1, cy);
+        ctx.moveTo(cx, y0);
+        ctx.lineTo(cx, y1);
+        ctx.stroke();
+        ctx.restore();
     }
     private detachPenCanvas(): void {
         if (this.pen_layer) {
@@ -2179,6 +2283,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             const m = this.last_move;
             delete this.last_move;
             this.drawSquare(m.x, m.y);
+            // The last-move crosshair lives on its own canvas; refresh it whenever
+            // the last move changes (live moves / navigation are targeted draws).
+            this.drawLastMoveCrosshair();
         }
 
         /* Draw last move */
@@ -2190,6 +2297,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 this.last_move = this.engine.cur_move;
+                // Keep the crosshair canvas in sync on the first move (no prior
+                // last move to trigger the "clear last move" path above).
+                this.drawLastMoveCrosshair();
 
                 if (i >= 0 && j >= 0) {
                     const color =
@@ -2765,6 +2875,16 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     }
                 }
 
+                if (this.crosshair_layer) {
+                    resizeDeviceScaledCanvas(this.crosshair_layer, metrics.width, metrics.height);
+                    const ctx = this.crosshair_layer.getContext("2d", {
+                        willReadFrequently: true,
+                    });
+                    if (ctx) {
+                        this.crosshair_ctx = ctx;
+                    }
+                }
+
                 this.__set_board_width = metrics.width;
                 this.__set_board_height = metrics.height;
                 const ctx = this.board.getContext("2d", { willReadFrequently: true });
@@ -2962,6 +3082,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
 
         this.drawPenMarks(this.pen_marks);
+        this.drawLastMoveCrosshair();
         this.move_tree_redraw();
     }
     public showMessage(

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -324,6 +324,11 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             try {
                 this.parent.insertBefore(this.crosshair_layer, this.board);
             } catch (e) {
+                // Mirrors attachShadowLayer's fallback: sentry.io shows insertBefore can
+                // occasionally throw. The appendChild fallback puts the layer last in DOM
+                // order, so correct under-stone stacking then relies on the consumer having
+                // defined --z-goban-crosshair-layer (as OGS does); without it both layers
+                // fall back to z-index:auto and the crosshair would paint over the stones.
                 console.warn("Error inserting crosshair layer before board", e);
                 try {
                     this.parent.appendChild(this.crosshair_layer);
@@ -2893,6 +2898,13 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     const ctx = this.crosshair_layer.getContext("2d", { willReadFrequently: true });
                     if (ctx) {
                         this.crosshair_ctx = ctx;
+                    } else {
+                        // resizeDeviceScaledCanvas reset the backing store; if we can't
+                        // re-acquire the context (e.g. GPU context loss) drop the stale
+                        // reference so drawLastMoveCrosshair skips rather than draws at the
+                        // wrong scale. The crosshair is an optional accessibility overlay,
+                        // so degrade gracefully instead of throwing like the core layers.
+                        delete this.crosshair_ctx;
                     }
                 }
 

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -331,7 +331,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     console.error(e2);
                 }
             }
-            const ctx = this.crosshair_layer.getContext("2d", { willReadFrequently: true });
+            // Write-only layer (clearRect + stroke, never getImageData), so keep
+            // it GPU-accelerated — no willReadFrequently hint.
+            const ctx = this.crosshair_layer.getContext("2d");
             if (ctx) {
                 this.crosshair_ctx = ctx;
             }
@@ -2877,9 +2879,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
                 if (this.crosshair_layer) {
                     resizeDeviceScaledCanvas(this.crosshair_layer, metrics.width, metrics.height);
-                    const ctx = this.crosshair_layer.getContext("2d", {
-                        willReadFrequently: true,
-                    });
+                    // Write-only layer — keep it GPU-accelerated (no willReadFrequently).
+                    const ctx = this.crosshair_layer.getContext("2d");
                     if (ctx) {
                         this.crosshair_ctx = ctx;
                     }

--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -245,6 +245,7 @@ export abstract class GobanInteractive extends GobanBase {
     protected display_width?: number;
     protected done_loading_review: boolean = false;
     protected dont_draw_last_move: boolean;
+    protected dont_draw_last_move_crosshair: boolean;
 
     protected edit_color?: "black" | "white";
     protected errorHandler: (e: Error) => void;
@@ -364,6 +365,7 @@ export abstract class GobanInteractive extends GobanBase {
             this.onError = config.onError;
         }
         this.dont_draw_last_move = !!config.dont_draw_last_move;
+        this.dont_draw_last_move_crosshair = !!config.dont_draw_last_move_crosshair;
         this.last_move_radius = config.last_move_radius || 0.25;
         this.circle_radius = config.circle_radius || 0.25;
         this.getPuzzlePlacementSetting = config.getPuzzlePlacementSetting;
@@ -501,6 +503,12 @@ export abstract class GobanInteractive extends GobanBase {
             return callbacks.getStoneFontScale();
         }
         return 1.0;
+    }
+    protected getLastMoveCrosshair(): { enabled: boolean; color: string; thickness: number } {
+        if (callbacks.getLastMoveCrosshair) {
+            return callbacks.getLastMoveCrosshair();
+        }
+        return { enabled: false, color: "#1e6bff", thickness: 0.1 };
     }
     public static getMoveTreeNumbering(): string {
         if (callbacks.getMoveTreeNumbering) {

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -319,6 +319,11 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
         delete (this as any).board;
         delete (this as any).svg;
+        // The crosshair layer was a child of the now-removed svg; drop our
+        // references so late updateLastMoveCrosshair() calls early-return and the
+        // detached subtree can be GC'd (mirrors the Canvas detachCrosshairLayer).
+        delete this.crosshair_layer;
+        delete this.grid_layer;
 
         this.detachPenLayer();
 
@@ -3752,7 +3757,9 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
         this.crosshair_layer.innerHTML = "";
 
-        // Mirror the intersection geometry used by drawLines().
+        // Align with the stone centres — metrics.mid is the canonical centre
+        // offset used by the stones and the Canvas crosshair (it accounts for the
+        // 0.5px adjustment on even square sizes; Math.round(ss/2) would be 0.5px off).
         const ss = this.square_size;
         let ox = this.draw_left_labels ? ss : 0;
         let oy = this.draw_top_labels ? ss : 0;
@@ -3762,8 +3769,8 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         if (this.bounds.top > 0) {
             oy = -ss * this.bounds.top;
         }
-        ox += Math.round(ss / 2);
-        oy += Math.round(ss / 2);
+        ox += this.metrics.mid;
+        oy += this.metrics.mid;
 
         const cx = ox + cm.x * ss;
         const cy = oy + cm.y * ss;

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -3743,8 +3743,13 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             this.crosshair_layer = document.createElementNS("http://www.w3.org/2000/svg", "g");
             this.crosshair_layer.setAttribute("class", "crosshair-layer");
         }
-        // Keep it directly before the stone grid layer (under the stones).
-        this.svg.insertBefore(this.crosshair_layer, this.grid_layer);
+        // Keep it directly before the stone grid layer (under the stones). Only
+        // (re)insert when not already positioned there — grid_layer is recreated
+        // on a force_clear redraw, but otherwise this avoids a DOM mutation (and
+        // layout invalidation) on every move.
+        if (this.crosshair_layer.nextSibling !== this.grid_layer) {
+            this.svg.insertBefore(this.crosshair_layer, this.grid_layer);
+        }
         this.crosshair_layer.innerHTML = "";
 
         // Mirror the intersection geometry used by drawLines().

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -3717,6 +3717,28 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         if (!this.grid_layer) {
             return;
         }
+
+        const cm = this.engine?.cur_move;
+        const ch = this.getLastMoveCrosshair();
+        const shows =
+            ch.enabled &&
+            !this.dont_draw_last_move &&
+            !this.dont_draw_last_move_crosshair &&
+            !!cm &&
+            cm.x >= 0 &&
+            cm.y >= 0 &&
+            (this.engine?.phase === "play" || this.engine?.phase === "finished");
+
+        // When the crosshair isn't shown, do no DOM work — only clear an already
+        // attached layer. The layer is created/attached lazily so boards never pay
+        // for it unless the feature is on (matches the Canvas renderer).
+        if (!shows || !cm) {
+            if (this.crosshair_layer) {
+                this.crosshair_layer.innerHTML = "";
+            }
+            return;
+        }
+
         if (!this.crosshair_layer) {
             this.crosshair_layer = document.createElementNS("http://www.w3.org/2000/svg", "g");
             this.crosshair_layer.setAttribute("class", "crosshair-layer");
@@ -3724,25 +3746,6 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         // Keep it directly before the stone grid layer (under the stones).
         this.svg.insertBefore(this.crosshair_layer, this.grid_layer);
         this.crosshair_layer.innerHTML = "";
-
-        if (!this.engine || !this.engine.cur_move) {
-            return;
-        }
-        const cm = this.engine.cur_move;
-        const playing = this.engine.phase === "play" || this.engine.phase === "finished";
-        if (
-            this.dont_draw_last_move ||
-            this.dont_draw_last_move_crosshair ||
-            !playing ||
-            cm.x < 0 ||
-            cm.y < 0
-        ) {
-            return;
-        }
-        const ch = this.getLastMoveCrosshair();
-        if (!ch.enabled) {
-            return;
-        }
 
         // Mirror the intersection geometry used by drawLines().
         const ss = this.square_size;

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -136,6 +136,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     private handleShiftKey: (ev: KeyboardEvent) => void;
 
     private lines_layer?: SVGGraphicsElement;
+    private crosshair_layer?: SVGGraphicsElement;
     private coordinate_labels_layer?: SVGGraphicsElement;
     private grid: Array<Array<SVGGraphicsElement>> = [];
     public grid_layer?: SVGGraphicsElement;
@@ -1977,6 +1978,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             const m = this.last_move;
             delete this.last_move;
             this.cell(m.x, m.y).clearLastMove();
+            this.updateLastMoveCrosshair();
         }
 
         /* Draw last move */
@@ -1988,6 +1990,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 this.last_move = this.engine.cur_move;
+                this.updateLastMoveCrosshair();
 
                 if (i >= 0 && j >= 0) {
                     const color =
@@ -2999,6 +3002,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             const m = this.last_move;
             delete this.last_move;
             this.drawSquare(m.x, m.y);
+            this.updateLastMoveCrosshair();
         }
 
         /* Draw last move */
@@ -3010,6 +3014,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 this.last_move = this.engine.cur_move;
+                this.updateLastMoveCrosshair();
 
                 if (i >= 0 && j >= 0) {
                     const color =
@@ -3704,6 +3709,73 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
     }
 
+    /* Last-move crosshair: a dedicated layer kept directly beneath the stone
+     * grid layer (so the lines pass under the stones) holding the full
+     * horizontal and vertical lines through the last move. Rebuilt on every
+     * redraw and whenever the last move changes. */
+    private updateLastMoveCrosshair(): void {
+        if (!this.grid_layer) {
+            return;
+        }
+        if (!this.crosshair_layer) {
+            this.crosshair_layer = document.createElementNS("http://www.w3.org/2000/svg", "g");
+            this.crosshair_layer.setAttribute("class", "crosshair-layer");
+        }
+        // Keep it directly before the stone grid layer (under the stones).
+        this.svg.insertBefore(this.crosshair_layer, this.grid_layer);
+        this.crosshair_layer.innerHTML = "";
+
+        if (!this.engine || !this.engine.cur_move) {
+            return;
+        }
+        const cm = this.engine.cur_move;
+        const playing = this.engine.phase === "play" || this.engine.phase === "finished";
+        if (
+            this.dont_draw_last_move ||
+            this.dont_draw_last_move_crosshair ||
+            !playing ||
+            cm.x < 0 ||
+            cm.y < 0
+        ) {
+            return;
+        }
+        const ch = this.getLastMoveCrosshair();
+        if (!ch.enabled) {
+            return;
+        }
+
+        // Mirror the intersection geometry used by drawLines().
+        const ss = this.square_size;
+        let ox = this.draw_left_labels ? ss : 0;
+        let oy = this.draw_top_labels ? ss : 0;
+        if (this.bounds.left > 0) {
+            ox = -ss * this.bounds.left;
+        }
+        if (this.bounds.top > 0) {
+            oy = -ss * this.bounds.top;
+        }
+        ox += Math.round(ss / 2);
+        oy += Math.round(ss / 2);
+
+        const cx = ox + cm.x * ss;
+        const cy = oy + cm.y * ss;
+        const lw = Math.max(1, ss * ch.thickness);
+        const mk = (x1: number, y1: number, x2: number, y2: number) => {
+            const line = document.createElementNS("http://www.w3.org/2000/svg", "line");
+            line.setAttribute("x1", x1.toString());
+            line.setAttribute("y1", y1.toString());
+            line.setAttribute("x2", x2.toString());
+            line.setAttribute("y2", y2.toString());
+            line.setAttribute("stroke", ch.color);
+            line.setAttribute("stroke-width", lw.toString());
+            this.crosshair_layer!.appendChild(line);
+        };
+        // horizontal: spans all columns at the last move's row
+        mk(ox, cy, ox + (this.width - 1) * ss, cy);
+        // vertical: spans all rows at the last move's column
+        mk(cx, oy, cx, oy + (this.height - 1) * ss);
+    }
+
     private drawCoordinateLabels(force_clear?: boolean): void {
         if (force_clear) {
             if (this.coordinate_labels_layer) {
@@ -3986,6 +4058,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             }
             this.drawPenMarks(this.pen_marks);
         }
+        this.updateLastMoveCrosshair();
         this.move_tree_redraw();
     }
 

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -1979,11 +1979,17 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         /* Clear last move */
+        // Tracks whether the crosshair was already refreshed in this draw, so the
+        // "draw last move" block below doesn't redraw it again for the same cur_move.
+        let crosshair_synced = false;
         if (this.last_move && this.engine && !this.last_move.is(this.engine.cur_move)) {
             const m = this.last_move;
             delete this.last_move;
             this.cell(m.x, m.y).clearLastMove();
+            // Also clears the crosshair when navigating to a position with no
+            // last-move stone, which the "draw last move" block below cannot.
             this.updateLastMoveCrosshair();
+            crosshair_synced = true;
         }
 
         /* Draw last move */
@@ -1995,7 +2001,10 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 this.last_move = this.engine.cur_move;
-                this.updateLastMoveCrosshair();
+                // Sync on the first move (no prior last move above); skip if done.
+                if (!crosshair_synced) {
+                    this.updateLastMoveCrosshair();
+                }
 
                 if (i >= 0 && j >= 0) {
                     const color =
@@ -3003,11 +3012,17 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         /* Clear last move */
+        // Tracks whether the crosshair was already refreshed in this draw, so the
+        // "draw last move" block below doesn't redraw it again for the same cur_move.
+        let crosshair_synced = false;
         if (this.last_move && this.engine && !this.last_move.is(this.engine.cur_move)) {
             const m = this.last_move;
             delete this.last_move;
             this.drawSquare(m.x, m.y);
+            // Also clears the crosshair when navigating to a position with no
+            // last-move stone, which the "draw last move" block below cannot.
             this.updateLastMoveCrosshair();
+            crosshair_synced = true;
         }
 
         /* Draw last move */
@@ -3019,7 +3034,10 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 this.last_move = this.engine.cur_move;
-                this.updateLastMoveCrosshair();
+                // Sync on the first move (no prior last move above); skip if done.
+                if (!crosshair_synced) {
+                    this.updateLastMoveCrosshair();
+                }
 
                 if (i >= 0 && j >= 0) {
                     const color =

--- a/src/Goban/callbacks.ts
+++ b/src/Goban/callbacks.ts
@@ -28,6 +28,7 @@ export interface GobanCallbacks {
     // getShowMoveNumbers?: () => boolean;
     getShowVariationMoveNumbers?: () => boolean;
     getStoneFontScale?: () => number;
+    getLastMoveCrosshair?: () => { enabled: boolean; color: string; thickness: number };
     getFuzzyPlacementEnabled?: () => boolean;
     getShowUndoRequestIndicator?: () => boolean;
     getMoveTreeNumbering?: () => "move-coordinates" | "none" | "move-number";

--- a/src/GobanBase.ts
+++ b/src/GobanBase.ts
@@ -91,6 +91,10 @@ export interface GobanConfig extends GobanEngineConfig, PuzzleConfig {
     draw_right_labels?: boolean;
     bounds?: GobanBounds;
     dont_draw_last_move?: boolean;
+    /** Suppress only the last-move accessibility crosshair on this board, even
+     *  when the global crosshair setting is enabled (e.g. small preview/thumbnail
+     *  boards). Does not affect the regular last-move marker. */
+    dont_draw_last_move_crosshair?: boolean;
     dont_show_messages?: boolean;
     last_move_radius?: number;
     circle_radius?: number;

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/Goban/InteractiveBase";
 import { GobanSocket, makeMatrix } from "engine";
 import { GobanBase } from "../../src/GobanBase";
+import { callbacks } from "../../src/Goban/callbacks";
 import WS from "jest-websocket-mock";
 
 let board_div: HTMLDivElement;
@@ -463,5 +464,104 @@ describe("onTap", () => {
             [0, 0, 0],
             [0, 0, 0],
         ]);
+    });
+});
+
+describe("last-move crosshair callback", () => {
+    afterEach(() => {
+        delete (callbacks as any).getLastMoveCrosshair;
+    });
+
+    test("getLastMoveCrosshair falls back to disabled when no callback is set", () => {
+        const goban = new GobanCanvas(basic3x3Config());
+        expect((goban as any).getLastMoveCrosshair()).toEqual({
+            enabled: false,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        goban.destroy();
+    });
+
+    test("getLastMoveCrosshair returns the callback value", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#00ff00",
+            thickness: 0.2,
+        });
+        const goban = new GobanCanvas(basic3x3Config());
+        expect((goban as any).getLastMoveCrosshair()).toEqual({
+            enabled: true,
+            color: "#00ff00",
+            thickness: 0.2,
+        });
+        goban.destroy();
+    });
+});
+
+describe("last-move crosshair (canvas layer)", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+    });
+
+    afterEach(() => {
+        delete (callbacks as any).getLastMoveCrosshair;
+        board_div.remove();
+    });
+
+    test("attaches a dedicated crosshair canvas under the stones when enabled", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new GobanCanvas(basicScorableBoardConfig());
+        goban.redraw(true);
+        const layer = (goban as any).crosshair_layer as HTMLCanvasElement | undefined;
+        expect(layer).toBeDefined();
+        // It must sit before the stone canvas so it renders under the stones.
+        expect(layer?.className).toBe("CrosshairLayer");
+        const board = (goban as any).board as HTMLCanvasElement;
+        const children = Array.from(board.parentNode!.childNodes);
+        expect(children.indexOf(layer as any)).toBeLessThan(children.indexOf(board));
+        goban.destroy();
+    });
+
+    test("does not attach the crosshair canvas when disabled", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: false,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new GobanCanvas(basicScorableBoardConfig());
+        goban.redraw(true);
+        expect((goban as any).crosshair_layer).toBeUndefined();
+        goban.destroy();
+    });
+
+    test("does not attach the crosshair canvas when dont_draw_last_move is set", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new GobanCanvas(basicScorableBoardConfig({ dont_draw_last_move: true }));
+        goban.redraw(true);
+        expect((goban as any).crosshair_layer).toBeUndefined();
+        goban.destroy();
+    });
+
+    test("does not attach the crosshair canvas when dont_draw_last_move_crosshair is set", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new GobanCanvas(
+            basicScorableBoardConfig({ dont_draw_last_move_crosshair: true }),
+        );
+        goban.redraw(true);
+        expect((goban as any).crosshair_layer).toBeUndefined();
+        goban.destroy();
     });
 });

--- a/test/unit_tests/GobanSVG.test.ts
+++ b/test/unit_tests/GobanSVG.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/Goban/InteractiveBase";
 import { GobanSocket, makeMatrix } from "engine";
 import { GobanBase } from "../../src/GobanBase";
+import { callbacks } from "../../src/Goban/callbacks";
 import WS from "jest-websocket-mock";
 
 let board_div: HTMLDivElement;
@@ -36,7 +37,10 @@ interface MouseClickOptions {
     metaKey?: boolean;
 }
 
-function simulateMouseClick(div: HTMLElement, { x, y, shiftKey, ctrlKey, altKey, metaKey }: MouseClickOptions) {
+function simulateMouseClick(
+    div: HTMLElement,
+    { x, y, shiftKey, ctrlKey, altKey, metaKey }: MouseClickOptions,
+) {
     const eventInitDict = {
         // 1.5 assumes axis labels, which take up exactly one stone width
         clientX: (x + 1.5) * TEST_SQUARE_SIZE,
@@ -459,5 +463,71 @@ describe("onTap", () => {
             [0, 0, 0],
             [0, 0, 0],
         ]);
+    });
+});
+
+describe("last-move crosshair (SVG)", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+    });
+
+    afterEach(() => {
+        delete (callbacks as any).getLastMoveCrosshair;
+        board_div.remove();
+    });
+
+    test("draws two crosshair lines when enabled", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new SVGRenderer(basicScorableBoardConfig());
+        goban.redraw(true);
+        const layer = (goban as any).crosshair_layer as SVGGraphicsElement;
+        expect(layer.querySelectorAll("line").length).toBe(2);
+        goban.destroy();
+    });
+
+    test("draws no crosshair lines when disabled", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: false,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new SVGRenderer(basicScorableBoardConfig());
+        goban.redraw(true);
+        const layer = (goban as any).crosshair_layer as SVGGraphicsElement | undefined;
+        expect(layer?.querySelectorAll("line").length ?? 0).toBe(0);
+        goban.destroy();
+    });
+
+    test("draws no crosshair lines when dont_draw_last_move is set", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new SVGRenderer(basicScorableBoardConfig({ dont_draw_last_move: true }));
+        goban.redraw(true);
+        const layer = (goban as any).crosshair_layer as SVGGraphicsElement | undefined;
+        expect(layer?.querySelectorAll("line").length ?? 0).toBe(0);
+        goban.destroy();
+    });
+
+    test("draws no crosshair lines when dont_draw_last_move_crosshair is set", () => {
+        (callbacks as any).getLastMoveCrosshair = () => ({
+            enabled: true,
+            color: "#1e6bff",
+            thickness: 0.1,
+        });
+        const goban = new SVGRenderer(
+            basicScorableBoardConfig({ dont_draw_last_move_crosshair: true }),
+        );
+        goban.redraw(true);
+        const layer = (goban as any).crosshair_layer as SVGGraphicsElement | undefined;
+        expect(layer?.querySelectorAll("line").length ?? 0).toBe(0);
+        goban.destroy();
     });
 });


### PR DESCRIPTION
## Summary

Adds an opt-in, high-contrast **crosshair** (full horizontal + vertical lines) through the last played stone, drawn **under** the stones, to help low-vision players locate the last move. Disabled by default; driven by the consuming app.

This is the **goban half** of a two-repo change. The web client side (preference keys, `configure-goban` wiring, the Accessibility settings section + live preview, and suppression on thumbnails) lives in a companion `online-go.com` PR that bumps the submodule to this commit once merged.

## What's here

- **`getLastMoveCrosshair()` callback** (`{ enabled, color, thickness }`) — read at draw time, like the other appearance getters (no watcher).
- **Canvas** (`CanvasRenderer`): a dedicated under-stone canvas (inserted behind the transparent stone canvas, z-index between shadow and stone) draws each line as a **single stroke**, cleared and redrawn wholesale on each last-move change → continuous lines, no residual segments when navigating moves. Attached lazily (no cost unless enabled).
- **SVG** (`SVGRenderer`): a dedicated crosshair layer beneath the stone cells holding two `<line>`s, rebuilt on redraw / last-move change.
- Gated on the existing `dont_draw_last_move`, plus a new per-board **`dont_draw_last_move_crosshair`** flag so thumbnail/preview boards can opt out while keeping the normal last-move marker.
- Thickness is relative (fraction of square size) so it scales with board size.

## Tests

- Unit tests (Canvas + SVG): crosshair layer is present when enabled and a last move exists; absent when disabled, when `dont_draw_last_move` / `dont_draw_last_move_crosshair` is set, or when there's no last move.
- Full suite green; lint + prettier clean.

## Manual testing

Verified visually in the web client (both renderers): lines run the full board, pass under the stones, follow each move, and erase cleanly on navigation; color and thickness controls work.