### PR TITLE
Add layered custom board grid backgrounds

### DIFF
--- a/src/Goban.css
+++ b/src/Goban.css
@@ -47,6 +47,12 @@
         z-index: var(--z-goban-pen-layer);
     }
 
+    /*
+     * The host application defines the --z-goban-* values. The optional themed
+     * baked-grid image layer is intentionally above the vector grid and below
+     * shadows/stones: if the image loads it covers the vector grid; if it does
+     * not load, the vector grid remains visible as graceful degradation.
+     */
     .GridLayer {
         position: absolute;
         top: 0;

--- a/src/Goban.css
+++ b/src/Goban.css
@@ -16,7 +16,7 @@
 
 .Goban {
     position: relative;
-    background-color: #DCB35C;
+    background-color: #dcb35c;
     display: inline-block;
     box-shadow: var(--goban-shadow);
 
@@ -47,6 +47,24 @@
         z-index: var(--z-goban-pen-layer);
     }
 
+    .GridLayer {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: var(--z-goban-grid-layer);
+        pointer-events: none;
+    }
+
+    .GridBackgroundLayer {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: var(--z-goban-grid-background-layer);
+        pointer-events: none;
+    }
+
     .StoneLayer {
         position: absolute;
         left: 0;
@@ -75,10 +93,10 @@
     .GobanMessage table td div {
         border-radius: 3px;
         box-shadow: 5px 5px 3px rgba(0, 0, 0, 0.26);
-        color: #FF5500;
+        color: #ff5500;
         background-color: #262626;
-        padding: .3em;
-        margin: .4em;
+        padding: 0.3em;
+        margin: 0.4em;
     }
 
     .hidden {

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -112,9 +112,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private message_timeout?: number;
     private shadow_layer?: HTMLCanvasElement;
     private shadow_ctx?: CanvasRenderingContext2D;
-    private grid_layer: HTMLCanvasElement;
-    private grid_ctx: CanvasRenderingContext2D;
-    private grid_background_layer: HTMLDivElement;
+    private grid_layer?: HTMLCanvasElement;
+    private grid_ctx?: CanvasRenderingContext2D;
+    private grid_background_layer?: HTMLDivElement;
     private handleShiftKey: (ev: KeyboardEvent) => void;
 
     private last_move_opacity: number = 1;
@@ -168,19 +168,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         /* TODO: Need to reconcile the clock fields before we can get rid of this `any` cast */
         super(config, preloaded_data as any);
 
-        this.grid_layer = createDeviceScaledCanvas(10, 10);
-        this.grid_layer.setAttribute("id", "grid-canvas");
-        this.grid_layer.className = "GridLayer";
-        const grid_ctx = this.grid_layer.getContext("2d");
-        if (grid_ctx) {
-            this.grid_ctx = grid_ctx;
-        } else {
-            throw new Error(`Failed to obtain drawing context for board grid`);
-        }
-
-        this.grid_background_layer = document.createElement("div");
-        this.grid_background_layer.className = "GridBackgroundLayer";
-
         this.board = createDeviceScaledCanvas(10, 10);
         this.board.setAttribute("id", "board-canvas");
         this.board.className = "StoneLayer";
@@ -192,8 +179,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             throw new Error(`Failed to obtain drawing context for board`);
         }
 
-        this.parent.appendChild(this.grid_layer);
-        this.parent.appendChild(this.grid_background_layer);
         this.parent.appendChild(this.board);
         this.bindPointerBindings(this.board);
 
@@ -265,18 +250,10 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         if (this.board && this.board.parentNode) {
             this.board.parentNode.removeChild(this.board);
         }
-        if (this.grid_layer && this.grid_layer.parentNode) {
-            this.grid_layer.parentNode.removeChild(this.grid_layer);
-        }
-        if (this.grid_background_layer && this.grid_background_layer.parentNode) {
-            this.grid_background_layer.parentNode.removeChild(this.grid_background_layer);
-        }
         delete (this as any).board;
         delete (this as any).ctx;
-        delete (this as any).grid_layer;
-        delete (this as any).grid_ctx;
-        delete (this as any).grid_background_layer;
 
+        this.detachGridBackgroundLayers();
         this.detachPenCanvas();
         this.detachShadowLayer();
         this.detachCrosshairLayer();
@@ -310,6 +287,70 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             delete this.shadow_layer;
             delete this.shadow_ctx;
         }
+    }
+    private invalidateDrawState(): void {
+        this.__draw_state = makeMatrix(this.width, this.height, "");
+    }
+    private detachGridBackgroundLayers(): void {
+        const had_layers = !!this.grid_layer || !!this.grid_background_layer;
+        if (this.grid_layer) {
+            if (this.grid_layer.parentNode) {
+                this.grid_layer.parentNode.removeChild(this.grid_layer);
+            }
+            delete this.grid_layer;
+            delete this.grid_ctx;
+        }
+        if (this.grid_background_layer) {
+            if (this.grid_background_layer.parentNode) {
+                this.grid_background_layer.parentNode.removeChild(this.grid_background_layer);
+            }
+            delete this.grid_background_layer;
+        }
+        if (had_layers) {
+            this.invalidateDrawState();
+        }
+    }
+    private attachGridBackgroundLayers(): boolean {
+        const had_grid_layer = !!this.grid_layer;
+
+        if (!this.grid_layer) {
+            this.grid_layer = createDeviceScaledCanvas(this.metrics.width, this.metrics.height);
+            this.grid_layer.setAttribute("id", "grid-canvas");
+            this.grid_layer.className = "GridLayer";
+
+            const ctx = this.grid_layer.getContext("2d");
+            if (ctx) {
+                this.grid_ctx = ctx;
+            } else {
+                console.error(new Error(`Failed to obtain drawing context for board grid`));
+                this.detachGridBackgroundLayers();
+                return false;
+            }
+        }
+
+        if (!this.grid_background_layer) {
+            this.grid_background_layer = document.createElement("div");
+            this.grid_background_layer.className = "GridBackgroundLayer";
+        }
+
+        try {
+            this.parent.insertBefore(this.grid_layer, this.board);
+            this.parent.insertBefore(this.grid_background_layer, this.board);
+        } catch (e) {
+            console.warn("Error inserting grid background layers before board", e);
+            try {
+                this.parent.appendChild(this.grid_layer);
+                this.parent.appendChild(this.grid_background_layer);
+            } catch (e2) {
+                console.error(e2);
+            }
+        }
+
+        if (!had_grid_layer) {
+            this.invalidateDrawState();
+        }
+
+        return true;
     }
     private attachShadowLayer(): void {
         if (!this.shadow_layer && this.parent) {
@@ -1379,6 +1420,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
     }
     private drawGridSquare(
+        ctx: CanvasRenderingContext2D,
         i: number,
         j: number,
         l: number,
@@ -1387,8 +1429,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         b: number,
         have_text_to_draw: boolean,
     ): void {
-        const ctx = this.grid_ctx;
-
         ctx.clearRect(l, t, r - l, b - t);
 
         let sx = l;
@@ -1482,21 +1522,24 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private syncBoardBackground(background: ResolvedBoardBackground): void {
         this.applyBaseBoardBackground(background);
 
-        this.grid_background_layer.style.width = `${this.metrics.width}px`;
-        this.grid_background_layer.style.height = `${this.metrics.height}px`;
-
         const grid = background.grid;
-        if (grid) {
-            this.grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
-            this.grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
-            this.grid_background_layer.style.backgroundPosition =
-                grid.css["background-position"] || "";
-            this.grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
-        } else {
-            this.grid_background_layer.style.backgroundImage = "";
-            this.grid_background_layer.style.backgroundSize = "";
-            this.grid_background_layer.style.backgroundPosition = "";
-            this.grid_background_layer.style.backgroundRepeat = "";
+        if (!grid) {
+            this.detachGridBackgroundLayers();
+            return;
+        }
+
+        if (!this.attachGridBackgroundLayers()) {
+            return;
+        }
+
+        const grid_background_layer = this.grid_background_layer;
+        if (grid_background_layer) {
+            grid_background_layer.style.width = `${this.metrics.width}px`;
+            grid_background_layer.style.height = `${this.metrics.height}px`;
+            grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
+            grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
+            grid_background_layer.style.backgroundPosition = grid.css["background-position"] || "";
+            grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
         }
     }
     public drawSquare(i: number, j: number): void {
@@ -1632,7 +1675,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
             cx = l + this.metrics.mid;
             cy = t + this.metrics.mid;
-            this.drawGridSquare(i, j, l, r, t, b, have_text_to_draw);
+            this.drawGridSquare(this.grid_ctx ?? ctx, i, j, l, r, t, b, have_text_to_draw);
         }
 
         /* Heatmap */
@@ -2921,7 +2964,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 //this.parent.css({"width": metrics.width + "px", "height": metrics.height + "px"});
                 this.parent.style.width = metrics.width + "px";
                 this.parent.style.height = metrics.height + "px";
-                resizeDeviceScaledCanvas(this.grid_layer, metrics.width, metrics.height);
                 resizeDeviceScaledCanvas(this.board, metrics.width, metrics.height);
 
                 if (this.pen_layer) {
@@ -2964,14 +3006,18 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     }
                 }
 
+                if (this.grid_layer) {
+                    resizeDeviceScaledCanvas(this.grid_layer, metrics.width, metrics.height);
+                    const grid_ctx = this.grid_layer.getContext("2d");
+                    if (grid_ctx) {
+                        this.grid_ctx = grid_ctx;
+                    } else {
+                        this.detachGridBackgroundLayers();
+                    }
+                }
+
                 this.__set_board_width = metrics.width;
                 this.__set_board_height = metrics.height;
-                const grid_ctx = this.grid_layer.getContext("2d");
-                if (grid_ctx) {
-                    this.grid_ctx = grid_ctx;
-                } else {
-                    throw new Error(`Failed to obtain drawing context for board grid`);
-                }
                 const ctx = this.board.getContext("2d", { willReadFrequently: true });
                 if (ctx) {
                     this.ctx = ctx;
@@ -3144,8 +3190,11 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             ctx.restore();
         }
 
-        this.syncBoardBackgroundIfNeeded(this.theme_board, this.themes, (background) =>
-            this.syncBoardBackground(background),
+        this.syncBoardBackgroundIfNeeded(
+            this.theme_board,
+            this.themes,
+            (background) => this.syncBoardBackground(background),
+            !!force_clear,
         );
 
         /* Draw squares */
@@ -3402,7 +3451,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
-        if (dont_redraw) {
+        if (dont_redraw && this.ready_to_draw) {
             this.syncBoardBackgroundIfNeeded(this.theme_board, this.themes, (background) =>
                 this.syncBoardBackground(background),
             );

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -166,7 +166,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.grid_layer = createDeviceScaledCanvas(10, 10);
         this.grid_layer.setAttribute("id", "grid-canvas");
         this.grid_layer.className = "GridLayer";
-        const grid_ctx = this.grid_layer.getContext("2d", { willReadFrequently: true });
+        const grid_ctx = this.grid_layer.getContext("2d");
         if (grid_ctx) {
             this.grid_ctx = grid_ctx;
         } else {
@@ -2812,7 +2812,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
                 this.__set_board_width = metrics.width;
                 this.__set_board_height = metrics.height;
-                const grid_ctx = this.grid_layer.getContext("2d", { willReadFrequently: true });
+                const grid_ctx = this.grid_layer.getContext("2d");
                 if (grid_ctx) {
                     this.grid_ctx = grid_ctx;
                 } else {

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -47,6 +47,7 @@ import {
     GOBAN_FONT,
     CaptureDisplayConfig,
     CaptureDisplay,
+    ResolvedBoardBackground,
 } from "./Goban";
 
 const __theme_cache: {
@@ -111,6 +112,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private message_timeout?: number;
     private shadow_layer?: HTMLCanvasElement;
     private shadow_ctx?: CanvasRenderingContext2D;
+    private grid_layer: HTMLCanvasElement;
+    private grid_ctx: CanvasRenderingContext2D;
+    private grid_background_layer: HTMLDivElement;
     private handleShiftKey: (ev: KeyboardEvent) => void;
 
     private last_move_opacity: number = 1;
@@ -159,6 +163,19 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         /* TODO: Need to reconcile the clock fields before we can get rid of this `any` cast */
         super(config, preloaded_data as any);
 
+        this.grid_layer = createDeviceScaledCanvas(10, 10);
+        this.grid_layer.setAttribute("id", "grid-canvas");
+        this.grid_layer.className = "GridLayer";
+        const grid_ctx = this.grid_layer.getContext("2d", { willReadFrequently: true });
+        if (grid_ctx) {
+            this.grid_ctx = grid_ctx;
+        } else {
+            throw new Error(`Failed to obtain drawing context for board grid`);
+        }
+
+        this.grid_background_layer = document.createElement("div");
+        this.grid_background_layer.className = "GridBackgroundLayer";
+
         this.board = createDeviceScaledCanvas(10, 10);
         this.board.setAttribute("id", "board-canvas");
         this.board.className = "StoneLayer";
@@ -170,6 +187,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             throw new Error(`Failed to obtain drawing context for board`);
         }
 
+        this.parent.appendChild(this.grid_layer);
+        this.parent.appendChild(this.grid_background_layer);
         this.parent.appendChild(this.board);
         this.bindPointerBindings(this.board);
 
@@ -240,6 +259,12 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
         if (this.board && this.board.parentNode) {
             this.board.parentNode.removeChild(this.board);
+        }
+        if (this.grid_layer && this.grid_layer.parentNode) {
+            this.grid_layer.parentNode.removeChild(this.grid_layer);
+        }
+        if (this.grid_background_layer && this.grid_background_layer.parentNode) {
+            this.grid_background_layer.parentNode.removeChild(this.grid_background_layer);
         }
         delete (this as any).board;
         delete (this as any).ctx;
@@ -1230,6 +1255,127 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             }
         }
     }
+    private drawGridSquare(
+        i: number,
+        j: number,
+        l: number,
+        r: number,
+        t: number,
+        b: number,
+        have_text_to_draw: boolean,
+    ): void {
+        const ctx = this.grid_ctx;
+
+        ctx.clearRect(l, t, r - l, b - t);
+
+        let sx = l;
+        let ex = r;
+        const mx = (r + l) / 2 - this.metrics.offset;
+        let sy = t;
+        let ey = b;
+        const my = (t + b) / 2 - this.metrics.offset;
+
+        if (i === 0) {
+            sx += this.metrics.mid;
+        }
+        if (i === this.width - 1) {
+            ex -= this.metrics.mid;
+        }
+        if (j === 0) {
+            sy += this.metrics.mid;
+        }
+        if (j === this.height - 1) {
+            ey -= this.metrics.mid;
+        }
+
+        if (i === this.width - 1 && j === this.height - 1) {
+            if (mx === ex && my === ey) {
+                ex += 1;
+                ey += 1;
+            }
+        }
+
+        ctx.lineWidth = this.square_size < 5 ? 0.2 : 1;
+        ctx.strokeStyle = have_text_to_draw ? this.theme_faded_line_color : this.theme_line_color;
+        ctx.lineCap = "butt";
+        ctx.beginPath();
+        ctx.moveTo(Math.floor(sx), my);
+        ctx.lineTo(Math.floor(ex), my);
+        ctx.moveTo(mx, Math.floor(sy));
+        ctx.lineTo(mx, Math.floor(ey));
+        ctx.stroke();
+
+        let star_radius;
+        if (this.square_size < 5) {
+            star_radius = 0.5;
+        } else {
+            star_radius = Math.max(2, (this.metrics.mid - 1.5) * 0.16);
+        }
+        let draw_star_point = false;
+        if (
+            this.width === 19 &&
+            this.height === 19 &&
+            ((i === 3 && (j === 3 || j === 9 || j === 15)) ||
+                (i === 9 && (j === 3 || j === 9 || j === 15)) ||
+                (i === 15 && (j === 3 || j === 9 || j === 15)))
+        ) {
+            draw_star_point = true;
+        }
+
+        if (
+            this.width === 13 &&
+            this.height === 13 &&
+            ((i === 3 && (j === 3 || j === 9)) ||
+                (i === 6 && j === 6) ||
+                (i === 9 && (j === 3 || j === 9)))
+        ) {
+            draw_star_point = true;
+        }
+
+        if (
+            this.width === 9 &&
+            this.height === 9 &&
+            ((i === 2 && (j === 2 || j === 6)) ||
+                (i === 4 && j === 4) ||
+                (i === 6 && (j === 2 || j === 6)))
+        ) {
+            draw_star_point = true;
+        }
+
+        if (draw_star_point) {
+            ctx.beginPath();
+            ctx.fillStyle = have_text_to_draw ? this.theme_faded_star_color : this.theme_star_color;
+            ctx.arc(
+                (l + r) / 2,
+                (t + b) / 2,
+                star_radius,
+                0.001,
+                2 * Math.PI,
+                false,
+            ); /* 0.001 to workaround fucked up chrome 27 bug */
+            ctx.fill();
+        }
+    }
+    private syncBoardBackground(background: ResolvedBoardBackground): void {
+        this.applyBaseBoardBackground(background);
+
+        this.grid_background_layer.style.width = `${this.metrics.width}px`;
+        this.grid_background_layer.style.height = `${this.metrics.height}px`;
+
+        const grid = background.grid;
+        if (grid) {
+            this.grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
+            this.grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
+            this.grid_background_layer.style.backgroundPosition =
+                grid.css["background-position"] || "";
+            this.grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
+        } else {
+            this.grid_background_layer.style.backgroundImage = "";
+            this.grid_background_layer.style.backgroundSize = "";
+            this.grid_background_layer.style.backgroundPosition = "";
+            this.grid_background_layer.style.backgroundRepeat = "";
+        }
+    }
     public drawSquare(i: number, j: number): void {
         if (this.destroyed) {
             return;
@@ -1363,109 +1509,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
             cx = l + this.metrics.mid;
             cy = t + this.metrics.mid;
-
-            /* draw line */
-            let sx = l;
-            let ex = r;
-            const mx = (r + l) / 2 - this.metrics.offset;
-            let sy = t;
-            let ey = b;
-            const my = (t + b) / 2 - this.metrics.offset;
-
-            if (i === 0) {
-                sx += this.metrics.mid;
-            }
-            if (i === this.width - 1) {
-                ex -= this.metrics.mid;
-            }
-            if (j === 0) {
-                sy += this.metrics.mid;
-            }
-            if (j === this.height - 1) {
-                ey -= this.metrics.mid;
-            }
-
-            if (i === this.width - 1 && j === this.height - 1) {
-                if (mx === ex && my === ey) {
-                    ex += 1;
-                    ey += 1;
-                }
-            }
-
-            if (this.square_size < 5) {
-                ctx.lineWidth = 0.2;
-            } else {
-                ctx.lineWidth = 1;
-            }
-            if (have_text_to_draw) {
-                ctx.strokeStyle = this.theme_faded_line_color;
-            } else {
-                ctx.strokeStyle = this.theme_line_color;
-            }
-            ctx.lineCap = "butt";
-            ctx.beginPath();
-            ctx.moveTo(Math.floor(sx), my);
-            ctx.lineTo(Math.floor(ex), my);
-            ctx.moveTo(mx, Math.floor(sy));
-            ctx.lineTo(mx, Math.floor(ey));
-            ctx.stroke();
-        }
-
-        /* Draw star points */
-        {
-            let star_radius;
-            if (this.square_size < 5) {
-                star_radius = 0.5;
-            } else {
-                star_radius = Math.max(2, (this.metrics.mid - 1.5) * 0.16);
-            }
-            let draw_star_point = false;
-            if (
-                this.width === 19 &&
-                this.height === 19 &&
-                ((i === 3 && (j === 3 || j === 9 || j === 15)) ||
-                    (i === 9 && (j === 3 || j === 9 || j === 15)) ||
-                    (i === 15 && (j === 3 || j === 9 || j === 15)))
-            ) {
-                draw_star_point = true;
-            }
-
-            if (
-                this.width === 13 &&
-                this.height === 13 &&
-                ((i === 3 && (j === 3 || j === 9)) ||
-                    (i === 6 && j === 6) ||
-                    (i === 9 && (j === 3 || j === 9)))
-            ) {
-                draw_star_point = true;
-            }
-
-            if (
-                this.width === 9 &&
-                this.height === 9 &&
-                ((i === 2 && (j === 2 || j === 6)) ||
-                    (i === 4 && j === 4) ||
-                    (i === 6 && (j === 2 || j === 6)))
-            ) {
-                draw_star_point = true;
-            }
-
-            if (draw_star_point) {
-                ctx.beginPath();
-                ctx.fillStyle = this.theme_star_color;
-                if (have_text_to_draw) {
-                    ctx.fillStyle = this.theme_faded_star_color;
-                }
-                ctx.arc(
-                    cx,
-                    cy,
-                    star_radius,
-                    0.001,
-                    2 * Math.PI,
-                    false,
-                ); /* 0.001 to workaround fucked up chrome 27 bug */
-                ctx.fill();
-            }
+            this.drawGridSquare(i, j, l, r, t, b, have_text_to_draw);
         }
 
         /* Heatmap */
@@ -2739,6 +2783,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 //this.parent.css({"width": metrics.width + "px", "height": metrics.height + "px"});
                 this.parent.style.width = metrics.width + "px";
                 this.parent.style.height = metrics.height + "px";
+                resizeDeviceScaledCanvas(this.grid_layer, metrics.width, metrics.height);
                 resizeDeviceScaledCanvas(this.board, metrics.width, metrics.height);
 
                 if (this.pen_layer) {
@@ -2767,6 +2812,12 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
                 this.__set_board_width = metrics.width;
                 this.__set_board_height = metrics.height;
+                const grid_ctx = this.grid_layer.getContext("2d", { willReadFrequently: true });
+                if (grid_ctx) {
+                    this.grid_ctx = grid_ctx;
+                } else {
+                    throw new Error(`Failed to obtain drawing context for board grid`);
+                }
                 const ctx = this.board.getContext("2d", { willReadFrequently: true });
                 if (ctx) {
                     this.ctx = ctx;
@@ -2938,6 +2989,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
             ctx.restore();
         }
+
+        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
 
         /* Draw squares */
         if (
@@ -3191,13 +3244,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
-        //this.parent.css(this.theme_board.getBackgroundCSS());
-        const bg_css = this.theme_board.getBackgroundCSS();
-        if (this.parent) {
-            for (const key in bg_css) {
-                (this.parent.style as any)[key] = (bg_css as any)[key];
-            }
-        }
+        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
 
         if (!dont_redraw) {
             this.redraw(true);

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -310,7 +310,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             this.invalidateDrawState();
         }
     }
-    private ensureGridBackgroundLayers(): HTMLDivElement | undefined {
+    private attachGridBackgroundLayers(): void {
         const had_grid_layer = !!this.grid_layer;
 
         if (!this.grid_layer) {
@@ -324,7 +324,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             } else {
                 console.error(new Error(`Failed to obtain drawing context for board grid`));
                 this.detachGridBackgroundLayers();
-                return undefined;
+                return;
             }
         }
 
@@ -334,8 +334,13 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
 
         try {
-            this.parent.insertBefore(this.grid_layer, this.board);
-            this.parent.insertBefore(this.grid_background_layer, this.board);
+            // Keep the grid canvas directly before the grid background, both beneath the board.
+            if (this.grid_background_layer.nextSibling !== this.board) {
+                this.parent.insertBefore(this.grid_background_layer, this.board);
+            }
+            if (this.grid_layer.nextSibling !== this.grid_background_layer) {
+                this.parent.insertBefore(this.grid_layer, this.grid_background_layer);
+            }
         } catch (e) {
             console.warn("Error inserting grid background layers before board", e);
             try {
@@ -349,8 +354,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         if (!had_grid_layer) {
             this.invalidateDrawState();
         }
-
-        return this.grid_background_layer;
     }
     private attachShadowLayer(): void {
         if (!this.shadow_layer && this.parent) {
@@ -1526,17 +1529,17 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             return;
         }
 
-        const grid_background_layer = this.ensureGridBackgroundLayers();
-        if (!grid_background_layer) {
+        this.attachGridBackgroundLayers();
+        if (!this.grid_ctx || !this.grid_layer || !this.grid_background_layer) {
             return;
         }
 
-        grid_background_layer.style.width = `${this.metrics.width}px`;
-        grid_background_layer.style.height = `${this.metrics.height}px`;
-        grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
-        grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
-        grid_background_layer.style.backgroundPosition = grid.css["background-position"] || "";
-        grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
+        this.grid_background_layer.style.width = `${this.metrics.width}px`;
+        this.grid_background_layer.style.height = `${this.metrics.height}px`;
+        this.grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
+        this.grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
+        this.grid_background_layer.style.backgroundPosition = grid.css["background-position"] || "";
+        this.grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
     }
     public drawSquare(i: number, j: number): void {
         if (this.destroyed) {

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -310,7 +310,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             this.invalidateDrawState();
         }
     }
-    private attachGridBackgroundLayers(): boolean {
+    private ensureGridBackgroundLayers(): HTMLDivElement | undefined {
         const had_grid_layer = !!this.grid_layer;
 
         if (!this.grid_layer) {
@@ -324,7 +324,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             } else {
                 console.error(new Error(`Failed to obtain drawing context for board grid`));
                 this.detachGridBackgroundLayers();
-                return false;
+                return undefined;
             }
         }
 
@@ -350,7 +350,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             this.invalidateDrawState();
         }
 
-        return true;
+        return this.grid_background_layer;
     }
     private attachShadowLayer(): void {
         if (!this.shadow_layer && this.parent) {
@@ -1429,8 +1429,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         b: number,
         have_text_to_draw: boolean,
     ): void {
-        ctx.clearRect(l, t, r - l, b - t);
-
         let sx = l;
         let ex = r;
         const mx = (r + l) / 2 - this.metrics.offset;
@@ -1528,19 +1526,17 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             return;
         }
 
-        if (!this.attachGridBackgroundLayers()) {
+        const grid_background_layer = this.ensureGridBackgroundLayers();
+        if (!grid_background_layer) {
             return;
         }
 
-        const grid_background_layer = this.grid_background_layer;
-        if (grid_background_layer) {
-            grid_background_layer.style.width = `${this.metrics.width}px`;
-            grid_background_layer.style.height = `${this.metrics.height}px`;
-            grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
-            grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
-            grid_background_layer.style.backgroundPosition = grid.css["background-position"] || "";
-            grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
-        }
+        grid_background_layer.style.width = `${this.metrics.width}px`;
+        grid_background_layer.style.height = `${this.metrics.height}px`;
+        grid_background_layer.style.backgroundImage = grid.css["background-image"] || "";
+        grid_background_layer.style.backgroundSize = grid.css["background-size"] || "";
+        grid_background_layer.style.backgroundPosition = grid.css["background-position"] || "";
+        grid_background_layer.style.backgroundRepeat = grid.css["background-repeat"] || "";
     }
     public drawSquare(i: number, j: number): void {
         if (this.destroyed) {
@@ -1675,7 +1671,11 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
             cx = l + this.metrics.mid;
             cy = t + this.metrics.mid;
-            this.drawGridSquare(this.grid_ctx ?? ctx, i, j, l, r, t, b, have_text_to_draw);
+            const grid_ctx = this.grid_ctx;
+            if (grid_ctx) {
+                grid_ctx.clearRect(l, t, r - l, b - t);
+            }
+            this.drawGridSquare(grid_ctx ?? ctx, i, j, l, r, t, b, have_text_to_draw);
         }
 
         /* Heatmap */

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -1349,8 +1349,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             ctx.beginPath();
             ctx.fillStyle = have_text_to_draw ? this.theme_faded_star_color : this.theme_star_color;
             ctx.arc(
-                (l + r) / 2,
-                (t + b) / 2,
+                l + this.metrics.mid,
+                t + this.metrics.mid,
                 star_radius,
                 0.001,
                 2 * Math.PI,

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -268,6 +268,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
         delete (this as any).board;
         delete (this as any).ctx;
+        delete (this as any).grid_layer;
+        delete (this as any).grid_ctx;
+        delete (this as any).grid_background_layer;
 
         this.detachPenCanvas();
         this.detachShadowLayer();
@@ -3244,7 +3247,12 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
-        this.applyBaseBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
+        const background = this.resolveBoardBackground(this.theme_board, this.themes);
+        if (dont_redraw) {
+            this.syncBoardBackground(background);
+        } else {
+            this.applyBaseBoardBackground(background);
+        }
 
         if (!dont_redraw) {
             this.redraw(true);

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -2993,7 +2993,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             ctx.restore();
         }
 
-        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
+        this.syncBoardBackgroundIfNeeded(this.theme_board, this.themes, (background) =>
+            this.syncBoardBackground(background),
+        );
 
         /* Draw squares */
         if (
@@ -3094,6 +3096,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
 
         this.themes = themes;
+        this.invalidateBoardBackgroundSync();
         const BoardTheme = THEMES["board"]?.[themes.board] || THEMES["board"]["Plain"];
         const WhiteTheme = THEMES["white"]?.[themes.white] || THEMES["white"]["Plain"];
         const BlackTheme = THEMES["black"]?.[themes.black] || THEMES["black"]["Plain"];
@@ -3247,10 +3250,13 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
-        const background = this.resolveBoardBackground(this.theme_board, this.themes);
         if (dont_redraw) {
-            this.syncBoardBackground(background);
+            this.syncBoardBackgroundIfNeeded(this.theme_board, this.themes, (background) =>
+                this.syncBoardBackground(background),
+            );
         } else {
+            // Preserve the previous eager base-board update; redraw will sync grid layers if needed.
+            const background = this.resolveBoardBackground(this.theme_board, this.themes);
             this.applyBaseBoardBackground(background);
         }
 

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -312,44 +312,57 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     }
     private attachGridBackgroundLayers(): void {
         const had_grid_layer = !!this.grid_layer;
+        // Stage new layers in locals so drawSquare does not switch to grid_ctx
+        // until the canvas is actually attached and visible.
+        let grid_layer = this.grid_layer;
+        let grid_ctx = this.grid_ctx;
 
-        if (!this.grid_layer) {
-            this.grid_layer = createDeviceScaledCanvas(this.metrics.width, this.metrics.height);
-            this.grid_layer.setAttribute("id", "grid-canvas");
-            this.grid_layer.className = "GridLayer";
+        if (!grid_layer) {
+            grid_layer = createDeviceScaledCanvas(this.metrics.width, this.metrics.height);
+            grid_layer.setAttribute("id", "grid-canvas");
+            grid_layer.className = "GridLayer";
+            grid_ctx = grid_layer.getContext("2d") ?? undefined;
+        } else if (!grid_ctx) {
+            grid_ctx = grid_layer.getContext("2d") ?? undefined;
+        }
 
-            const ctx = this.grid_layer.getContext("2d");
-            if (ctx) {
-                this.grid_ctx = ctx;
-            } else {
-                console.error(new Error(`Failed to obtain drawing context for board grid`));
+        if (!grid_ctx) {
+            console.error(new Error(`Failed to obtain drawing context for board grid`));
+            this.detachGridBackgroundLayers();
+            return;
+        }
+
+        let grid_background_layer = this.grid_background_layer;
+        if (!grid_background_layer) {
+            grid_background_layer = document.createElement("div");
+            grid_background_layer.className = "GridBackgroundLayer";
+        }
+
+        try {
+            // Keep the grid canvas directly before the grid background, both beneath the board.
+            if (grid_background_layer.nextSibling !== this.board) {
+                this.parent.insertBefore(grid_background_layer, this.board);
+            }
+            if (grid_layer.nextSibling !== grid_background_layer) {
+                this.parent.insertBefore(grid_layer, grid_background_layer);
+            }
+        } catch (e) {
+            console.warn("Error inserting grid background layers before board", e);
+            try {
+                this.parent.appendChild(grid_layer);
+                this.parent.appendChild(grid_background_layer);
+            } catch (e2) {
+                console.error(e2);
+                grid_layer.remove();
+                grid_background_layer.remove();
                 this.detachGridBackgroundLayers();
                 return;
             }
         }
 
-        if (!this.grid_background_layer) {
-            this.grid_background_layer = document.createElement("div");
-            this.grid_background_layer.className = "GridBackgroundLayer";
-        }
-
-        try {
-            // Keep the grid canvas directly before the grid background, both beneath the board.
-            if (this.grid_background_layer.nextSibling !== this.board) {
-                this.parent.insertBefore(this.grid_background_layer, this.board);
-            }
-            if (this.grid_layer.nextSibling !== this.grid_background_layer) {
-                this.parent.insertBefore(this.grid_layer, this.grid_background_layer);
-            }
-        } catch (e) {
-            console.warn("Error inserting grid background layers before board", e);
-            try {
-                this.parent.appendChild(this.grid_layer);
-                this.parent.appendChild(this.grid_background_layer);
-            } catch (e2) {
-                console.error(e2);
-            }
-        }
+        this.grid_layer = grid_layer;
+        this.grid_ctx = grid_ctx;
+        this.grid_background_layer = grid_background_layer;
 
         if (!had_grid_layer) {
             this.invalidateDrawState();

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -3244,7 +3244,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
-        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
+        this.applyBaseBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
 
         if (!dont_redraw) {
             this.redraw(true);

--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -21,9 +21,62 @@ import { callbacks } from "./callbacks";
 import { makeMatrix, StoneStringBuilder } from "../engine";
 import { getRelativeEventPosition } from "./canvas_utils";
 import { THEMES, THEMES_SORTED } from "./themes";
+import type { GobanTheme, GobanThemeBackgroundCSS } from "./themes/GobanTheme";
 
 export const GOBAN_FONT = "Verdana,Arial,sans-serif";
 export type ShadowTheme = "none" | "low" | "mid" | "high" | "custom" | "default" | "anime";
+export type BoardGridBackgroundSize = "9" | "13" | "19";
+export type BoardGridBackgroundNumericSize = 9 | 13 | 19;
+export type CustomBoardGridBackgrounds = Record<BoardGridBackgroundSize, string>;
+
+export const emptyCustomBoardGridBackgrounds: CustomBoardGridBackgrounds = {
+    "9": "",
+    "13": "",
+    "19": "",
+};
+
+export type BoardBackgroundAsset =
+    | { kind: "default"; url: string; hasGrid: false }
+    | {
+          kind: "grid";
+          url: string;
+          hasGrid: true;
+          size: BoardGridBackgroundNumericSize;
+          marginProfile: "coordinate-space-all-sides";
+          bakedCoordinates: false;
+      };
+
+export interface ResolvedBoardBackground {
+    baseCSS: GobanThemeBackgroundCSS;
+    grid?: {
+        asset: Extract<BoardBackgroundAsset, { kind: "grid" }>;
+        css: GobanThemeBackgroundCSS;
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+        url: string;
+    };
+}
+
+function isBoardGridBackgroundSize(size: number): size is BoardGridBackgroundNumericSize {
+    return size === 9 || size === 13 || size === 19;
+}
+
+function boardGridBackgroundKey(size: BoardGridBackgroundNumericSize): BoardGridBackgroundSize {
+    switch (size) {
+        case 9:
+            return "9";
+        case 13:
+            return "13";
+        case 19:
+            return "19";
+    }
+}
+
+function cssUrl(url: string): string {
+    return `url("${url.replace(/["\\]/g, "\\$&")}")`;
+}
 
 export interface CustomShadowConfig {
     black?: {
@@ -44,6 +97,14 @@ export interface GobanSelectedThemes {
     "removal-scale": number;
     "stone-shadows"?: ShadowTheme;
     "custom-shadow-config"?: CustomShadowConfig;
+    /*
+     * V1 stores only one baked-grid background URL per supported board size, and those
+     * assets use the same margin geometry as a board with coordinate labels on all sides.
+     * Keep the renderer-facing asset descriptor more explicit than this compact preference
+     * so future small-margin assets, baked labels, label origins, and coordinate systems can
+     * be added without reinterpreting saved URLs.
+     */
+    "custom-board-grid-backgrounds"?: CustomBoardGridBackgrounds;
 }
 export type LabelPosition =
     | "all"
@@ -311,6 +372,99 @@ export abstract class Goban extends OGSConnectivity {
         });
         this.setSquareSize(square_size, suppress_redraw);
         this.evaluation_bar_width = Goban.computeEvaluationBarWidth(this.display_width);
+    }
+
+    protected resolveBoardBackground(
+        theme_board: Pick<GobanTheme, "getBackgroundCSS">,
+        themes: GobanSelectedThemes,
+    ): ResolvedBoardBackground {
+        const default_css = theme_board.getBackgroundCSS();
+        const default_background: ResolvedBoardBackground = {
+            baseCSS: {
+                ...default_css,
+                "background-position": "",
+                "background-repeat": "",
+            },
+        };
+
+        if (themes.board !== "Custom" || this.width !== this.height) {
+            return default_background;
+        }
+
+        const board_size = this.width;
+        if (!isBoardGridBackgroundSize(board_size)) {
+            return default_background;
+        }
+
+        if (!Number.isFinite(this.square_size) || this.square_size <= 0) {
+            return default_background;
+        }
+
+        const url =
+            themes["custom-board-grid-backgrounds"]?.[boardGridBackgroundKey(board_size)].trim() ||
+            "";
+
+        if (!url) {
+            return default_background;
+        }
+
+        /*
+         * The first baked-grid asset profile is intentionally explicit:
+         * - marginProfile describes geometry, not whether coordinates are in the image.
+         * - bakedCoordinates stays false for v1 because OGS still draws labels as overlays.
+         * Future profiles can add small margins or baked coordinate labels without changing
+         * the meaning of existing saved preferences.
+         *
+         * The baked-grid image is rendered as a layer above the vector grid, not as a
+         * replacement for it. This is deliberate graceful degradation: if an external
+         * baked-grid URL is slow or broken, the browser simply leaves that layer blank and
+         * the default board background plus vector grid below remain usable. The default
+         * board image itself still falls back to the board color if its URL fails.
+         */
+        const asset: Extract<BoardBackgroundAsset, { kind: "grid" }> = {
+            kind: "grid",
+            url,
+            hasGrid: true,
+            size: board_size,
+            marginProfile: "coordinate-space-all-sides",
+            bakedCoordinates: false,
+        };
+        const virtual_width = (this.width + 2) * this.square_size;
+        const virtual_height = (this.height + 2) * this.square_size;
+        const visible_left =
+            this.bounds.left + (this.draw_left_labels && this.bounds.left === 0 ? 0 : 1);
+        const visible_top =
+            this.bounds.top + (this.draw_top_labels && this.bounds.top === 0 ? 0 : 1);
+
+        return {
+            baseCSS: default_background.baseCSS,
+            grid: {
+                asset,
+                url,
+                x: -visible_left * this.square_size,
+                y: -visible_top * this.square_size,
+                width: virtual_width,
+                height: virtual_height,
+                css: {
+                    "background-image": cssUrl(url),
+                    "background-size": `${virtual_width}px ${virtual_height}px`,
+                    "background-position": `${-visible_left * this.square_size}px ${
+                        -visible_top * this.square_size
+                    }px`,
+                    "background-repeat": "no-repeat",
+                },
+            },
+        };
+    }
+
+    protected applyBaseBoardBackground(background: ResolvedBoardBackground): void {
+        const css = background.baseCSS;
+
+        this.parent.style.backgroundColor = css["background-color"] || "";
+        this.parent.style.backgroundImage = css["background-image"] || "";
+        this.parent.style.backgroundSize = css["background-size"] || "";
+        this.parent.style.backgroundPosition = css["background-position"] || "";
+        this.parent.style.backgroundRepeat = css["background-repeat"] || "";
     }
 
     set evaluation_bar_width(width: number) {

--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -74,10 +74,6 @@ function boardGridBackgroundKey(size: BoardGridBackgroundNumericSize): BoardGrid
     }
 }
 
-function cssUrl(url: string): string {
-    return `url("${url.replace(/["\\]/g, "\\$&")}")`;
-}
-
 export interface CustomShadowConfig {
     black?: {
         gradientTransform?: string;
@@ -446,7 +442,7 @@ export abstract class Goban extends OGSConnectivity {
                 width: virtual_width,
                 height: virtual_height,
                 css: {
-                    "background-image": cssUrl(url),
+                    "background-image": "url('" + url + "')",
                     "background-size": `${virtual_width}px ${virtual_height}px`,
                     "background-position": `${-visible_left * this.square_size}px ${
                         -visible_top * this.square_size

--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -152,6 +152,7 @@ export abstract class Goban extends OGSConnectivity {
     private analysis_scoring_last_position: { i: number; j: number } = { i: NaN, j: NaN };
     private _evaluation: number = 0.5;
     private _evaluation_bar_width: number = 8;
+    private board_background_sync_key?: string;
 
     private prng(seed: number, irrational: number): number {
         return (((seed + irrational) % 1) - 0.5) * 2;
@@ -451,6 +452,53 @@ export abstract class Goban extends OGSConnectivity {
                 },
             },
         };
+    }
+
+    /*
+     * Baked-grid backgrounds are synced from redraw, not only from theme changes,
+     * because their geometry follows square size, cropped bounds, and coordinate
+     * label margins. Keep that redraw call cheap: theme changes explicitly
+     * invalidate this key, and geometry changes produce a different key.
+     */
+    protected syncBoardBackgroundIfNeeded(
+        theme_board: Pick<GobanTheme, "getBackgroundCSS">,
+        themes: GobanSelectedThemes,
+        sync: (background: ResolvedBoardBackground) => void,
+        force: boolean = false,
+    ): void {
+        const sync_key = this.getBoardBackgroundSyncKey(themes);
+        if (!force && this.board_background_sync_key === sync_key) {
+            return;
+        }
+
+        sync(this.resolveBoardBackground(theme_board, themes));
+        this.board_background_sync_key = sync_key;
+    }
+
+    protected invalidateBoardBackgroundSync(): void {
+        this.board_background_sync_key = undefined;
+    }
+
+    private getBoardBackgroundSyncKey(themes: GobanSelectedThemes): string {
+        const grid_backgrounds = themes["custom-board-grid-backgrounds"];
+
+        return JSON.stringify([
+            themes.board,
+            grid_backgrounds?.["9"] || "",
+            grid_backgrounds?.["13"] || "",
+            grid_backgrounds?.["19"] || "",
+            this.width,
+            this.height,
+            this.square_size,
+            this.bounds.left,
+            this.bounds.top,
+            this.bounds.right,
+            this.bounds.bottom,
+            this.draw_left_labels,
+            this.draw_right_labels,
+            this.draw_top_labels,
+            this.draw_bottom_labels,
+        ]);
     }
 
     protected applyBaseBoardBackground(background: ResolvedBoardBackground): void {

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -43,6 +43,7 @@ import {
     ShadowTheme,
     CaptureDisplayConfig,
     CaptureDisplay,
+    ResolvedBoardBackground,
 } from "./Goban";
 import { ColoredCircle } from "./InteractiveBase";
 
@@ -136,6 +137,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     private handleShiftKey: (ev: KeyboardEvent) => void;
 
     private lines_layer?: SVGGraphicsElement;
+    private grid_background_layer?: SVGImageElement;
     private coordinate_labels_layer?: SVGGraphicsElement;
     private grid: Array<Array<SVGGraphicsElement>> = [];
     public grid_layer?: SVGGraphicsElement;
@@ -161,6 +163,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     private drawing_enabled: boolean = true;
     public event_layer?: HTMLDivElement;
     private activeTouchCompleter?: () => void;
+    private board_grid_background_configured: boolean = false;
 
     public themes: GobanSelectedThemes = {
         "board": "Plain",
@@ -1430,7 +1433,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         /* Fade our lines if we have text to draw */
-        if (have_text_to_draw) {
+        if (have_text_to_draw && !this.board_grid_background_configured) {
             let star_radius;
             if (this.square_size < 5) {
                 star_radius = 0.5;
@@ -2152,7 +2155,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         /* Fade our lines if we have text to draw */
-        if (have_text_to_draw) {
+        if (have_text_to_draw && !this.board_grid_background_configured) {
             /* draw lighter colored lines */
             let sx = 0;
             let ex = ss;
@@ -3704,6 +3707,42 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
     }
 
+    private syncBoardBackground(background: ResolvedBoardBackground): void {
+        this.applyBaseBoardBackground(background);
+
+        const grid = background.grid;
+        this.board_grid_background_configured = !!grid;
+        if (!grid) {
+            this.grid_background_layer?.remove();
+            this.grid_background_layer = undefined;
+            return;
+        }
+
+        if (!this.grid_background_layer) {
+            this.grid_background_layer = document.createElementNS(
+                "http://www.w3.org/2000/svg",
+                "image",
+            );
+            this.grid_background_layer.setAttribute("class", "grid-background");
+            this.grid_background_layer.setAttribute("pointer-events", "none");
+        }
+
+        this.grid_background_layer.setAttribute("x", grid.x.toString());
+        this.grid_background_layer.setAttribute("y", grid.y.toString());
+        this.grid_background_layer.setAttribute("width", grid.width.toString());
+        this.grid_background_layer.setAttribute("height", grid.height.toString());
+        this.grid_background_layer.setAttribute("preserveAspectRatio", "none");
+        this.grid_background_layer.setAttribute("href", grid.url);
+        this.grid_background_layer.setAttributeNS("http://www.w3.org/1999/xlink", "href", grid.url);
+
+        const reference = this.coordinate_labels_layer ?? this.lines_layer?.nextSibling ?? null;
+        if (this.grid_background_layer.parentNode !== this.svg) {
+            this.svg.insertBefore(this.grid_background_layer, reference);
+        } else if (reference !== this.grid_background_layer) {
+            this.svg.insertBefore(this.grid_background_layer, reference);
+        }
+    }
+
     private drawCoordinateLabels(force_clear?: boolean): void {
         if (force_clear) {
             if (this.coordinate_labels_layer) {
@@ -3926,7 +3965,13 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             }
         }
 
+        if (force_clear && this.coordinate_labels_layer) {
+            this.coordinate_labels_layer.remove();
+            delete this.coordinate_labels_layer;
+        }
+
         this.drawLines(force_clear);
+        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
         this.drawCoordinateLabels(force_clear);
 
         if (force_clear || !this.grid_layer || !this.shadow_layer) {
@@ -4174,12 +4219,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
         this.theme_shadow_color = this.theme_board.getShadowColor();
-        const bg_css = this.theme_board.getBackgroundCSS();
-        if (this.parent) {
-            for (const key in bg_css) {
-                (this.parent.style as any)[key] = (bg_css as any)[key];
-            }
-        }
+        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
 
         if (!dont_redraw) {
             this.redraw(true);

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -3976,7 +3976,13 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         this.drawLines(force_clear);
-        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
+        this.syncBoardBackgroundIfNeeded(
+            this.theme_board,
+            this.themes,
+            (background) => this.syncBoardBackground(background),
+            // force_clear rebuilds SVG layers, so re-check placement even if geometry is unchanged.
+            !!force_clear,
+        );
         this.drawCoordinateLabels(force_clear);
 
         if (force_clear || !this.grid_layer || !this.shadow_layer) {
@@ -4165,6 +4171,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         this.themes = themes;
+        this.invalidateBoardBackgroundSync();
         const BoardTheme = THEMES["board"]?.[themes.board] || THEMES["board"]["Plain"];
         const WhiteTheme = THEMES["white"]?.[themes.white] || THEMES["white"]["Plain"];
         const BlackTheme = THEMES["black"]?.[themes.black] || THEMES["black"]["Plain"];
@@ -4224,10 +4231,13 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
         this.theme_shadow_color = this.theme_board.getShadowColor();
-        const background = this.resolveBoardBackground(this.theme_board, this.themes);
         if (dont_redraw) {
-            this.syncBoardBackground(background);
+            this.syncBoardBackgroundIfNeeded(this.theme_board, this.themes, (background) =>
+                this.syncBoardBackground(background),
+            );
         } else {
+            // Preserve the previous eager base-board update; redraw will sync grid layers if needed.
+            const background = this.resolveBoardBackground(this.theme_board, this.themes);
             this.applyBaseBoardBackground(background);
         }
 

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -3734,7 +3734,16 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.grid_background_layer.setAttributeNS("http://www.w3.org/1999/xlink", "href", grid.url);
 
         const reference = this.coordinate_labels_layer ?? this.lines_layer?.nextSibling ?? null;
-        if (reference !== this.grid_background_layer) {
+        /*
+         * insertBefore handles both first insertion and moving an existing node, but
+         * nextSibling is also null for detached nodes. Keep the parent check so the
+         * first insert still happens, and the nextSibling check so redraws do not
+         * move an already-correct layer before coordinate labels on every sync.
+         */
+        if (
+            this.grid_background_layer.parentNode !== this.svg ||
+            this.grid_background_layer.nextSibling !== reference
+        ) {
             this.svg.insertBefore(this.grid_background_layer, reference);
         }
     }

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -4217,7 +4217,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
         this.theme_shadow_color = this.theme_board.getShadowColor();
-        this.syncBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
+        this.applyBaseBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
 
         if (!dont_redraw) {
             this.redraw(true);

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -326,6 +326,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         // detached subtree can be GC'd (mirrors the Canvas detachCrosshairLayer).
         delete this.crosshair_layer;
         delete this.grid_layer;
+        delete this.grid_background_layer;
 
         this.detachPenLayer();
 

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -163,7 +163,6 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     private drawing_enabled: boolean = true;
     public event_layer?: HTMLDivElement;
     private activeTouchCompleter?: () => void;
-    private board_grid_background_configured: boolean = false;
 
     public themes: GobanSelectedThemes = {
         "board": "Plain",
@@ -1433,7 +1432,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         /* Fade our lines if we have text to draw */
-        if (have_text_to_draw && !this.board_grid_background_configured) {
+        if (have_text_to_draw) {
             let star_radius;
             if (this.square_size < 5) {
                 star_radius = 0.5;
@@ -2155,7 +2154,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         /* Fade our lines if we have text to draw */
-        if (have_text_to_draw && !this.board_grid_background_configured) {
+        if (have_text_to_draw) {
             /* draw lighter colored lines */
             let sx = 0;
             let ex = ss;
@@ -3711,7 +3710,6 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.applyBaseBoardBackground(background);
 
         const grid = background.grid;
-        this.board_grid_background_configured = !!grid;
         if (!grid) {
             this.grid_background_layer?.remove();
             this.grid_background_layer = undefined;
@@ -4217,7 +4215,12 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
         this.theme_shadow_color = this.theme_board.getShadowColor();
-        this.applyBaseBoardBackground(this.resolveBoardBackground(this.theme_board, this.themes));
+        const background = this.resolveBoardBackground(this.theme_board, this.themes);
+        if (dont_redraw) {
+            this.syncBoardBackground(background);
+        } else {
+            this.applyBaseBoardBackground(background);
+        }
 
         if (!dont_redraw) {
             this.redraw(true);

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -3736,9 +3736,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.grid_background_layer.setAttributeNS("http://www.w3.org/1999/xlink", "href", grid.url);
 
         const reference = this.coordinate_labels_layer ?? this.lines_layer?.nextSibling ?? null;
-        if (this.grid_background_layer.parentNode !== this.svg) {
-            this.svg.insertBefore(this.grid_background_layer, reference);
-        } else if (reference !== this.grid_background_layer) {
+        if (reference !== this.grid_background_layer) {
             this.svg.insertBefore(this.grid_background_layer, reference);
         }
     }

--- a/src/Goban/themes/GobanTheme.ts
+++ b/src/Goban/themes/GobanTheme.ts
@@ -24,6 +24,8 @@ export interface GobanThemeBackgroundCSS {
     "background-color"?: string;
     "background-image"?: string;
     "background-size"?: string;
+    "background-position"?: string;
+    "background-repeat"?: string;
 }
 
 export interface GobanThemeBackgroundReactStyles {

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -38,7 +38,14 @@ function makeSvgImageData(svg: string): string {
     return "data:image/svg+xml," + svg.replace(/#/g, "%23");
 }
 
-type StoneType = { stone: HTMLCanvasElement; shadow: HTMLCanvasElement };
+/* Canvas-backed custom URL stones can be pending or fail due to CORS/broken URLs.
+ * Track image readiness so board and move-tree drawing can use a plain-stone fallback
+ * instead of painting a blank pre-rendered canvas. */
+type StoneType = {
+    stone: HTMLCanvasElement;
+    shadow: HTMLCanvasElement;
+    image_loaded: boolean;
+};
 type StoneTypeArray = Array<StoneType>;
 
 function square_size(radius: number, scaled: boolean): number {
@@ -67,7 +74,7 @@ export function preRenderImageStone(
     }
 
     const ret: StoneTypeArray = [];
-    const promises: Promise<any>[] = [];
+    const promises: Promise<void>[] = [];
 
     for (const url of urls) {
         const stone_image = new Image(ss, ss);
@@ -76,16 +83,40 @@ export function preRenderImageStone(
         stone_image.width = ss;
         stone_image.height = ss;
 
-        stone_image.src = url;
-
         const stone = allocateCanvasOrError(`${ss}px`, `${ss}px`);
         const shadow = allocateCanvasOrError(`${sss}px`, `${sss}px`);
+        const rendered_stone: StoneType = {
+            stone,
+            shadow,
+            image_loaded: false,
+        };
 
-        const stone_load_promise = new Promise((resolve, reject) => {
-            stone_image.onerror = reject;
-            stone_image.onload = resolve;
+        const stone_load_promise = new Promise<void>((resolve) => {
+            stone_image.onerror = (err) => {
+                console.error(err);
+                resolve();
+            };
+            stone_image.onload = () => {
+                const stone_ctx = stone.getContext("2d", { willReadFrequently: true });
+
+                if (!stone_ctx) {
+                    console.error(new Error("Error getting stone context 2d"));
+                    resolve();
+                    return;
+                }
+
+                try {
+                    stone_ctx.drawImage(stone_image, 0, 0, ss, ss);
+                    rendered_stone.image_loaded = true;
+                } catch (err) {
+                    console.error(err);
+                }
+
+                resolve();
+            };
         });
         promises.push(stone_load_promise);
+        stone_image.src = url;
 
         const shadow_ctx = shadow.getContext("2d", { willReadFrequently: true });
         if (!shadow_ctx) {
@@ -95,20 +126,7 @@ export function preRenderImageStone(
             renderShadow(shadow_ctx, center, radius * 1.05, sss, 0.0, "rgba(60,60,40,0.4)");
         }
 
-        stone_load_promise
-            .then(() => {
-                const stone_ctx = stone.getContext("2d", { willReadFrequently: true });
-
-                if (!stone_ctx) {
-                    throw new Error("Error getting stone context 2d");
-                }
-
-                stone_ctx.drawImage(stone_image, 0, 0, ss, ss);
-                //deferredRenderCallback();
-            })
-            .catch((err) => console.error(err));
-
-        ret.push({ stone, shadow });
+        ret.push(rendered_stone);
     }
 
     Promise.all(promises)
@@ -116,6 +134,10 @@ export function preRenderImageStone(
         .catch((err) => console.error(err));
 
     return ret;
+}
+
+function imageStoneIsReady(stone: StoneType): boolean {
+    return stone.image_loaded;
 }
 
 export function placeRenderedImageStone(
@@ -302,7 +324,11 @@ export default function (THEMES: ThemesInterface) {
             cy: number,
             radius: number,
         ): void {
-            if (callbacks.customBlackStoneUrl && callbacks.customBlackStoneUrl() !== "") {
+            if (
+                callbacks.customBlackStoneUrl &&
+                callbacks.customBlackStoneUrl() !== "" &&
+                imageStoneIsReady(stone)
+            ) {
                 placeRenderedImageStone(ctx, shadow_ctx, stone, cx, cy, radius);
             } else {
                 renderPlainStone(
@@ -349,7 +375,11 @@ export default function (THEMES: ThemesInterface) {
             cy: number,
             radius: number,
         ): void {
-            if (callbacks.customWhiteStoneUrl && callbacks.customWhiteStoneUrl() !== "") {
+            if (
+                callbacks.customWhiteStoneUrl &&
+                callbacks.customWhiteStoneUrl() !== "" &&
+                imageStoneIsReady(stone)
+            ) {
                 placeRenderedImageStone(ctx, shadow_ctx, stone, cx, cy, radius);
             } else {
                 renderPlainStone(

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -603,6 +603,17 @@ describe("custom board grid background (canvas layers)", () => {
         goban.destroy();
     });
 
+    test("does not attach optional grid background layers for custom themes without a grid URL", () => {
+        callbacks.getSelectedThemes = () => selectedThemes("Custom");
+        const goban = new GobanCanvas(basic3x3Config({ width: 9, height: 9 }));
+
+        expect(board_div.querySelector("#grid-canvas")).toBeNull();
+        expect(board_div.querySelector(".GridBackgroundLayer")).toBeNull();
+        expect(board_div.querySelector("#board-canvas")).not.toBeNull();
+
+        goban.destroy();
+    });
+
     test("attaches optional grid background layers for a configured custom grid background", () => {
         callbacks.getSelectedThemes = () =>
             selectedThemes("Custom", "https://cdn.example.test/grid-9.png");

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -655,4 +655,37 @@ describe("custom board grid background (canvas layers)", () => {
 
         goban.destroy();
     });
+
+    test("does not keep grid context when optional grid layer insertion fails", () => {
+        callbacks.getSelectedThemes = () => selectedThemes("Kaya");
+        const goban = new GobanCanvas(basic3x3Config({ width: 9, height: 9 }));
+        const internals = goban as unknown as {
+            grid_ctx?: CanvasRenderingContext2D;
+            grid_layer?: HTMLCanvasElement;
+            grid_background_layer?: HTMLDivElement;
+        };
+
+        const insert_before = jest.spyOn(board_div, "insertBefore").mockImplementation(() => {
+            throw new Error("insert failed");
+        });
+        const append_child = jest.spyOn(board_div, "appendChild").mockImplementation(() => {
+            throw new Error("append failed");
+        });
+        const console_warn = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+        const console_error = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+        goban.setTheme(selectedThemes("Custom", "https://cdn.example.test/grid-9.png"), false);
+
+        expect(internals.grid_ctx).toBeUndefined();
+        expect(internals.grid_layer).toBeUndefined();
+        expect(internals.grid_background_layer).toBeUndefined();
+        expect(board_div.querySelector("#grid-canvas")).toBeNull();
+        expect(board_div.querySelector(".GridBackgroundLayer")).toBeNull();
+
+        insert_before.mockRestore();
+        append_child.mockRestore();
+        console_warn.mockRestore();
+        console_error.mockRestore();
+        goban.destroy();
+    });
 });

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -7,6 +7,7 @@
 (global as any).CLIENT = true;
 
 import { GobanCanvas, CanvasRendererGobanConfig } from "../../src/Goban/CanvasRenderer";
+import type { GobanSelectedThemes } from "../../src/Goban/Goban";
 import {
     SCORE_ESTIMATION_TOLERANCE,
     SCORE_ESTIMATION_TRIALS,
@@ -91,6 +92,22 @@ function basicScorableBoardConfig(
             [2, 1],
         ],
         ...(additionalOptions ?? {}),
+    };
+}
+
+function selectedThemes(board: "Custom" | "Kaya", grid9Url: string = ""): GobanSelectedThemes {
+    return {
+        "white": "Shell",
+        "black": "Slate",
+        "board": board,
+        "removal-graphic": "square",
+        "removal-scale": 1.0,
+        "stone-shadows": "none",
+        "custom-board-grid-backgrounds": {
+            "9": grid9Url,
+            "13": "",
+            "19": "",
+        },
     };
 }
 
@@ -560,6 +577,71 @@ describe("last-move crosshair (canvas layer)", () => {
         );
         goban.redraw(true);
         expect((goban as any).crosshair_layer).toBeUndefined();
+        goban.destroy();
+    });
+});
+
+describe("custom board grid background (canvas layers)", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+    });
+
+    afterEach(() => {
+        delete callbacks.getSelectedThemes;
+        board_div.remove();
+    });
+
+    test("does not attach optional grid background layers for default themes", () => {
+        callbacks.getSelectedThemes = () => selectedThemes("Kaya");
+        const goban = new GobanCanvas(basic3x3Config());
+
+        expect(board_div.querySelector("#grid-canvas")).toBeNull();
+        expect(board_div.querySelector(".GridBackgroundLayer")).toBeNull();
+        expect(board_div.querySelector("#board-canvas")).not.toBeNull();
+
+        goban.destroy();
+    });
+
+    test("attaches optional grid background layers for a configured custom grid background", () => {
+        callbacks.getSelectedThemes = () =>
+            selectedThemes("Custom", "https://cdn.example.test/grid-9.png");
+        const goban = new GobanCanvas(basic3x3Config({ width: 9, height: 9 }));
+
+        const grid_layer = board_div.querySelector<HTMLCanvasElement>("#grid-canvas");
+        const grid_background_layer =
+            board_div.querySelector<HTMLDivElement>(".GridBackgroundLayer");
+        const board = board_div.querySelector<HTMLCanvasElement>("#board-canvas");
+
+        if (!grid_layer || !grid_background_layer || !board) {
+            throw new Error("Expected grid background layers and board canvas to exist");
+        }
+
+        const children = Array.from(board.parentNode?.childNodes ?? []);
+        expect(grid_layer.className).toBe("GridLayer");
+        expect(grid_background_layer.className).toBe("GridBackgroundLayer");
+        expect(children.indexOf(grid_layer)).toBeLessThan(children.indexOf(grid_background_layer));
+        expect(children.indexOf(grid_background_layer)).toBeLessThan(children.indexOf(board));
+        expect(grid_background_layer.style.backgroundImage).toContain("grid-9.png");
+
+        goban.destroy();
+    });
+
+    test("detaches optional grid background layers when switching away from custom grid backgrounds", () => {
+        let themes = selectedThemes("Custom", "https://cdn.example.test/grid-9.png");
+        callbacks.getSelectedThemes = () => themes;
+        const goban = new GobanCanvas(basic3x3Config({ width: 9, height: 9 }));
+
+        expect(board_div.querySelector("#grid-canvas")).not.toBeNull();
+        expect(board_div.querySelector(".GridBackgroundLayer")).not.toBeNull();
+
+        themes = selectedThemes("Kaya");
+        goban.setTheme(themes, false);
+
+        expect(board_div.querySelector("#grid-canvas")).toBeNull();
+        expect(board_div.querySelector(".GridBackgroundLayer")).toBeNull();
+        expect(board_div.querySelector("#board-canvas")).not.toBeNull();
+
         goban.destroy();
     });
 });


### PR DESCRIPTION
## Summary

Adds renderer support for custom board background assets that include a baked-in grid. The motivation is to make boards that look better - the vector grid doesn't fit some organic look. Although I included very stylized examples, even the regular wooden board would look better when the lines are a part of the image.

The changes are made with Codex. I've reviewed them and closely steered the technical design.

This keeps the existing custom board background behavior intact, and adds an optional per-board-size baked-grid background path for 9x9, 13x13, and 19x19 boards. The baked-grid image is rendered as a separate layer above the default board background and vector grid, so broken image URLs gracefully degrade to the vector-grid board.

Related online-go.com PR: https://github.com/online-go/online-go.com/pull/3593

## Screenshots

From testing on OGS locally. The grid is painted lines on the lawn
<img width="904" height="857" alt="image" src="https://github.com/user-attachments/assets/9563c21a-82ae-4a21-9f3b-42e72623d8de" />

Screenshot of another theme I made, where grid blends with the theme more. The grid is formed by the gaps between the tiles.
<img width="494" height="494" alt="image" src="https://github.com/user-attachments/assets/70c3ce61-248c-4b0f-a2fb-c3249b5a0e93" />


## Details

- Adds optional `custom-board-grid-backgrounds` theme data.
- Resolves baked-grid backgrounds only for supported square board sizes.
- Uses explicit asset metadata for the current large-margin/no-baked-label profile, leaving room for future small-margin or baked-label profiles.
- Updates both SVG and canvas renderers to layer baked-grid backgrounds without removing fallback rendering.
- Keeps coordinate labels as renderer overlays.
- Fixes canvas custom URL stones to load plain stones instead of blank canvases, including move-tree stones. When testing, I thought that my changes broke the canvas rendering so I fixed it. But actually that bug exists upstream too. To test it, set the stones assets to URL and set the legacy canvas renderer.

## Compatibility

This is backward-compatible for existing goban consumers:
- The new theme data is optional.
- Existing custom board URLs/colors continue to work.
- Missing, broken, or unsupported baked-grid backgrounds fall back to the default board background and vector grid.
- Existing theme implementations remain valid.

## Testing

- Tested on the desktop and mobile browsers
- Tested for graceful degradation when background assets that have broken URL's