### PR TITLE
Separate stone marker and territory colors

### DIFF
--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -151,6 +151,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         "stone-shadows": "default",
     };
     private theme_black!: GobanTheme;
+    private theme_black_stone_color: string = HOT_PINK;
     private theme_black_stones: Array<any> = [];
     private theme_black_text_color: string = HOT_PINK;
     private theme_blank_text_color: string = HOT_PINK;
@@ -162,6 +163,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private theme_star_color: string = "";
     private theme_stone_radius: number = 10;
     private theme_white!: GobanTheme;
+    private theme_white_stone_color: string = HOT_PINK;
     private theme_white_stones: Array<any> = [];
     private theme_white_text_color: string = HOT_PINK;
 
@@ -2018,9 +2020,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             ctx.lineTo(cx - r, cy + r);
 
             if (pos.score === "black" && color === "white") {
-                ctx.strokeStyle = this.theme_white_text_color;
+                ctx.strokeStyle = this.theme_black_stone_color;
             } else if (pos.score === "white" && color === "black") {
-                ctx.strokeStyle = this.theme_black_text_color;
+                ctx.strokeStyle = this.theme_white_stone_color;
             } else if (
                 (pos.score === "white" && color === "white") ||
                 (pos.score === "black" && color === "black")
@@ -2122,10 +2124,10 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 }
 
                 if (color === "white") {
-                    ctx.fillStyle = this.theme_black_text_color;
+                    ctx.fillStyle = this.theme_white_stone_color;
                     ctx.strokeStyle = "#777777";
                 } else if (color === "black") {
-                    ctx.fillStyle = this.theme_white_text_color;
+                    ctx.fillStyle = this.theme_black_stone_color;
                     ctx.strokeStyle = "#888888";
                 } else if (color === "dame") {
                     ctx.fillStyle = "#ff0000";
@@ -2498,10 +2500,10 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
 
             if (color_num !== stone_color) {
                 if (color === "white") {
-                    ctx.fillStyle = this.theme_black_text_color;
+                    ctx.fillStyle = this.theme_white_stone_color;
                     ctx.strokeStyle = "#777777";
                 } else if (color === "black") {
-                    ctx.fillStyle = this.theme_white_text_color;
+                    ctx.fillStyle = this.theme_black_stone_color;
                     ctx.strokeStyle = "#888888";
                 }
                 ctx.lineWidth = Math.ceil(this.square_size * 0.035) - 0.5;
@@ -3466,7 +3468,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.theme_star_color = this.theme_board.getStarColor();
         this.theme_faded_star_color = this.theme_board.getFadedStarColor();
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
+        this.theme_black_stone_color = this.theme_black.getBlackStoneColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
+        this.theme_white_stone_color = this.theme_white.getWhiteStoneColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
         if (dont_redraw && this.ready_to_draw) {
             this.syncBoardBackgroundIfNeeded(this.theme_board, this.themes, (background) =>

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -175,6 +175,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         "stone-shadows": "default",
     };
     public theme_black!: GobanTheme;
+    public theme_black_stone_color: string = HOT_PINK;
     private theme_black_stones: Array<any> = [];
     public theme_black_text_color: string = HOT_PINK;
     private theme_blank_text_color: string = HOT_PINK;
@@ -187,6 +188,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     private theme_star_color: string = "";
     private theme_stone_radius: number = 10;
     public theme_white!: GobanTheme;
+    public theme_white_stone_color: string = HOT_PINK;
     private theme_white_stones: Array<any> = [];
     public theme_white_text_color: string = HOT_PINK;
 
@@ -1699,9 +1701,9 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             let r = Math.max(1, mid * 0.5);
 
             if (pos.score === "black" && color === "white") {
-                fill = this.theme_white_text_color;
+                fill = this.theme_black_stone_color;
             } else if (pos.score === "white" && color === "black") {
-                fill = this.theme_black_text_color;
+                fill = this.theme_white_stone_color;
             } else if (
                 (pos.score === "white" && color === "white") ||
                 (pos.score === "black" && color === "black")
@@ -1797,11 +1799,11 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             let fill = "";
             let stroke = "";
             if (color === "white") {
-                fill = this.theme_black_text_color;
+                fill = this.theme_white_stone_color;
                 stroke = "#777777";
             }
             if (color === "black") {
-                fill = this.theme_white_text_color;
+                fill = this.theme_black_stone_color;
                 stroke = "#888888";
             }
             if (color === "dame") {
@@ -2558,9 +2560,9 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 this.engine.board[j][i] === JGOFNumericPlayerColor.BLACK ? "black" : "white";
 
             if (pos.score === "black" && color === "white") {
-                cross.setAttribute("fill", this.theme_white_text_color);
+                cross.setAttribute("fill", this.theme_black_stone_color);
             } else if (pos.score === "white" && color === "black") {
-                cross.setAttribute("fill", this.theme_black_text_color);
+                cross.setAttribute("fill", this.theme_white_stone_color);
             } else if (
                 (pos.score === "white" && color === "white") ||
                 (pos.score === "black" && color === "black")
@@ -2716,11 +2718,11 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 rect.setAttribute("width", (r * 2).toFixed(1));
                 rect.setAttribute("height", (r * 2).toFixed(1));
                 if (color === "white") {
-                    rect.setAttribute("fill", this.theme_black_text_color);
+                    rect.setAttribute("fill", this.theme_white_stone_color);
                     rect.setAttribute("stroke", "#777777");
                 }
                 if (color === "black") {
-                    rect.setAttribute("fill", this.theme_white_text_color);
+                    rect.setAttribute("fill", this.theme_black_stone_color);
                     rect.setAttribute("stroke", "#888888");
                 }
                 if (color === "dame") {
@@ -3149,11 +3151,11 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 rect.setAttribute("width", (r * 2).toFixed(1));
                 rect.setAttribute("height", (r * 2).toFixed(1));
                 if (color === "white") {
-                    rect.setAttribute("fill", this.theme_black_text_color);
+                    rect.setAttribute("fill", this.theme_white_stone_color);
                     rect.setAttribute("stroke", "#777777");
                 }
                 if (color === "black") {
-                    rect.setAttribute("fill", this.theme_white_text_color);
+                    rect.setAttribute("fill", this.theme_black_stone_color);
                     rect.setAttribute("stroke", "#888888");
                 }
                 rect.setAttribute(
@@ -4337,7 +4339,9 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         this.theme_star_color = this.theme_board.getStarColor();
         this.theme_faded_star_color = this.theme_board.getFadedStarColor();
         this.theme_blank_text_color = this.theme_board.getBlankTextColor();
+        this.theme_black_stone_color = this.theme_black.getBlackStoneColor();
         this.theme_black_text_color = this.theme_black.getBlackTextColor();
+        this.theme_white_stone_color = this.theme_white.getWhiteStoneColor();
         this.theme_white_text_color = this.theme_white.getWhiteTextColor();
         this.theme_shadow_color = this.theme_board.getShadowColor();
         if (dont_redraw) {
@@ -6227,11 +6231,11 @@ class GCell {
         rect.setAttribute("width", (r * 2).toFixed(1));
         rect.setAttribute("height", (r * 2).toFixed(1));
         if (color === "white") {
-            rect.setAttribute("fill", this.renderer.theme_black_text_color);
+            rect.setAttribute("fill", this.renderer.theme_white_stone_color);
             rect.setAttribute("stroke", "#777777");
         }
         if (color === "black") {
-            rect.setAttribute("fill", this.renderer.theme_white_text_color);
+            rect.setAttribute("fill", this.renderer.theme_black_stone_color);
             rect.setAttribute("stroke", "#888888");
         }
         rect.setAttribute("stroke-width", (Math.ceil(ss * 0.035) - 0.5).toFixed(1));

--- a/src/Goban/themes/rendered_stones.ts
+++ b/src/Goban/themes/rendered_stones.ts
@@ -1045,6 +1045,10 @@ export default function (THEMES: ThemesInterface) {
             return "#888888";
         }
 
+        override getBlackStoneColor(): string {
+            return "#000000";
+        }
+
         override preRenderWhite(radius: number, seed: number): StoneTypeArray {
             return preRenderStone(radius, (seed *= 13), {
                 base_color: "rgba(100,100,100,1.0)",
@@ -1058,6 +1062,12 @@ export default function (THEMES: ThemesInterface) {
 
         override getWhiteTextColor(color: string): string {
             return "#000000";
+        }
+
+        override getWhiteStoneColor(): string {
+            // Preserve the existing ownership color for now. Perceived colors for
+            // image and gradient themes can be tuned independently in a follow-up.
+            return "#888888";
         }
         /*
         public override preRenderBlackSVG(

--- a/test/unit_tests/GobanCanvas.test.ts
+++ b/test/unit_tests/GobanCanvas.test.ts
@@ -122,6 +122,57 @@ function selectedThemesWithoutStoneScale(): GobanSelectedThemes {
     return themes as GobanSelectedThemes;
 }
 
+function customStoneThemes(): GobanSelectedThemes {
+    return {
+        ...selectedThemes("Kaya"),
+        black: "Custom",
+        white: "Custom",
+    };
+}
+
+describe("theme colors", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+
+        callbacks.getSelectedThemes = customStoneThemes;
+        callbacks.customBlackStoneColor = () => "#112233";
+        callbacks.customBlackTextColor = () => "#aabbcc";
+        callbacks.customWhiteStoneColor = () => "#ddeeff";
+        callbacks.customWhiteTextColor = () => "#334455";
+        callbacks.customBlackStoneUrl = () => "";
+        callbacks.customWhiteStoneUrl = () => "";
+    });
+
+    afterEach(() => {
+        delete callbacks.getSelectedThemes;
+        delete callbacks.customBlackStoneColor;
+        delete callbacks.customBlackTextColor;
+        delete callbacks.customWhiteStoneColor;
+        delete callbacks.customWhiteTextColor;
+        delete callbacks.customBlackStoneUrl;
+        delete callbacks.customWhiteStoneUrl;
+        board_div.remove();
+    });
+
+    test("keeps perceived stone colors separate from marker colors", () => {
+        const goban = new GobanCanvas(basic3x3Config());
+        const colors = goban as unknown as {
+            theme_black_stone_color: string;
+            theme_black_text_color: string;
+            theme_white_stone_color: string;
+            theme_white_text_color: string;
+        };
+
+        expect(colors.theme_black_stone_color).toBe("#112233");
+        expect(colors.theme_black_text_color).toBe("#aabbcc");
+        expect(colors.theme_white_stone_color).toBe("#ddeeff");
+        expect(colors.theme_white_text_color).toBe("#334455");
+
+        goban.destroy();
+    });
+});
+
 describe("stone scale", () => {
     beforeEach(() => {
         board_div = document.createElement("div");

--- a/test/unit_tests/GobanSVG.test.ts
+++ b/test/unit_tests/GobanSVG.test.ts
@@ -114,6 +114,55 @@ function selectedThemesWithoutStoneScale(): GobanSelectedThemes {
     return themes as GobanSelectedThemes;
 }
 
+function customStoneThemes(): GobanSelectedThemes {
+    return {
+        ...selectedThemes(),
+        black: "Custom",
+        white: "Custom",
+    };
+}
+
+describe("theme colors", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+
+        callbacks.getSelectedThemes = customStoneThemes;
+        callbacks.customBlackStoneColor = () => "#112233";
+        callbacks.customBlackTextColor = () => "#aabbcc";
+        callbacks.customWhiteStoneColor = () => "#ddeeff";
+        callbacks.customWhiteTextColor = () => "#334455";
+        callbacks.customBlackStoneUrl = () => "";
+        callbacks.customWhiteStoneUrl = () => "";
+    });
+
+    afterEach(() => {
+        delete callbacks.getSelectedThemes;
+        delete callbacks.customBlackStoneColor;
+        delete callbacks.customBlackTextColor;
+        delete callbacks.customWhiteStoneColor;
+        delete callbacks.customWhiteTextColor;
+        delete callbacks.customBlackStoneUrl;
+        delete callbacks.customWhiteStoneUrl;
+        board_div.remove();
+    });
+
+    test("uses marker colors for stone symbols and stone colors for ownership", () => {
+        const goban = new SVGRenderer(basic3x3Config());
+        goban.cell(0, 0).lastMove("o", goban.theme_black_text_color, 1);
+        goban.cell(1, 0).scoreEstimate("white", 1);
+        const svg = (goban as unknown as { svg: SVGSVGElement }).svg;
+
+        const last_move = svg.querySelector<SVGElement>(".last-move");
+        const white_ownership = svg.querySelector<SVGRectElement>('rect[fill="#ddeeff"]');
+
+        expect(last_move?.getAttribute("stroke")).toBe("#aabbcc");
+        expect(white_ownership).not.toBeNull();
+
+        goban.destroy();
+    });
+});
+
 describe("stone scale", () => {
     beforeEach(() => {
         board_div = document.createElement("div");


### PR DESCRIPTION
Separating the stone marker and dead stone allows custom themes to avoid making a tradeoff when choosing the same color for the marker and territory squares that appear on board and over dead stones. Markers and territory markers also serve different semantics and needs - one just has to look good, and the other has to be clearly related to opponent's color.

TLDR: make this look possible - the marker colors look good on the stones in the preview, and the territory looks good too
<img width="902" height="773" alt="image" src="https://github.com/user-attachments/assets/18d64c10-445c-435e-8eee-b431d4a03d0b" />

Currently setting colors that are best for markers works poorly for the territory - screenshot taken from upstream, with the same palette
<img width="917" height="766" alt="image" src="https://github.com/user-attachments/assets/de66e88a-10df-45a1-9f71-da0549132f77" />

## Proposed Changes
- Introduce `theme_(black|white)_stone_color` that represents the flat color for the stone, including themes rendered from images or gradients.
- Keep `theme_(black|white)_text_color` exclusively for content drawn on stones, including last-move indicators, review marks, labels, and move-tree numbers.
- Use the corresponding stone color for ownership graphics: `theme_(black|white)_stone_color`. This includes dead-stone removal graphics, territory markers, and score-estimation squares.
- Override the Night theme’s representative stone colors to preserve its existing ownership-marker appearance. Other image and gradient themes can tune these values independently in follow-up changes.

Stone and marker appearance remain unchanged until the users update the marker-color preference. The change to `getWhiteStoneColor` for the Night theme preserves the current look by overriding the default pure black&white.

See the corresponding https://github.com/online-go/online-go.com/pull/3623