### PR TITLE
Support custom stone image variants

### DIFF
--- a/examples/main.tsx
+++ b/examples/main.tsx
@@ -68,11 +68,11 @@ Goban.setCallbacks({
         "stone-scale": 1.0,
     }),
 
-    customWhiteStoneUrl: () => {
-        return "https://cdn.online-go.com/goban/anime_white.svg";
+    customWhiteStoneUrls: () => {
+        return ["https://cdn.online-go.com/goban/anime_white.svg"];
     },
-    customBlackStoneUrl: () => {
-        return "https://cdn.online-go.com/goban/anime_black.svg";
+    customBlackStoneUrls: () => {
+        return ["https://cdn.online-go.com/goban/anime_black.svg"];
     },
 });
 

--- a/src/Goban/callbacks.ts
+++ b/src/Goban/callbacks.ts
@@ -47,7 +47,11 @@ export interface GobanCallbacks {
     customBoardLineColor?: () => string;
     customBoardLabelColor?: () => string;
     customBoardUrl?: () => string;
+    customBlackStoneUrls?: () => string[];
+    customWhiteStoneUrls?: () => string[];
+    /** @deprecated Use customBlackStoneUrls instead. */
     customBlackStoneUrl?: () => string;
+    /** @deprecated Use customWhiteStoneUrls instead. */
     customWhiteStoneUrl?: () => string;
 
     canvasAllocationErrorHandler?: (
@@ -70,8 +74,20 @@ export interface GobanCallbacks {
     toast?: (message_id: string, duration: number) => void;
 }
 
+function legacyBlackStoneUrls(): string[] {
+    const url = callbacks.customBlackStoneUrl?.().trim();
+    return url ? [url] : [];
+}
+
+function legacyWhiteStoneUrls(): string[] {
+    const url = callbacks.customWhiteStoneUrl?.().trim();
+    return url ? [url] : [];
+}
+
 export const callbacks: GobanCallbacks = {
     getClockDrift: () => 0,
+    customBlackStoneUrls: legacyBlackStoneUrls,
+    customWhiteStoneUrls: legacyWhiteStoneUrls,
 };
 
 /**
@@ -79,6 +95,14 @@ export const callbacks: GobanCallbacks = {
  * or all of the callbacks, only the provided callbacks will be updated.
  */
 export function setGobanCallbacks(newCallbacks: GobanCallbacks): void {
+    // This is a partial update, so only restore a legacy shim when its singular callback is supplied.
+    if (newCallbacks.customBlackStoneUrl && !newCallbacks.customBlackStoneUrls) {
+        callbacks.customBlackStoneUrls = legacyBlackStoneUrls;
+    }
+    if (newCallbacks.customWhiteStoneUrl && !newCallbacks.customWhiteStoneUrls) {
+        callbacks.customWhiteStoneUrls = legacyWhiteStoneUrls;
+    }
+
     for (const key in newCallbacks) {
         if (newCallbacks[key as keyof GobanCallbacks] !== undefined) {
             callbacks[key as keyof GobanCallbacks] = newCallbacks[

--- a/src/Goban/callbacks.ts
+++ b/src/Goban/callbacks.ts
@@ -51,10 +51,6 @@ export interface GobanCallbacks {
     customBlackStoneUrls?: () => string[];
     /** Returns custom white stone image URLs, trimmed and unique within the array. */
     customWhiteStoneUrls?: () => string[];
-    /** @deprecated Use customBlackStoneUrls instead. */
-    customBlackStoneUrl?: () => string;
-    /** @deprecated Use customWhiteStoneUrls instead. */
-    customWhiteStoneUrl?: () => string;
 
     canvasAllocationErrorHandler?: (
         note: string | null,
@@ -76,20 +72,10 @@ export interface GobanCallbacks {
     toast?: (message_id: string, duration: number) => void;
 }
 
-function legacyBlackStoneUrls(): string[] {
-    const url = callbacks.customBlackStoneUrl?.().trim();
-    return url ? [url] : [];
-}
-
-function legacyWhiteStoneUrls(): string[] {
-    const url = callbacks.customWhiteStoneUrl?.().trim();
-    return url ? [url] : [];
-}
-
 export const callbacks: GobanCallbacks = {
     getClockDrift: () => 0,
-    customBlackStoneUrls: legacyBlackStoneUrls,
-    customWhiteStoneUrls: legacyWhiteStoneUrls,
+    customBlackStoneUrls: () => [],
+    customWhiteStoneUrls: () => [],
 };
 
 /**
@@ -97,14 +83,6 @@ export const callbacks: GobanCallbacks = {
  * or all of the callbacks, only the provided callbacks will be updated.
  */
 export function setGobanCallbacks(newCallbacks: GobanCallbacks): void {
-    // This is a partial update, so only restore a legacy shim when its singular callback is supplied.
-    if (newCallbacks.customBlackStoneUrl && !newCallbacks.customBlackStoneUrls) {
-        callbacks.customBlackStoneUrls = legacyBlackStoneUrls;
-    }
-    if (newCallbacks.customWhiteStoneUrl && !newCallbacks.customWhiteStoneUrls) {
-        callbacks.customWhiteStoneUrls = legacyWhiteStoneUrls;
-    }
-
     for (const key in newCallbacks) {
         if (newCallbacks[key as keyof GobanCallbacks] !== undefined) {
             callbacks[key as keyof GobanCallbacks] = newCallbacks[

--- a/src/Goban/callbacks.ts
+++ b/src/Goban/callbacks.ts
@@ -47,7 +47,9 @@ export interface GobanCallbacks {
     customBoardLineColor?: () => string;
     customBoardLabelColor?: () => string;
     customBoardUrl?: () => string;
+    /** Returns custom black stone image URLs, trimmed and unique within the array. */
     customBlackStoneUrls?: () => string[];
+    /** Returns custom white stone image URLs, trimmed and unique within the array. */
     customWhiteStoneUrls?: () => string[];
     /** @deprecated Use customBlackStoneUrls instead. */
     customBlackStoneUrl?: () => string;

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -50,19 +50,26 @@ type StoneType = {
 type StoneTypeArray = Array<StoneType>;
 
 type CustomStoneRandomValues = number[][];
+type CustomStoneRandomValuesKey = GobanBase["engine"];
 
-const custom_stone_random_values = new WeakMap<GobanBase, CustomStoneRandomValues>();
+const custom_stone_random_values = new WeakMap<
+    CustomStoneRandomValuesKey,
+    CustomStoneRandomValues
+>();
 
-function initializeCustomStoneRandomValues(goban: GobanBase): CustomStoneRandomValues {
-    const values = Array.from({ length: goban.engine.height }, () =>
-        Array.from({ length: goban.engine.width }, () => Math.random()),
+function initializeCustomStoneRandomValues(
+    engine: CustomStoneRandomValuesKey,
+): CustomStoneRandomValues {
+    const values = Array.from({ length: engine.height }, () =>
+        Array.from({ length: engine.width }, () => Math.random()),
     );
-    custom_stone_random_values.set(goban, values);
+    custom_stone_random_values.set(engine, values);
     return values;
 }
 
 function customStoneRandomValuesFor(goban: GobanBase): CustomStoneRandomValues {
-    return custom_stone_random_values.get(goban) ?? initializeCustomStoneRandomValues(goban);
+    const engine = goban.engine;
+    return custom_stone_random_values.get(engine) ?? initializeCustomStoneRandomValues(engine);
 }
 
 function normalizeCustomStoneUrls(urls: string[]): string[] {

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -364,7 +364,10 @@ export default function (THEMES: ThemesInterface) {
             cy: number,
             radius: number,
         ): void {
-            if (imageStoneIsReady(stone)) {
+            if (
+                getCustomStoneUrls(callbacks.customBlackStoneUrls).length > 0 &&
+                imageStoneIsReady(stone)
+            ) {
                 placeRenderedImageStone(ctx, shadow_ctx, stone, cx, cy, radius);
             } else {
                 renderPlainStone(
@@ -382,7 +385,7 @@ export default function (THEMES: ThemesInterface) {
             radius: number,
             _seed: number,
             deferredRenderCallback: () => void,
-        ): StoneTypeArray | boolean {
+        ): StoneTypeArray | true {
             const [url] = getCustomStoneUrls(callbacks.customBlackStoneUrls);
             if (!url) {
                 return true;
@@ -412,7 +415,10 @@ export default function (THEMES: ThemesInterface) {
             cy: number,
             radius: number,
         ): void {
-            if (imageStoneIsReady(stone)) {
+            if (
+                getCustomStoneUrls(callbacks.customWhiteStoneUrls).length > 0 &&
+                imageStoneIsReady(stone)
+            ) {
                 placeRenderedImageStone(ctx, shadow_ctx, stone, cx, cy, radius);
             } else {
                 renderPlainStone(
@@ -430,7 +436,7 @@ export default function (THEMES: ThemesInterface) {
             radius: number,
             _seed: number,
             deferredRenderCallback: () => void,
-        ): StoneTypeArray | boolean {
+        ): StoneTypeArray | true {
             const [url] = getCustomStoneUrls(callbacks.customWhiteStoneUrls);
             if (!url) {
                 return true;

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -467,7 +467,7 @@ export default function (THEMES: ThemesInterface) {
 
             return urls.map((url, index) => {
                 const id = this.def_uid(`custom-black-${index}-${radius}`);
-                defs.append(this.createCustomStoneSVG(id, url, radius, this.getBlackStoneColor()));
+                defs.append(this.renderSVG({ id, url }, radius));
                 return id;
             });
         }
@@ -485,38 +485,9 @@ export default function (THEMES: ThemesInterface) {
 
             return urls.map((url, index) => {
                 const id = this.def_uid(`custom-white-${index}-${radius}`);
-                defs.append(this.createCustomStoneSVG(id, url, radius, this.getWhiteStoneColor()));
+                defs.append(this.renderSVG({ id, url }, radius));
                 return id;
             });
-        }
-
-        private createCustomStoneSVG(
-            id: string,
-            url: string,
-            radius: number,
-            fallback_color: string,
-        ): SVGGraphicsElement {
-            const stone = this.renderSVG({ id, url }, radius);
-            const image = stone.querySelector("image");
-            image?.addEventListener(
-                "error",
-                () => {
-                    const fallback = this.renderSVG(
-                        {
-                            id: `${id}-fallback`,
-                            fill: fallback_color,
-                            stroke: fallback_color,
-                        },
-                        radius,
-                    );
-                    stone.replaceChildren();
-                    while (fallback.firstChild) {
-                        stone.appendChild(fallback.firstChild);
-                    }
-                },
-                { once: true },
-            );
-            return stone;
         }
     }
 

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -72,12 +72,8 @@ function customStoneRandomValuesFor(goban: GobanBase): CustomStoneRandomValues {
     return custom_stone_random_values.get(engine) ?? initializeCustomStoneRandomValues(engine);
 }
 
-function normalizeCustomStoneUrls(urls: string[]): string[] {
-    return Array.from(new Set(urls.map((url) => url.trim()).filter((url) => url.length > 0)));
-}
-
 function getCustomStoneUrls(callback: (() => string[]) | undefined): string[] {
-    return normalizeCustomStoneUrls(callback?.() ?? []);
+    return callback?.() ?? [];
 }
 
 function square_size(radius: number, scaled: boolean): number {

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -23,6 +23,7 @@ import { renderShadow } from "./rendered_stones";
 import { renderPlainStone } from "./plain_stones";
 import { callbacks } from "../callbacks";
 import { raw_anime_black_svg, raw_anime_white_svg } from "./raw_image_stone_data";
+import type { GobanBase } from "../../GobanBase";
 
 const anime_black_imagedata = makeSvgImageData(raw_anime_black_svg);
 const anime_white_imagedata = makeSvgImageData(raw_anime_white_svg);
@@ -47,6 +48,30 @@ type StoneType = {
     image_loaded: boolean;
 };
 type StoneTypeArray = Array<StoneType>;
+
+type CustomStoneRandomValues = number[][];
+
+const custom_stone_random_values = new WeakMap<GobanBase, CustomStoneRandomValues>();
+
+function initializeCustomStoneRandomValues(goban: GobanBase): CustomStoneRandomValues {
+    const values = Array.from({ length: goban.engine.height }, () =>
+        Array.from({ length: goban.engine.width }, () => Math.random()),
+    );
+    custom_stone_random_values.set(goban, values);
+    return values;
+}
+
+function customStoneRandomValuesFor(goban: GobanBase): CustomStoneRandomValues {
+    return custom_stone_random_values.get(goban) ?? initializeCustomStoneRandomValues(goban);
+}
+
+function normalizeCustomStoneUrls(urls: string[]): string[] {
+    return Array.from(new Set(urls.map((url) => url.trim()).filter((url) => url.length > 0)));
+}
+
+function getCustomStoneUrls(callback: (() => string[]) | undefined): string[] {
+    return normalizeCustomStoneUrls(callback?.() ?? []);
+}
 
 function square_size(radius: number, scaled: boolean): number {
     return 2 * Math.floor(radius) + (scaled ? 0 : 1);
@@ -316,6 +341,14 @@ export default function (THEMES: ThemesInterface) {
             return "Custom";
         }
 
+        override getStone(x: number, y: number, stones: unknown, goban: GobanBase): unknown {
+            if (!Array.isArray(stones) || stones.length <= 1) {
+                return super.getStone(x, y, stones, goban);
+            }
+            const random_value = customStoneRandomValuesFor(goban)[y][x];
+            return stones[Math.floor(random_value * stones.length)];
+        }
+
         override placeBlackStone(
             ctx: CanvasRenderingContext2D,
             shadow_ctx: CanvasRenderingContext2D | null,
@@ -324,11 +357,7 @@ export default function (THEMES: ThemesInterface) {
             cy: number,
             radius: number,
         ): void {
-            if (
-                callbacks.customBlackStoneUrl &&
-                callbacks.customBlackStoneUrl() !== "" &&
-                imageStoneIsReady(stone)
-            ) {
+            if (imageStoneIsReady(stone)) {
                 placeRenderedImageStone(ctx, shadow_ctx, stone, cx, cy, radius);
             } else {
                 renderPlainStone(
@@ -347,12 +376,13 @@ export default function (THEMES: ThemesInterface) {
             _seed: number,
             deferredRenderCallback: () => void,
         ): StoneTypeArray | boolean {
-            if (!callbacks.customBlackStoneUrl || callbacks.customBlackStoneUrl() === "") {
+            const [url] = getCustomStoneUrls(callbacks.customBlackStoneUrls);
+            if (!url) {
                 return true;
             }
             return preRenderImageStone(
                 radius,
-                callbacks.customBlackStoneUrl ? callbacks.customBlackStoneUrl() : "",
+                url,
                 deferredRenderCallback,
                 false /* show_shadow */,
             );
@@ -375,11 +405,7 @@ export default function (THEMES: ThemesInterface) {
             cy: number,
             radius: number,
         ): void {
-            if (
-                callbacks.customWhiteStoneUrl &&
-                callbacks.customWhiteStoneUrl() !== "" &&
-                imageStoneIsReady(stone)
-            ) {
+            if (imageStoneIsReady(stone)) {
                 placeRenderedImageStone(ctx, shadow_ctx, stone, cx, cy, radius);
             } else {
                 renderPlainStone(
@@ -398,12 +424,13 @@ export default function (THEMES: ThemesInterface) {
             _seed: number,
             deferredRenderCallback: () => void,
         ): StoneTypeArray | boolean {
-            if (!callbacks.customWhiteStoneUrl || callbacks.customWhiteStoneUrl() === "") {
+            const [url] = getCustomStoneUrls(callbacks.customWhiteStoneUrls);
+            if (!url) {
                 return true;
             }
             return preRenderImageStone(
                 radius,
-                callbacks.customWhiteStoneUrl ? callbacks.customWhiteStoneUrl() : "",
+                url,
                 deferredRenderCallback,
                 false /* show_shadow */,
             );
@@ -424,22 +451,16 @@ export default function (THEMES: ThemesInterface) {
             _seed: number,
             deferredRenderCallback: () => void,
         ): string[] {
-            if (!callbacks.customBlackStoneUrl || callbacks.customBlackStoneUrl() === "") {
+            const urls = getCustomStoneUrls(callbacks.customBlackStoneUrls);
+            if (urls.length === 0) {
                 return super.preRenderBlackSVG(defs, radius, _seed, deferredRenderCallback);
             }
 
-            const id = this.def_uid(`custom-black-${radius}`);
-            defs.append(
-                this.renderSVG(
-                    {
-                        id,
-                        url: callbacks.customBlackStoneUrl(),
-                    },
-                    radius,
-                ),
-            );
-
-            return [id];
+            return urls.map((url, index) => {
+                const id = this.def_uid(`custom-black-${index}-${radius}`);
+                defs.append(this.createCustomStoneSVG(id, url, radius, this.getBlackStoneColor()));
+                return id;
+            });
         }
 
         public override preRenderWhiteSVG(
@@ -448,22 +469,45 @@ export default function (THEMES: ThemesInterface) {
             _seed: number,
             deferredRenderCallback: () => void,
         ): string[] {
-            if (!callbacks.customWhiteStoneUrl || callbacks.customWhiteStoneUrl() === "") {
+            const urls = getCustomStoneUrls(callbacks.customWhiteStoneUrls);
+            if (urls.length === 0) {
                 return super.preRenderWhiteSVG(defs, radius, _seed, deferredRenderCallback);
             }
 
-            const id = this.def_uid(`custom-white-${radius}`);
-            defs.append(
-                this.renderSVG(
-                    {
-                        id,
-                        url: callbacks.customWhiteStoneUrl(),
-                    },
-                    radius,
-                ),
-            );
+            return urls.map((url, index) => {
+                const id = this.def_uid(`custom-white-${index}-${radius}`);
+                defs.append(this.createCustomStoneSVG(id, url, radius, this.getWhiteStoneColor()));
+                return id;
+            });
+        }
 
-            return [id];
+        private createCustomStoneSVG(
+            id: string,
+            url: string,
+            radius: number,
+            fallback_color: string,
+        ): SVGGraphicsElement {
+            const stone = this.renderSVG({ id, url }, radius);
+            const image = stone.querySelector("image");
+            image?.addEventListener(
+                "error",
+                () => {
+                    const fallback = this.renderSVG(
+                        {
+                            id: `${id}-fallback`,
+                            fill: fallback_color,
+                            stroke: fallback_color,
+                        },
+                        radius,
+                    );
+                    stone.replaceChildren();
+                    while (fallback.firstChild) {
+                        stone.appendChild(fallback.firstChild);
+                    }
+                },
+                { once: true },
+            );
+            return stone;
         }
     }
 

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -23,7 +23,6 @@ import { renderShadow } from "./rendered_stones";
 import { renderPlainStone } from "./plain_stones";
 import { callbacks } from "../callbacks";
 import { raw_anime_black_svg, raw_anime_white_svg } from "./raw_image_stone_data";
-import type { GobanBase } from "../../GobanBase";
 
 const anime_black_imagedata = makeSvgImageData(raw_anime_black_svg);
 const anime_white_imagedata = makeSvgImageData(raw_anime_white_svg);
@@ -48,39 +47,6 @@ type StoneType = {
     image_loaded: boolean;
 };
 type StoneTypeArray = Array<StoneType>;
-
-type CustomStoneRandomValues = number[][];
-
-/* Custom stone layouts are scoped to the durable renderer, not its engine: a
- * reconnect can replace goban.engine while preserving the GobanBase instance.
- * The renderer can also load a different logical board size, so the matrix
- * dimensions are checked before reusing its random values. */
-const custom_stone_random_values = new WeakMap<GobanBase, CustomStoneRandomValues>();
-
-function initializeCustomStoneRandomValues(goban: GobanBase): CustomStoneRandomValues {
-    const random_values = Array.from({ length: goban.engine.height }, () =>
-        Array.from({ length: goban.engine.width }, () => Math.random()),
-    );
-    custom_stone_random_values.set(goban, random_values);
-    return random_values;
-}
-
-function customStoneRandomValuesFor(goban: GobanBase): number[][] {
-    const random_values = custom_stone_random_values.get(goban);
-    if (
-        !random_values ||
-        random_values.length !== goban.engine.height ||
-        random_values[0]?.length !== goban.engine.width
-    ) {
-        return initializeCustomStoneRandomValues(goban);
-    }
-    return random_values;
-}
-
-function getCustomStoneIndex(x: number, y: number, stones: unknown[], goban: GobanBase): number {
-    const random_value = customStoneRandomValuesFor(goban)[y][x];
-    return Math.floor(random_value * stones.length);
-}
 
 function getCustomStoneUrls(callback: (() => string[]) | undefined): string[] {
     return callback?.() ?? [];
@@ -352,20 +318,6 @@ export default function (THEMES: ThemesInterface) {
 
         override get theme_name(): string {
             return "Custom";
-        }
-
-        override getStone(x: number, y: number, stones: unknown, goban: GobanBase): unknown {
-            if (!Array.isArray(stones) || stones.length <= 1) {
-                return super.getStone(x, y, stones, goban);
-            }
-            return stones[getCustomStoneIndex(x, y, stones, goban)];
-        }
-
-        override getStoneHash(x: number, y: number, stones: unknown, goban: GobanBase): string {
-            if (!Array.isArray(stones) || stones.length <= 1) {
-                return super.getStoneHash(x, y, stones, goban);
-            }
-            return `${getCustomStoneIndex(x, y, stones, goban)}`;
         }
 
         override placeBlackStone(

--- a/src/Goban/themes/image_stones.ts
+++ b/src/Goban/themes/image_stones.ts
@@ -50,26 +50,36 @@ type StoneType = {
 type StoneTypeArray = Array<StoneType>;
 
 type CustomStoneRandomValues = number[][];
-type CustomStoneRandomValuesKey = GobanBase["engine"];
 
-const custom_stone_random_values = new WeakMap<
-    CustomStoneRandomValuesKey,
-    CustomStoneRandomValues
->();
+/* Custom stone layouts are scoped to the durable renderer, not its engine: a
+ * reconnect can replace goban.engine while preserving the GobanBase instance.
+ * The renderer can also load a different logical board size, so the matrix
+ * dimensions are checked before reusing its random values. */
+const custom_stone_random_values = new WeakMap<GobanBase, CustomStoneRandomValues>();
 
-function initializeCustomStoneRandomValues(
-    engine: CustomStoneRandomValuesKey,
-): CustomStoneRandomValues {
-    const values = Array.from({ length: engine.height }, () =>
-        Array.from({ length: engine.width }, () => Math.random()),
+function initializeCustomStoneRandomValues(goban: GobanBase): CustomStoneRandomValues {
+    const random_values = Array.from({ length: goban.engine.height }, () =>
+        Array.from({ length: goban.engine.width }, () => Math.random()),
     );
-    custom_stone_random_values.set(engine, values);
-    return values;
+    custom_stone_random_values.set(goban, random_values);
+    return random_values;
 }
 
-function customStoneRandomValuesFor(goban: GobanBase): CustomStoneRandomValues {
-    const engine = goban.engine;
-    return custom_stone_random_values.get(engine) ?? initializeCustomStoneRandomValues(engine);
+function customStoneRandomValuesFor(goban: GobanBase): number[][] {
+    const random_values = custom_stone_random_values.get(goban);
+    if (
+        !random_values ||
+        random_values.length !== goban.engine.height ||
+        random_values[0]?.length !== goban.engine.width
+    ) {
+        return initializeCustomStoneRandomValues(goban);
+    }
+    return random_values;
+}
+
+function getCustomStoneIndex(x: number, y: number, stones: unknown[], goban: GobanBase): number {
+    const random_value = customStoneRandomValuesFor(goban)[y][x];
+    return Math.floor(random_value * stones.length);
 }
 
 function getCustomStoneUrls(callback: (() => string[]) | undefined): string[] {
@@ -348,8 +358,14 @@ export default function (THEMES: ThemesInterface) {
             if (!Array.isArray(stones) || stones.length <= 1) {
                 return super.getStone(x, y, stones, goban);
             }
-            const random_value = customStoneRandomValuesFor(goban)[y][x];
-            return stones[Math.floor(random_value * stones.length)];
+            return stones[getCustomStoneIndex(x, y, stones, goban)];
+        }
+
+        override getStoneHash(x: number, y: number, stones: unknown, goban: GobanBase): string {
+            if (!Array.isArray(stones) || stones.length <= 1) {
+                return super.getStoneHash(x, y, stones, goban);
+            }
+            return `${getCustomStoneIndex(x, y, stones, goban)}`;
         }
 
         override placeBlackStone(

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import type { GobanBase } from "../../src/GobanBase";
 import { callbacks } from "../../src/Goban/callbacks";
 import { THEMES } from "../../src/Goban/themes";
 
@@ -74,72 +73,14 @@ describe("custom image stones", () => {
         expect(ctx.fill).toHaveBeenCalledTimes(1);
     });
 
-    test("keeps a random arrangement stable within each goban", () => {
-        let random_value = 0.1;
-        jest.spyOn(Math, "random").mockImplementation(() => random_value);
+    test("selects custom variants deterministically by board coordinate", () => {
         const theme = new THEMES.black.Custom();
         const stones = ["one", "two", "three", "four"];
-        const first_goban = {
-            engine: { width: 19, height: 19 },
-        } as unknown as GobanBase;
-        const second_goban = {
-            engine: { width: 19, height: 19 },
-        } as unknown as GobanBase;
 
-        const first_layout = Array.from({ length: 19 }, (_, x) =>
-            Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, first_goban)),
-        );
-        const repeated_layout = Array.from({ length: 19 }, (_, x) =>
-            Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, first_goban)),
-        );
-        random_value = 0.8;
-        const second_layout = Array.from({ length: 19 }, (_, x) =>
-            Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, second_goban)),
-        );
-
-        expect(repeated_layout).toEqual(first_layout);
-        expect(second_layout).not.toEqual(first_layout);
-        expect(theme.getStone(4, 7, stones, first_goban)).toBe("one");
-        expect(theme.getStone(4, 7, stones, second_goban)).toBe("four");
-    });
-
-    test("keeps the random arrangement when a goban replaces its engine", () => {
-        let random_value = 0.1;
-        jest.spyOn(Math, "random").mockImplementation(() => random_value);
-        const theme = new THEMES.black.Custom();
-        const stones = ["one", "two"];
-        const goban_state = {
-            engine: { width: 2, height: 2 },
-        };
-        const goban = goban_state as unknown as GobanBase;
-
-        expect(theme.getStone(1, 1, stones, goban)).toBe("one");
-        expect(theme.getStoneHash(1, 1, stones, goban)).toBe("0");
-
-        random_value = 0.8;
-        goban_state.engine = { width: 2, height: 2 };
-
-        expect(theme.getStone(1, 1, stones, goban)).toBe("one");
-        expect(theme.getStoneHash(1, 1, stones, goban)).toBe("0");
-    });
-
-    test("reinitializes the random arrangement when a goban changes board size", () => {
-        let random_value = 0.1;
-        jest.spyOn(Math, "random").mockImplementation(() => random_value);
-        const theme = new THEMES.black.Custom();
-        const stones = ["one", "two"];
-        const goban_state = {
-            engine: { width: 2, height: 2 },
-        };
-        const goban = goban_state as unknown as GobanBase;
-
-        expect(theme.getStone(1, 1, stones, goban)).toBe("one");
-
-        random_value = 0.8;
-        goban_state.engine = { width: 3, height: 3 };
-
-        expect(theme.getStone(2, 2, stones, goban)).toBe("two");
-        expect(theme.getStone(1, 1, stones, goban)).toBe("two");
-        expect(theme.getStoneHash(1, 1, stones, goban)).toBe("1");
+        expect(theme.getStone(0, 0, stones, undefined as never)).toBe("two");
+        expect(theme.getStone(1, 0, stones, undefined as never)).toBe("three");
+        expect(theme.getStone(0, 0, stones, undefined as never)).toBe("two");
+        expect(theme.getStoneHash(0, 0, stones, undefined as never)).toBe("1");
+        expect(theme.getStoneHash(1, 0, stones, undefined as never)).toBe("2");
     });
 });

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GobanBase } from "../../src/GobanBase";
+import { callbacks, setGobanCallbacks } from "../../src/Goban/callbacks";
+import { THEMES } from "../../src/Goban/themes";
+
+function makeDefs(): SVGDefsElement {
+    return document.createElementNS("http://www.w3.org/2000/svg", "defs");
+}
+
+describe("custom image stones", () => {
+    afterEach(() => {
+        delete callbacks.customBlackStoneUrls;
+        delete callbacks.customWhiteStoneUrls;
+        delete callbacks.customBlackStoneUrl;
+        delete callbacks.customWhiteStoneUrl;
+        delete callbacks.customBlackStoneColor;
+        delete callbacks.customWhiteStoneColor;
+        callbacks.customBlackStoneUrls = () => [];
+        callbacks.customWhiteStoneUrls = () => [];
+        jest.restoreAllMocks();
+    });
+
+    test("creates one SVG definition per normalized URL", () => {
+        callbacks.customBlackStoneUrls = () => [" first.png ", "", "second.png", "first.png"];
+        const theme = new THEMES.black.Custom();
+        const defs = makeDefs();
+
+        const stones = theme.preRenderBlackSVG(defs, 10, 1, () => undefined);
+
+        expect(stones).toHaveLength(2);
+        expect(
+            Array.from(defs.querySelectorAll("image")).map((image) =>
+                image.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
+            ),
+        ).toEqual(["first.png", "second.png"]);
+    });
+
+    test("adapts the legacy singular callback", () => {
+        setGobanCallbacks({ customWhiteStoneUrl: () => "white.png" });
+        const theme = new THEMES.white.Custom();
+        const defs = makeDefs();
+
+        const stones = theme.preRenderWhiteSVG(defs, 10, 1, () => undefined);
+
+        expect(stones).toHaveLength(1);
+        expect(
+            defs.querySelector("image")?.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
+        ).toBe("white.png");
+    });
+
+    test("replaces a failed SVG image with a solid stone", () => {
+        callbacks.customBlackStoneUrls = () => ["broken.png"];
+        callbacks.customBlackStoneColor = () => "#123456";
+        const theme = new THEMES.black.Custom();
+        const defs = makeDefs();
+        theme.preRenderBlackSVG(defs, 10, 1, () => undefined);
+
+        defs.querySelector("image")?.dispatchEvent(new Event("error"));
+
+        expect(defs.querySelector("image")).toBeNull();
+        expect(defs.querySelector("circle")?.getAttribute("fill")).toBe("#123456");
+    });
+
+    test("keeps a random arrangement stable within each goban", () => {
+        let random_value = 0.1;
+        jest.spyOn(Math, "random").mockImplementation(() => random_value);
+        const theme = new THEMES.black.Custom();
+        const stones = ["one", "two", "three", "four"];
+        const first_goban = { engine: { width: 19, height: 19 } } as unknown as GobanBase;
+        const second_goban = { engine: { width: 19, height: 19 } } as unknown as GobanBase;
+
+        const first_layout = Array.from({ length: 19 }, (_, x) =>
+            Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, first_goban)),
+        );
+        const repeated_layout = Array.from({ length: 19 }, (_, x) =>
+            Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, first_goban)),
+        );
+        random_value = 0.8;
+        const second_layout = Array.from({ length: 19 }, (_, x) =>
+            Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, second_goban)),
+        );
+
+        expect(repeated_layout).toEqual(first_layout);
+        expect(second_layout).not.toEqual(first_layout);
+        expect(theme.getStone(4, 7, stones, first_goban)).toBe("one");
+        expect(theme.getStone(4, 7, stones, second_goban)).toBe("four");
+    });
+});

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -76,6 +76,20 @@ describe("custom image stones", () => {
         expect(defs.querySelector("circle")?.getAttribute("fill")).toBe("#123456");
     });
 
+    test("falls back when no custom URL and the cached stone is missing", () => {
+        callbacks.customBlackStoneUrls = () => [];
+        const theme = new THEMES.black.Custom();
+        const ctx = {
+            beginPath: jest.fn(),
+            arc: jest.fn(),
+            stroke: jest.fn(),
+            fill: jest.fn(),
+        } as unknown as CanvasRenderingContext2D;
+
+        expect(() => theme.placeBlackStone(ctx, null, undefined as never, 10, 10, 5)).not.toThrow();
+        expect(ctx.fill).toHaveBeenCalledTimes(1);
+    });
+
     test("keeps a random arrangement stable within each goban", () => {
         let random_value = 0.1;
         jest.spyOn(Math, "random").mockImplementation(() => random_value);

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -94,8 +94,12 @@ describe("custom image stones", () => {
         jest.spyOn(Math, "random").mockImplementation(() => random_value);
         const theme = new THEMES.black.Custom();
         const stones = ["one", "two", "three", "four"];
-        const first_goban = { engine: { width: 19, height: 19 } } as unknown as GobanBase;
-        const second_goban = { engine: { width: 19, height: 19 } } as unknown as GobanBase;
+        const first_goban = {
+            engine: { width: 19, height: 19 },
+        } as unknown as GobanBase;
+        const second_goban = {
+            engine: { width: 19, height: 19 },
+        } as unknown as GobanBase;
 
         const first_layout = Array.from({ length: 19 }, (_, x) =>
             Array.from({ length: 19 }, (_, y) => theme.getStone(x, y, stones, first_goban)),
@@ -114,19 +118,43 @@ describe("custom image stones", () => {
         expect(theme.getStone(4, 7, stones, second_goban)).toBe("four");
     });
 
-    test("reinitializes the random arrangement when a goban changes board size", () => {
-        jest.spyOn(Math, "random").mockReturnValue(0.1);
+    test("keeps the random arrangement when a goban replaces its engine", () => {
+        let random_value = 0.1;
+        jest.spyOn(Math, "random").mockImplementation(() => random_value);
         const theme = new THEMES.black.Custom();
         const stones = ["one", "two"];
-        const goban = { engine: { width: 2, height: 2 } } as unknown as GobanBase;
+        const goban_state = {
+            engine: { width: 2, height: 2 },
+        };
+        const goban = goban_state as unknown as GobanBase;
+
+        expect(theme.getStone(1, 1, stones, goban)).toBe("one");
+        expect(theme.getStoneHash(1, 1, stones, goban)).toBe("0");
+
+        random_value = 0.8;
+        goban_state.engine = { width: 2, height: 2 };
+
+        expect(theme.getStone(1, 1, stones, goban)).toBe("one");
+        expect(theme.getStoneHash(1, 1, stones, goban)).toBe("0");
+    });
+
+    test("reinitializes the random arrangement when a goban changes board size", () => {
+        let random_value = 0.1;
+        jest.spyOn(Math, "random").mockImplementation(() => random_value);
+        const theme = new THEMES.black.Custom();
+        const stones = ["one", "two"];
+        const goban_state = {
+            engine: { width: 2, height: 2 },
+        };
+        const goban = goban_state as unknown as GobanBase;
 
         expect(theme.getStone(1, 1, stones, goban)).toBe("one");
 
-        (goban as unknown as { engine: { width: number; height: number } }).engine = {
-            width: 3,
-            height: 3,
-        };
+        random_value = 0.8;
+        goban_state.engine = { width: 3, height: 3 };
 
-        expect(theme.getStone(2, 2, stones, goban)).toBe("one");
+        expect(theme.getStone(2, 2, stones, goban)).toBe("two");
+        expect(theme.getStone(1, 1, stones, goban)).toBe("two");
+        expect(theme.getStoneHash(1, 1, stones, goban)).toBe("1");
     });
 });

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { GobanBase } from "../../src/GobanBase";
-import { callbacks, setGobanCallbacks } from "../../src/Goban/callbacks";
+import { callbacks } from "../../src/Goban/callbacks";
 import { THEMES } from "../../src/Goban/themes";
 
 function makeDefs(): SVGDefsElement {
@@ -26,8 +26,6 @@ describe("custom image stones", () => {
     afterEach(() => {
         delete callbacks.customBlackStoneUrls;
         delete callbacks.customWhiteStoneUrls;
-        delete callbacks.customBlackStoneUrl;
-        delete callbacks.customWhiteStoneUrl;
         delete callbacks.customBlackStoneColor;
         delete callbacks.customWhiteStoneColor;
         callbacks.customBlackStoneUrls = () => [];
@@ -60,19 +58,6 @@ describe("custom image stones", () => {
         expect(stones).toHaveLength(1);
         expect(defs.querySelector("image")).toBeNull();
         expect(defs.querySelector("circle")?.getAttribute("fill")).toBe("#000000");
-    });
-
-    test("adapts the legacy singular callback", () => {
-        setGobanCallbacks({ customWhiteStoneUrl: () => " white.png " });
-        const theme = new THEMES.white.Custom();
-        const defs = makeDefs();
-
-        const stones = theme.preRenderWhiteSVG(defs, 10, 1, () => undefined);
-
-        expect(stones).toHaveLength(1);
-        expect(
-            defs.querySelector("image")?.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
-        ).toBe("white.png");
     });
 
     test("falls back when no custom URL and the cached stone is missing", () => {

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -75,19 +75,6 @@ describe("custom image stones", () => {
         ).toBe("white.png");
     });
 
-    test("replaces a failed SVG image with a solid stone", () => {
-        callbacks.customBlackStoneUrls = () => ["broken.png"];
-        callbacks.customBlackStoneColor = () => "#123456";
-        const theme = new THEMES.black.Custom();
-        const defs = makeDefs();
-        theme.preRenderBlackSVG(defs, 10, 1, () => undefined);
-
-        defs.querySelector("image")?.dispatchEvent(new Event("error"));
-
-        expect(defs.querySelector("image")).toBeNull();
-        expect(defs.querySelector("circle")?.getAttribute("fill")).toBe("#123456");
-    });
-
     test("falls back when no custom URL and the cached stone is missing", () => {
         callbacks.customBlackStoneUrls = () => [];
         const theme = new THEMES.black.Custom();

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -35,8 +35,8 @@ describe("custom image stones", () => {
         jest.restoreAllMocks();
     });
 
-    test("creates one SVG definition per normalized URL", () => {
-        callbacks.customBlackStoneUrls = () => [" first.png ", "", "second.png", "first.png"];
+    test("creates one SVG definition per custom URL", () => {
+        callbacks.customBlackStoneUrls = () => ["first.png", "second.png"];
         const theme = new THEMES.black.Custom();
         const defs = makeDefs();
 
@@ -50,8 +50,20 @@ describe("custom image stones", () => {
         ).toEqual(["first.png", "second.png"]);
     });
 
+    test("uses the solid SVG fallback for an empty custom URL list", () => {
+        callbacks.customBlackStoneUrls = () => [];
+        const theme = new THEMES.black.Custom();
+        const defs = makeDefs();
+
+        const stones = theme.preRenderBlackSVG(defs, 10, 1, () => undefined);
+
+        expect(stones).toHaveLength(1);
+        expect(defs.querySelector("image")).toBeNull();
+        expect(defs.querySelector("circle")?.getAttribute("fill")).toBe("#000000");
+    });
+
     test("adapts the legacy singular callback", () => {
-        setGobanCallbacks({ customWhiteStoneUrl: () => "white.png" });
+        setGobanCallbacks({ customWhiteStoneUrl: () => " white.png " });
         const theme = new THEMES.white.Custom();
         const defs = makeDefs();
 

--- a/test/unit_tests/image_stones.test.ts
+++ b/test/unit_tests/image_stones.test.ts
@@ -100,4 +100,20 @@ describe("custom image stones", () => {
         expect(theme.getStone(4, 7, stones, first_goban)).toBe("one");
         expect(theme.getStone(4, 7, stones, second_goban)).toBe("four");
     });
+
+    test("reinitializes the random arrangement when a goban changes board size", () => {
+        jest.spyOn(Math, "random").mockReturnValue(0.1);
+        const theme = new THEMES.black.Custom();
+        const stones = ["one", "two"];
+        const goban = { engine: { width: 2, height: 2 } } as unknown as GobanBase;
+
+        expect(theme.getStone(1, 1, stones, goban)).toBe("one");
+
+        (goban as unknown as { engine: { width: number; height: number } }).engine = {
+            width: 3,
+            height: 3,
+        };
+
+        expect(theme.getStone(2, 2, stones, goban)).toBe("one");
+    });
 });


### PR DESCRIPTION
This adds support for multiple custom black and white stone images in the SVG renderer, as I suggested at https://github.com/online-go/online-go.com/issues/3608. The Canvas renderer uses the first variant.

Stone variants are randomly distributed across intersections while remaining stable for the lifetime of each board. The variants may change on page reload. I think that the random arrangements work better, particularly for the themes where the variants differ more. Deterministic selection feels as if you always pick the same stone out of the bowl when playing the first moves. The default Shell theme still has the stable coordinate-based selection.

The change preserves compatibility with the existing single-URL callbacks and falls back to solid-color stones when custom images fail to load. Unit tests cover URL normalization, legacy compatibility, image failures, and stable variant placement.

Disclaimer: mostly written by Codex, extensively reviewed and edited in person