### PR TITLE
Stop reading window.user to decide analysis availability

### DIFF
--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -540,11 +540,17 @@ export abstract class GobanInteractive extends GobanBase {
         }
         return {};
     }
+    /**
+     * Whether analysis is disabled for the current viewer. The host
+     * application decides through the isAnalysisDisabled callback (typically
+     * exempting spectators from the per-game setting); without a callback the
+     * per-game setting applies to everyone.
+     */
     public isAnalysisDisabled(perGameSettingAppliesToNonPlayers: boolean = false): boolean {
         if (callbacks.isAnalysisDisabled) {
             return callbacks.isAnalysisDisabled(this, perGameSettingAppliesToNonPlayers);
         }
-        return false;
+        return !!this.engine.config.disable_analysis;
     }
 
     protected getLocation(): string {
@@ -1302,9 +1308,9 @@ export abstract class GobanInteractive extends GobanBase {
         }
 
         if (
-            this.engine.config.disable_analysis &&
+            (mode === "analyze" || mode === "conditional") &&
             this.engine.phase !== "finished" &&
-            (mode === "analyze" || mode === "conditional")
+            this.isAnalysisDisabled()
         ) {
             try {
                 swal.fire("Unable to enter " + mode + " mode");

--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -629,20 +629,7 @@ export class GobanEngine extends BoardState {
 
         this.rengo_casual_mode = config.rengo_casual_mode || false;
 
-        try {
-            this.config.original_disable_analysis = this.config.disable_analysis;
-            if (
-                typeof window !== "undefined" &&
-                typeof (window as any)["user"] !== "undefined" &&
-                (window as any)["user"] &&
-                !this.isParticipant((window as any)["user"].id)
-            ) {
-                this.disable_analysis = false;
-                this.config.disable_analysis = false;
-            }
-        } catch (e) {
-            console.log(e);
-        }
+        this.config.original_disable_analysis = this.config.disable_analysis;
 
         this.player = 1;
 

--- a/test/unit_tests/disable_analysis.test.ts
+++ b/test/unit_tests/disable_analysis.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GobanEngine } from "engine";
+import { TestGoban } from "../../src/Goban/TestGoban";
+import { callbacks } from "../../src/Goban/callbacks";
+
+const GAME_CONFIG = {
+    width: 9,
+    height: 9,
+    players: {
+        black: { id: 111, username: "black-player" },
+        white: { id: 222, username: "white-player" },
+    },
+    disable_analysis: true,
+    phase: "play" as const,
+};
+
+afterEach(() => {
+    delete callbacks.isAnalysisDisabled;
+    delete (window as { user?: unknown }).user;
+});
+
+describe("GobanEngine disable_analysis", () => {
+    test("preserves the per-game setting regardless of window.user", () => {
+        (window as { user?: unknown }).user = { id: 999, username: "spectator" };
+        const engine = new GobanEngine({ ...GAME_CONFIG });
+
+        expect(engine.disable_analysis).toBe(true);
+        expect(engine.config.disable_analysis).toBe(true);
+        expect(engine.config.original_disable_analysis).toBe(true);
+    });
+
+    test("records original_disable_analysis", () => {
+        const engine = new GobanEngine({ ...GAME_CONFIG, disable_analysis: false });
+
+        expect(engine.config.original_disable_analysis).toBe(false);
+    });
+});
+
+describe("setMode analysis gating", () => {
+    test("blocks analyze mode by the per-game setting when no callback is set", () => {
+        const goban = new TestGoban({ ...GAME_CONFIG });
+
+        expect(goban.setMode("analyze")).toBe(false);
+        expect(goban.mode).toBe("play");
+    });
+
+    test("allows analyze mode when the game does not disable analysis", () => {
+        const goban = new TestGoban({ ...GAME_CONFIG, disable_analysis: false });
+
+        expect(goban.setMode("analyze")).toBe(true);
+    });
+
+    test("allows analyze mode in finished games", () => {
+        const goban = new TestGoban({ ...GAME_CONFIG, phase: "finished" });
+
+        expect(goban.setMode("analyze")).toBe(true);
+    });
+
+    test("defers to the isAnalysisDisabled callback when set", () => {
+        const goban = new TestGoban({ ...GAME_CONFIG });
+
+        callbacks.isAnalysisDisabled = () => false;
+        expect(goban.setMode("analyze")).toBe(true);
+
+        goban.setMode("play");
+        callbacks.isAnalysisDisabled = () => true;
+        expect(goban.setMode("analyze")).toBe(false);
+    });
+});


### PR DESCRIPTION
Companion to online-go/online-go.com#3674 (fixes online-go/online-go.com#1765 at the root).

## Problem

`GobanEngine` cleared `disable_analysis` in its constructor when `window.user` was not a participant (the "spectators may always analyze" rule). That has two problems:

- It is a one-time snapshot of a window global taken at construction, stored in a `readonly` field. When the engine is constructed before the host application has finished loading the logged-in user (e.g. a stale-cache session on OGS), a player is mistaken for a spectator and analysis stays force-enabled until a refresh.
- The engine is cross-platform code and shouldn't be reaching into `window` at all.

## Changes

- `GobanEngine`: no longer touches `window.user`. `disable_analysis` now always reflects the per-game setting, and `original_disable_analysis` is still recorded for compatibility.
- `InteractiveBase.setMode`: the analyze/conditional gate now goes through `isAnalysisDisabled()` instead of reading `engine.config.disable_analysis` directly, so the decision is made at call time.
- `InteractiveBase.isAnalysisDisabled()`: when no `isAnalysisDisabled` callback is registered, it now falls back to the per-game setting instead of `false`. The host application's callback remains the place to implement viewer-specific policy such as exempting spectators (OGS already does this in `configure-goban.tsx`).

No callback API changes were needed — the existing `isAnalysisDisabled` callback already receives the goban and is evaluated at call time.

## Behavior notes

- With the callback registered (OGS): participants in no-analysis games are blocked, spectators are not — same intended behavior as before, but evaluated with the current user instead of a construction-time snapshot.
- Without a callback: the per-game setting applies to everyone, which matches the previous effective behavior for embedders where `window.user` was undefined.

## Testing

- New `test/unit_tests/disable_analysis.test.ts` covering the engine no longer mutating the setting, and the `setMode` gate with and without the callback.
- Full suite: 368 tests pass; lint, prettier, and production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015d6fFFvu5MQMWMEDAfJFqi