### PR TITLE
Add stone scale theme setting

### DIFF
--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -65,6 +65,7 @@ Goban.setCallbacks({
         //black: "Custom",
         "removal-graphic": "square",
         "removal-scale": 1.0,
+        "stone-scale": 1.0,
     }),
 
     customWhiteStoneUrl: () => {

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -3798,7 +3798,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     }
 
     private getStoneScale(): number {
-        return Math.min(this.themes["stone-scale"], 1.0);
+        const stone_scale = this.themes["stone-scale"];
+        return Math.min(Number.isFinite(stone_scale) ? stone_scale : 1.0, 1.0);
     }
 
     move_tree_drawStone(

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -147,6 +147,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         "white": "Plain",
         "removal-graphic": "x",
         "removal-scale": 1.0,
+        "stone-scale": 1.0,
         "stone-shadows": "default",
     };
     private theme_black!: GobanTheme;
@@ -3793,7 +3794,11 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             r = Math.min(r, (this.square_size - 1) / 2);
         }
 
-        return Math.max(1, r);
+        return Math.max(1, r * this.getStoneScale());
+    }
+
+    private getStoneScale(): number {
+        return Math.min(this.themes["stone-scale"], 1.0);
     }
 
     move_tree_drawStone(

--- a/src/Goban/Goban.ts
+++ b/src/Goban/Goban.ts
@@ -91,6 +91,7 @@ export interface GobanSelectedThemes {
     "black": string;
     "removal-graphic": "square" | "x";
     "removal-scale": number;
+    "stone-scale": number;
     "stone-shadows"?: ShadowTheme;
     "custom-shadow-config"?: CustomShadowConfig;
     /*
@@ -323,6 +324,7 @@ export abstract class Goban extends OGSConnectivity {
             "board": "Kaya",
             "removal-graphic": "square",
             "removal-scale": 1.0,
+            "stone-scale": 1.0,
             "stone-shadows": "default",
         };
     }

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -4029,7 +4029,8 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     }
 
     private getStoneScale(): number {
-        return this.themes["stone-scale"];
+        const stone_scale = this.themes["stone-scale"];
+        return Number.isFinite(stone_scale) ? stone_scale : 1.0;
     }
 
     public redraw(force_clear?: boolean): void {

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -171,6 +171,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         "white": "Plain",
         "removal-graphic": "x",
         "removal-scale": 1.0,
+        "stone-scale": 1.0,
         "stone-shadows": "default",
     };
     public theme_black!: GobanTheme;
@@ -4024,7 +4025,11 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
 
     protected computeThemeStoneRadius(): number {
         const scale = this.getFuzzyPlacementEnabled() ? 0.49 : 0.5;
-        return Math.max(1, this.square_size * scale);
+        return Math.max(1, this.square_size * scale * this.getStoneScale());
+    }
+
+    private getStoneScale(): number {
+        return this.themes["stone-scale"];
     }
 
     public redraw(force_clear?: boolean): void {

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -95,13 +95,18 @@ function basicScorableBoardConfig(
     };
 }
 
-function selectedThemes(board: "Custom" | "Kaya", grid9Url: string = ""): GobanSelectedThemes {
+function selectedThemes(
+    board: "Custom" | "Kaya",
+    grid9Url: string = "",
+    stoneScale: number = 1.0,
+): GobanSelectedThemes {
     return {
         "white": "Shell",
         "black": "Slate",
         "board": board,
         "removal-graphic": "square",
         "removal-scale": 1.0,
+        "stone-scale": stoneScale,
         "stone-shadows": "none",
         "custom-board-grid-backgrounds": {
             "9": grid9Url,
@@ -110,6 +115,54 @@ function selectedThemes(board: "Custom" | "Kaya", grid9Url: string = ""): GobanS
         },
     };
 }
+
+describe("stone scale", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+    });
+
+    afterEach(() => {
+        delete callbacks.getSelectedThemes;
+        board_div.remove();
+    });
+
+    test("preserves the existing default radius", () => {
+        callbacks.getSelectedThemes = () => selectedThemes("Kaya");
+        const goban = new GobanCanvas(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(4.5);
+
+        goban.destroy();
+    });
+
+    test("caps scale above one", () => {
+        callbacks.getSelectedThemes = () => selectedThemes("Kaya", "", 1.5);
+        const goban = new GobanCanvas(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(4.5);
+
+        goban.destroy();
+    });
+
+    test("shrinks radius below one", () => {
+        callbacks.getSelectedThemes = () => selectedThemes("Kaya", "", 0.5);
+        const goban = new GobanCanvas(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(2.25);
+
+        goban.destroy();
+    });
+});
 
 describe("onTap", () => {
     beforeEach(async () => {

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -116,6 +116,12 @@ function selectedThemes(
     };
 }
 
+function selectedThemesWithoutStoneScale(): GobanSelectedThemes {
+    const themes: Partial<GobanSelectedThemes> = selectedThemes("Kaya");
+    delete themes["stone-scale"];
+    return themes as GobanSelectedThemes;
+}
+
 describe("stone scale", () => {
     beforeEach(() => {
         board_div = document.createElement("div");
@@ -129,6 +135,18 @@ describe("stone scale", () => {
 
     test("preserves the existing default radius", () => {
         callbacks.getSelectedThemes = () => selectedThemes("Kaya");
+        const goban = new GobanCanvas(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(4.5);
+
+        goban.destroy();
+    });
+
+    test("defaults missing runtime stone scale to one", () => {
+        callbacks.getSelectedThemes = () => selectedThemesWithoutStoneScale();
         const goban = new GobanCanvas(basic3x3Config());
         const radius = (
             goban as unknown as { computeThemeStoneRadius(): number }

--- a/test/unit_tests/GobanSVG.test.ts
+++ b/test/unit_tests/GobanSVG.test.ts
@@ -7,6 +7,7 @@
 (global as any).CLIENT = true;
 
 import { SVGRenderer, SVGRendererGobanConfig } from "../../src/Goban/SVGRenderer";
+import type { GobanSelectedThemes } from "../../src/Goban/Goban";
 import {
     SCORE_ESTIMATION_TOLERANCE,
     SCORE_ESTIMATION_TRIALS,
@@ -94,6 +95,68 @@ function basicScorableBoardConfig(
         ...(additionalOptions ?? {}),
     };
 }
+
+function selectedThemes(stoneScale: number = 1.0): GobanSelectedThemes {
+    return {
+        "white": "Shell",
+        "black": "Slate",
+        "board": "Kaya",
+        "removal-graphic": "square",
+        "removal-scale": 1.0,
+        "stone-scale": stoneScale,
+        "stone-shadows": "none",
+    };
+}
+
+describe("stone scale", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+    });
+
+    afterEach(() => {
+        delete callbacks.getSelectedThemes;
+        delete callbacks.getFuzzyPlacementEnabled;
+        board_div.remove();
+    });
+
+    test("uses half the square size by default", () => {
+        callbacks.getSelectedThemes = () => selectedThemes();
+        const goban = new SVGRenderer(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(5);
+
+        goban.destroy();
+    });
+
+    test("keeps the fuzzy placement size reduction", () => {
+        callbacks.getSelectedThemes = () => selectedThemes();
+        callbacks.getFuzzyPlacementEnabled = () => true;
+        const goban = new SVGRenderer(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(4.9);
+
+        goban.destroy();
+    });
+
+    test("allows scale above one", () => {
+        callbacks.getSelectedThemes = () => selectedThemes(1.5);
+        const goban = new SVGRenderer(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(7.5);
+
+        goban.destroy();
+    });
+});
 
 describe("onTap", () => {
     beforeEach(async () => {

--- a/test/unit_tests/GobanSVG.test.ts
+++ b/test/unit_tests/GobanSVG.test.ts
@@ -108,6 +108,12 @@ function selectedThemes(stoneScale: number = 1.0): GobanSelectedThemes {
     };
 }
 
+function selectedThemesWithoutStoneScale(): GobanSelectedThemes {
+    const themes: Partial<GobanSelectedThemes> = selectedThemes();
+    delete themes["stone-scale"];
+    return themes as GobanSelectedThemes;
+}
+
 describe("stone scale", () => {
     beforeEach(() => {
         board_div = document.createElement("div");
@@ -122,6 +128,18 @@ describe("stone scale", () => {
 
     test("uses half the square size by default", () => {
         callbacks.getSelectedThemes = () => selectedThemes();
+        const goban = new SVGRenderer(basic3x3Config());
+        const radius = (
+            goban as unknown as { computeThemeStoneRadius(): number }
+        ).computeThemeStoneRadius();
+
+        expect(radius).toBeCloseTo(5);
+
+        goban.destroy();
+    });
+
+    test("defaults missing runtime stone scale to one", () => {
+        callbacks.getSelectedThemes = () => selectedThemesWithoutStoneScale();
         const goban = new SVGRenderer(basic3x3Config());
         const radius = (
             goban as unknown as { computeThemeStoneRadius(): number }


### PR DESCRIPTION
This adds a new setting for the stone scaling, as I suggested at https://github.com/online-go/online-go.com/issues/3608

The canvas renderer limits the scaling factor to at most 1 to prevent overlapping.

See the matching PR https://github.com/online-go/online-go.com/pull/3612