### PR TITLE
Add GobanNativeBridge renderer backend and a goban/engine entry point

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,19 @@ SLACK_WEBHOOK=$(shell cat ~/meta/ogs/Makefile | grep SLACK_WEBHOOK= | cut -d '='
 all dev: 
 	yarn run dev
 	
-build: build-debug build-production
+build: build-debug build-production dts-engine
 	cp src/Goban.css build/Goban.css
-	
+
 build-debug:
 	yarn run build-debug
 
 build-production:
 	yarn run build-production
+
+# The package.json "./engine" export points its types at this generated
+# bundle; it is gitignored, so every build/publish must (re)generate it.
+dts-engine:
+	yarn run dts-engine
 
 
 lint:
@@ -91,5 +96,5 @@ upload_to_cdn: set-versions
 	cp build/goban.min.js* deployment-staging-area
 	gsutil -m rsync -r deployment-staging-area/ gs://ogs-site-files/goban/`node -pe 'JSON.parse(require("fs").readFileSync("package.json")).version'`/
 
-.PHONY: doc build docs test clean all dev typedoc publish push build publish-production upload_to_cdn notify beta beta_npm publish-beta publish_docs build-debug build-production detect-duplicate-code duplicate-code-detection lint
+.PHONY: doc build docs test clean all dev typedoc publish push build publish-production upload_to_cdn notify beta beta_npm publish-beta publish_docs build-debug build-production dts-engine detect-duplicate-code duplicate-code-detection lint
  

--- a/package.json
+++ b/package.json
@@ -4,8 +4,21 @@
     "description": "",
     "main": "build/goban.js",
     "types": "build/src/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./build/src/index.d.ts",
+            "default": "./build/goban.js"
+        },
+        "./engine": {
+            "types": "./engine/goban-engine.d.ts",
+            "default": "./engine/build/goban-engine.js"
+        },
+        "./package.json": "./package.json"
+    },
     "files": [
-        "build/"
+        "build/",
+        "engine/build/",
+        "engine/goban-engine.d.ts"
     ],
     "keywords": [
         "go",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
             "types": "./engine/goban-engine.d.ts",
             "default": "./engine/build/goban-engine.js"
         },
+        "./build/*": "./build/*",
         "./package.json": "./package.json"
     },
     "files": [

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -104,7 +104,9 @@ export interface GobanCanvasInterface {
 export class GobanCanvas extends Goban implements GobanCanvasInterface {
     public engine: GobanEngine;
     //private board_div: HTMLElement;
-    private board: HTMLCanvasElement;
+    /** Protected so the GobanNativeBridge subclass can measure and
+     *  show/hide the canvas when swapping in the native draw layer. */
+    protected board: HTMLCanvasElement;
     private __set_board_height: number = -1;
     private __set_board_width: number = -1;
     private ready_to_draw: boolean = false;
@@ -112,7 +114,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private message_td?: HTMLElement;
     private message_text?: HTMLDivElement;
     private message_timeout?: number;
-    private shadow_layer?: HTMLCanvasElement;
+    /** Protected for GobanNativeBridge (see `board`). */
+    protected shadow_layer?: HTMLCanvasElement;
     private shadow_ctx?: CanvasRenderingContext2D;
     private grid_layer?: HTMLCanvasElement;
     private grid_ctx?: CanvasRenderingContext2D;
@@ -152,19 +155,22 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         "stone-scale": 1.0,
         "stone-shadows": "default",
     };
-    private theme_black!: GobanTheme;
+    /** Protected so GobanNativeBridge can resolve theme colors. */
+    protected theme_black!: GobanTheme;
     private theme_black_stone_color: string = HOT_PINK;
     private theme_black_stones: Array<any> = [];
     private theme_black_text_color: string = HOT_PINK;
     private theme_blank_text_color: string = HOT_PINK;
-    private theme_board!: GobanTheme;
+    /** Protected so GobanNativeBridge can resolve theme colors. */
+    protected theme_board!: GobanTheme;
     private theme_faded_line_color: string = HOT_PINK;
     private theme_faded_star_color: string = HOT_PINK;
     //private theme_faded_text_color:string;
     private theme_line_color: string = "";
     private theme_star_color: string = "";
     private theme_stone_radius: number = 10;
-    private theme_white!: GobanTheme;
+    /** Protected so GobanNativeBridge can resolve theme colors. */
+    protected theme_white!: GobanTheme;
     private theme_white_stone_color: string = HOT_PINK;
     private theme_white_stones: Array<any> = [];
     private theme_white_text_color: string = HOT_PINK;

--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -104,8 +104,8 @@ export interface GobanCanvasInterface {
 export class GobanCanvas extends Goban implements GobanCanvasInterface {
     public engine: GobanEngine;
     //private board_div: HTMLElement;
-    /** Protected so the GobanNativeBridge subclass can measure and
-     *  show/hide the canvas when swapping in the native draw layer. */
+    /** Protected so the GobanNativeBridge subclass can measure it: the
+     *  native draw layer is anchored to this canvas's rect. */
     protected board: HTMLCanvasElement;
     private __set_board_height: number = -1;
     private __set_board_width: number = -1;
@@ -114,8 +114,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     private message_td?: HTMLElement;
     private message_text?: HTMLDivElement;
     private message_timeout?: number;
-    /** Protected for GobanNativeBridge (see `board`). */
-    protected shadow_layer?: HTMLCanvasElement;
+    private shadow_layer?: HTMLCanvasElement;
     private shadow_ctx?: CanvasRenderingContext2D;
     private grid_layer?: HTMLCanvasElement;
     private grid_ctx?: CanvasRenderingContext2D;
@@ -288,6 +287,32 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         this.removeMoveTreeFromDOM();
         delete this.move_tree_container;
         delete this.title_div;
+    }
+    /**
+     * Show or hide every DOM layer that paints the web board.
+     *
+     * Protected for GobanNativeBridge, which hides the whole stack while
+     * the native draw layer owns the pixels. The stack is recomputed on
+     * each call rather than captured once: the shadow, themed grid
+     * background and crosshair layers all attach lazily, so a layer can
+     * appear long after the native view went active. It deliberately
+     * excludes the message overlay, which stays visible over the board.
+     */
+    protected setBoardLayersVisible(visible: boolean): void {
+        const visibility = visible ? "" : "hidden";
+        const layers: Array<HTMLElement | undefined> = [
+            this.grid_background_layer,
+            this.grid_layer,
+            this.crosshair_layer,
+            this.shadow_layer,
+            this.pen_layer,
+            this.board,
+        ];
+        for (const layer of layers) {
+            if (layer && layer.style.visibility !== visibility) {
+                layer.style.visibility = visibility;
+            }
+        }
     }
     private detachShadowLayer(): void {
         if (this.shadow_layer) {

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -178,7 +178,7 @@ export class GobanNativeBridge extends GobanCanvas {
         if (this.native_state === "active" && this.native_transport) {
             const transport = this.native_transport;
             this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
-                () => undefined,
+                () => this.recoverFromActiveTransportFailure("resume"),
             );
         }
         this.scheduleNativeSync();
@@ -441,11 +441,27 @@ export class GobanNativeBridge extends GobanCanvas {
         this.pushNativeUpdate();
         if (!this.native_overlay_suspended) {
             this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
-                () => undefined,
+                () => this.recoverFromActiveTransportFailure("resume"),
             );
         }
         this.setCanvasVisible(false);
         this.nativeLog("board v1-serviceable again; native view re-engaged");
+    }
+
+    /**
+     * A transport rejection while the native view owns the pixels must
+     * never be swallowed: the native bitmap would silently freeze over a
+     * hidden canvas with no recovery path. Show the canvas immediately and
+     * re-probe with a fresh attach (the reattach path): transient failures
+     * recover on the next sync, persistent ones surface as an attach
+     * rejection and become a permanent canvas fallback.
+     */
+    private recoverFromActiveTransportFailure(label: string): void {
+        if (this.destroyed || this.native_state !== "active") {
+            return;
+        }
+        this.nativeLog(`${label} rejected while active; showing canvas and re-probing`);
+        this.reattachNative();
     }
 
     private pushNativeUpdate(): void {
@@ -464,7 +480,9 @@ export class GobanNativeBridge extends GobanCanvas {
             return;
         }
         this.native_last_update_json = json;
-        this.enqueueNativeOp(() => transport.update(update), "update").catch(() => undefined);
+        this.enqueueNativeOp(() => transport.update(update), "update").catch(() =>
+            this.recoverFromActiveTransportFailure("update"),
+        );
     }
 
     private pushNativeGeometry(force: boolean = false): void {
@@ -486,7 +504,7 @@ export class GobanNativeBridge extends GobanCanvas {
         }
         this.native_last_rect = rect;
         this.enqueueNativeOp(() => transport.move({ id: this.nativeId(), rect }), "move").catch(
-            () => undefined,
+            () => this.recoverFromActiveTransportFailure("move"),
         );
     }
 

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -103,6 +103,12 @@ export class GobanNativeBridge extends GobanCanvas {
             this.on("update", () => this.scheduleNativeSync());
             this.on("mode", () => this.scheduleNativeSync());
             this.on("load", () => this.scheduleNativeSync());
+            /* "cur_move" is emitted on the *engine* emitter, but GobanEngine
+             * forwards every emit to the owning goban through
+             * `parentEventEmitter` (wired whenever load() creates an engine),
+             * so this listener is live -- including across engine swaps on
+             * "load" -- and covers move-tree navigation that does not go
+             * through set()/setState()/"update". */
             this.on("cur_move", () => this.scheduleNativeSync());
 
             if (typeof ResizeObserver !== "undefined") {

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -369,21 +369,29 @@ export class GobanNativeBridge extends GobanCanvas {
             return;
         }
         this.native_state = "attaching";
-        const size = this.engine.width;
-        const rect = this.measureNativeRect();
         this.enqueueNativeOp(async () => {
             if (this.destroyed || !this.native_transport) {
                 /* destroy() ran while this op was queued. */
                 return;
             }
+            /* Build the *entire* payload at op execution time: this op may
+             * have waited in the queue behind other transport calls, and
+             * the engine can be swapped or resized meanwhile (game loads,
+             * 19x19 -> 9x9). Capturing any field earlier would send a
+             * mismatched size/board pair the rim rightly rejects. */
+            const size = this.engine.width;
+            const rect = this.measureNativeRect();
+            const board = this.flattenBoard();
+            const color_to_move: 1 | 2 = this.engine.player === 2 ? 2 : 1;
+            const last_move = this.nativeLastMove();
             try {
                 await transport.attach({
                     id: this.nativeId(),
                     rect,
                     size,
-                    board: this.flattenBoard(),
-                    colorToMove: this.engine.player === 2 ? 2 : 1,
-                    lastMove: this.nativeLastMove(),
+                    board,
+                    colorToMove: color_to_move,
+                    lastMove: last_move,
                     interactive: this.interactive,
                     theme: this.resolveNativeTheme(),
                     showCoordinates:
@@ -398,7 +406,9 @@ export class GobanNativeBridge extends GobanCanvas {
                 }
                 /* Plugin absent/old rim/bad args: permanent canvas
                  * fallback for this instance (capability probe, never
-                 * version sniffing). */
+                 * version sniffing, per contract v1). Note the payload is
+                 * built at execution time above, so a rejection can no
+                 * longer be a stale size/rect racing the queue. */
                 this.native_state = "fallback";
                 this.setCanvasVisible(true);
                 this.nativeLog("attach rejected; falling back to canvas", err);
@@ -413,7 +423,15 @@ export class GobanNativeBridge extends GobanCanvas {
             this.native_state = "active";
             this.native_attached_size = size;
             this.native_last_rect = rect;
-            this.native_last_update_json = "";
+            /* The attach itself carried this exact state, so baseline the
+             * update dedup on it; the first post-attach sync would
+             * otherwise re-send the same board in a wasted round-trip. */
+            this.native_last_update_json = JSON.stringify({
+                id: this.nativeId(),
+                board,
+                colorToMove: color_to_move,
+                lastMove: last_move,
+            } satisfies NativeBridgeUpdateOptions);
             if (this.native_overlay_suspended) {
                 /* An overlay opened while we were attaching. The
                  * coordinator's suspendNativeView() resolved null before we

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -386,6 +386,23 @@ export class GobanNativeBridge extends GobanCanvas {
      * and circles, pen marks, non-square boards) falls back to the web
      * canvas; non-"play" engine phases (stone removal, finished) need
      * removal/score drawing, so they fall back too.
+     *
+     * `present_next_move` is the AI review's presented-move space, where
+     * the board shows a move that has not been played: a translucent stone
+     * at the current move's trunk_next, over a last-move ring dimmed to
+     * make room for it. Contract v1 models neither -- its `board` carries
+     * only played stones and its `lastMove` draws one fixed ring -- so a
+     * presented board is never serviceable. In practice the presented
+     * stone arrives as a mark and `hasMarks()` would catch it, but the flag
+     * is what actually means "not a plain board", and it also dims the ring
+     * on its own.
+     *
+     * The conditions below are the renderer's own `drawingHash()` -- the
+     * canonical list of everything that changes a drawn square -- minus
+     * what v1 carries. The one entry deliberately left out is the
+     * variation move number (`alt_marking`), which needs an off-trunk
+     * cur_move, and every mode that navigates off the trunk has already
+     * bailed on `mode === "play"`.
      */
     private isV1Serviceable(): boolean {
         const cur_move = this.engine.cur_move;
@@ -393,9 +410,16 @@ export class GobanNativeBridge extends GobanCanvas {
             this.mode === "play" &&
             this.engine.phase === "play" &&
             this.engine.width === this.engine.height &&
+            !this.present_next_move &&
             !this.scoring_mode &&
             !this.heatmap &&
             !this.colored_circles &&
+            /* An undo request draws a "?" over the moves it would take
+             * back -- live-game state, so this is the one bail here that
+             * the game page actually hits. */
+            !(this.engine.undo_requested !== undefined && this.getShowUndoRequestIndicator()) &&
+            /* Puzzle configs highlight the moves the move tree knows. */
+            !this.highlight_movetree_moves &&
             !(cur_move && cur_move.pen_marks && cur_move.pen_marks.length > 0) &&
             !(cur_move && cur_move.hasMarks())
         );

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -80,7 +80,12 @@ export class GobanNativeBridge extends GobanCanvas {
     private native_last_rect?: NativeBridgeRect;
     private native_last_update_json = "";
     private native_sync_scheduled = false;
-    private readonly native_window_listener = () => this.scheduleNativeSync();
+    /** True while the pending coalesced sync was requested only by
+     *  geometry sources (scroll/resize); lets the sync skip the board
+     *  flatten + serialize entirely. Any state-driven request upgrades
+     *  the pending sync to a full one. */
+    private native_sync_geometry_only = false;
+    private readonly native_window_listener = () => this.scheduleNativeSync(true);
 
     constructor(config: NativeBridgeGobanConfig, preloaded_data?: AdHocFormat | JGOF) {
         super(config, preloaded_data);
@@ -112,7 +117,9 @@ export class GobanNativeBridge extends GobanCanvas {
             this.on("cur_move", () => this.scheduleNativeSync());
 
             if (typeof ResizeObserver !== "undefined") {
-                this.native_resize_observer = new ResizeObserver(() => this.scheduleNativeSync());
+                this.native_resize_observer = new ResizeObserver(() =>
+                    this.scheduleNativeSync(true),
+                );
                 this.native_resize_observer.observe(this.board);
                 this.native_resize_observer.observe(this.parent);
             }
@@ -156,6 +163,12 @@ export class GobanNativeBridge extends GobanCanvas {
      * is still recorded, so a native view that attaches or re-engages while
      * the overlay is open stays hidden (with the canvas left visible as the
      * board) until {@link resumeNativeView}.
+     *
+     * Future note: the snapshot is a point-in-time capture; if the game
+     * state changes while the overlay is open, the displayed snapshot goes
+     * stale until resume (the native view itself is kept in sync). A later
+     * contract revision could refresh the snapshot on update-while-
+     * suspended if this becomes user-visible in practice.
      */
     public suspendNativeView(): Promise<string | null> {
         const transport = this.native_transport;
@@ -257,6 +270,11 @@ export class GobanNativeBridge extends GobanCanvas {
                 this.native_state === "attaching")
         ) {
             const transport = this.native_transport;
+            /* Future note: the detach is asynchronous, so when a successor
+             * goban attaches immediately (unmount/remount of the same game
+             * view) both native views can exist for a frame -- a brief
+             * dual-view, not corruption; detach is id-safe per the
+             * contract. Revisit only if it becomes visible in practice. */
             this.enqueueNativeOp(() => transport.detach({ id: this.nativeId() }), "detach").catch(
                 () => undefined,
             );
@@ -289,16 +307,23 @@ export class GobanNativeBridge extends GobanCanvas {
         return next;
     }
 
-    private scheduleNativeSync(): void {
-        if (!this.native_transport || this.native_sync_scheduled || this.destroyed) {
+    private scheduleNativeSync(geometry_only: boolean = false): void {
+        if (!this.native_transport || this.destroyed) {
+            return;
+        }
+        if (this.native_sync_scheduled) {
+            /* Coalesce: any full request upgrades a pending geometry-only
+             * sync. */
+            this.native_sync_geometry_only = this.native_sync_geometry_only && geometry_only;
             return;
         }
         this.native_sync_scheduled = true;
+        this.native_sync_geometry_only = geometry_only;
         Promise.resolve()
             .then(() => {
                 this.native_sync_scheduled = false;
                 if (!this.destroyed) {
-                    this.syncNative();
+                    this.syncNative(this.native_sync_geometry_only);
                 }
             })
             .catch((err) => this.nativeLog("sync failed", err));
@@ -307,7 +332,7 @@ export class GobanNativeBridge extends GobanCanvas {
     /** Single driver for the native state machine; coalesced to a
      *  microtask so bursts of renderer calls produce one transport
      *  round-trip. */
-    private syncNative(): void {
+    private syncNative(geometry_only: boolean = false): void {
         if (!this.native_transport || this.native_state === "fallback") {
             return;
         }
@@ -331,7 +356,9 @@ export class GobanNativeBridge extends GobanCanvas {
                     this.reattachNative();
                 } else {
                     this.pushNativeGeometry();
-                    this.pushNativeUpdate();
+                    if (!geometry_only) {
+                        this.pushNativeUpdate();
+                    }
                 }
                 return;
 
@@ -650,8 +677,10 @@ export class GobanNativeBridge extends GobanCanvas {
 
 /** Normalize a CSS color to six-digit hex where cheaply possible
  *  (contract: "six-digit hex preferred"); pass through anything a canvas
- *  cannot normalize (or when no 2d context is available, e.g. jsdom). */
-export function normalizeColor(color: string): string {
+ *  cannot normalize (or when no 2d context is available, e.g. jsdom).
+ *  Deliberately not exported: the name is far too generic for the
+ *  package's flat public API. */
+function normalizeColor(color: string): string {
     if (/^#[0-9a-fA-F]{6}$/.test(color)) {
         return color;
     }

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -372,6 +372,10 @@ export class GobanNativeBridge extends GobanCanvas {
         const size = this.engine.width;
         const rect = this.measureNativeRect();
         this.enqueueNativeOp(async () => {
+            if (this.destroyed || !this.native_transport) {
+                /* destroy() ran while this op was queued. */
+                return;
+            }
             try {
                 await transport.attach({
                     id: this.nativeId(),
@@ -389,12 +393,21 @@ export class GobanNativeBridge extends GobanCanvas {
                         this.draw_right_labels,
                 });
             } catch (err) {
+                if (this.destroyed) {
+                    return;
+                }
                 /* Plugin absent/old rim/bad args: permanent canvas
                  * fallback for this instance (capability probe, never
                  * version sniffing). */
                 this.native_state = "fallback";
                 this.setCanvasVisible(true);
                 this.nativeLog("attach rejected; falling back to canvas", err);
+                return;
+            }
+            if (this.destroyed) {
+                /* destroy() ran while attach was in flight; it already
+                 * queued a detach behind us, so just don't resurrect any
+                 * state (the board elements are gone). */
                 return;
             }
             this.native_state = "active";

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -21,6 +21,7 @@ import { JGOF } from "../engine/formats/JGOF";
 import { JGOFNumericPlayerColor } from "../engine/formats/JGOF";
 import {
     GobanNativeBridgeTransport,
+    NativeBridgeAttachOptions,
     NativeBridgeRect,
     NativeBridgeTheme,
     NativeBridgeUpdateOptions,
@@ -436,24 +437,29 @@ export class GobanNativeBridge extends GobanCanvas {
                 /* destroy() ran while this op was queued. */
                 return;
             }
-            /* Build the *entire* payload at op execution time: this op may
-             * have waited in the queue behind other transport calls, and
-             * the engine can be swapped or resized meanwhile (game loads,
-             * 19x19 -> 9x9). Capturing any field earlier would send a
-             * mismatched size/board pair the rim rightly rejects. */
-            const size = this.engine.width;
-            const rect = this.measureNativeRect();
-            const board = this.flattenBoard();
-            const color_to_move: 1 | 2 = this.engine.player === 2 ? 2 : 1;
-            const last_move = this.nativeLastMove();
+            let payload: NativeBridgeAttachOptions;
             try {
-                await transport.attach({
+                /* Build the *entire* payload at op execution time: this op
+                 * may have waited in the queue behind other transport
+                 * calls, and the engine can be swapped or resized meanwhile
+                 * (game loads, 19x19 -> 9x9). Capturing any field earlier
+                 * would send a mismatched size/board pair the rim rightly
+                 * rejects.
+                 *
+                 * Building it *inside* the try matters as much as building
+                 * it late. Measuring the rect or flattening a half-swapped
+                 * engine can throw, and an exception escaping this op would
+                 * strand native_state at "attaching" -- which syncNative()
+                 * reads as "an attach is already in flight" and returns on,
+                 * forever. The bridge would then never attach and never
+                 * fall back: silently dead for the life of the instance. */
+                payload = {
                     id: this.nativeId(),
-                    rect,
-                    size,
-                    board,
-                    colorToMove: color_to_move,
-                    lastMove: last_move,
+                    rect: this.measureNativeRect(),
+                    size: this.engine.width,
+                    board: this.flattenBoard(),
+                    colorToMove: this.engine.player === 2 ? 2 : 1,
+                    lastMove: this.nativeLastMove(),
                     interactive: this.interactive,
                     theme: this.resolveNativeTheme(),
                     showCoordinates:
@@ -461,19 +467,23 @@ export class GobanNativeBridge extends GobanCanvas {
                         this.draw_bottom_labels ||
                         this.draw_left_labels ||
                         this.draw_right_labels,
-                });
+                };
+                await transport.attach(payload);
             } catch (err) {
                 if (this.destroyed) {
                     return;
                 }
-                /* Plugin absent/old rim/bad args: permanent canvas
-                 * fallback for this instance (capability probe, never
-                 * version sniffing, per contract v1). Note the payload is
-                 * built at execution time above, so a rejection can no
-                 * longer be a stale size/rect racing the queue. */
+                /* Plugin absent, old rim, bad args -- or a payload we could
+                 * not build at all. Either way we cannot produce a valid
+                 * attach, so this instance takes the permanent canvas
+                 * fallback (capability probe, never version sniffing, per
+                 * contract v1); the canvas is a lossless stand-in, and
+                 * nothing was attached that would need detaching. Note the
+                 * payload is built at execution time above, so a rejection
+                 * can no longer be a stale size/rect racing the queue. */
                 this.native_state = "fallback";
                 this.setCanvasVisible(true);
-                this.nativeLog("attach rejected; falling back to canvas", err);
+                this.nativeLog("attach failed; falling back to canvas", err);
                 return;
             }
             if (this.destroyed) {
@@ -483,16 +493,17 @@ export class GobanNativeBridge extends GobanCanvas {
                 return;
             }
             this.native_state = "active";
-            this.native_attached_size = size;
-            this.native_last_rect = rect;
+            this.native_attached_size = payload.size;
+            this.native_last_rect = payload.rect;
             /* The attach itself carried this exact state, so baseline the
-             * update dedup on it; the first post-attach sync would
-             * otherwise re-send the same board in a wasted round-trip. */
+             * update dedup on it (read back off the payload we sent, so the
+             * two cannot drift); the first post-attach sync would otherwise
+             * re-send the same board in a wasted round-trip. */
             this.native_last_update_json = JSON.stringify({
-                id: this.nativeId(),
-                board,
-                colorToMove: color_to_move,
-                lastMove: last_move,
+                id: payload.id,
+                board: payload.board,
+                colorToMove: payload.colorToMove,
+                lastMove: payload.lastMove,
             } satisfies NativeBridgeUpdateOptions);
             if (this.native_overlay_suspended) {
                 /* An overlay opened while we were attaching. The

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -146,7 +146,10 @@ export class GobanNativeBridge extends GobanCanvas {
      * hide it, so site overlays (modals, popovers, the drawer) can stack
      * above the board. The caller places the snapshot in the DOM and calls
      * {@link resumeNativeView} when the overlay closes. Returns null when
-     * there is nothing to suspend (native view not active).
+     * there is nothing to suspend (native view not active); the suspension
+     * is still recorded, so a native view that attaches or re-engages while
+     * the overlay is open stays hidden (with the canvas left visible as the
+     * board) until {@link resumeNativeView}.
      */
     public suspendNativeView(): Promise<string | null> {
         const transport = this.native_transport;
@@ -180,6 +183,10 @@ export class GobanNativeBridge extends GobanCanvas {
             this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
                 () => this.recoverFromActiveTransportFailure("resume"),
             );
+            /* The canvas may have been left visible by a suspension that
+             * predated the attach/re-engage (no snapshot covered the board
+             * then); the native view owns the pixels again now. */
+            this.setCanvasVisible(false);
         }
         this.scheduleNativeSync();
     }
@@ -208,9 +215,11 @@ export class GobanNativeBridge extends GobanCanvas {
         if (!this.native_transport) {
             return;
         }
-        if (this.native_state === "active") {
+        if (this.native_state === "active" && !this.native_overlay_suspended) {
             /* setTheme may have re-created the shadow layer; keep it
-             * hidden while the native view owns the pixels. */
+             * hidden while the native view owns the pixels. (While an
+             * overlay suspension is in effect the canvas may be serving
+             * as the visible board, so leave it alone.) */
             this.setCanvasVisible(false);
         }
         if (this.native_state === "active" || this.native_state === "bailed") {
@@ -392,10 +401,16 @@ export class GobanNativeBridge extends GobanCanvas {
             this.native_attached_size = size;
             this.native_last_rect = rect;
             this.native_last_update_json = "";
-            this.setCanvasVisible(false);
             if (this.native_overlay_suspended) {
-                /* An overlay opened while we were attaching. */
+                /* An overlay opened while we were attaching. The
+                 * coordinator's suspendNativeView() resolved null before we
+                 * were active, so it has no snapshot covering the board:
+                 * hide the fresh native view but keep the canvas visible
+                 * as the board until resumeNativeView(). */
                 await transport.suspend({ id: this.nativeId() }).catch(() => undefined);
+                this.setCanvasVisible(true);
+            } else {
+                this.setCanvasVisible(false);
             }
             this.scheduleNativeSync();
         }, "attach").catch(() => undefined);
@@ -439,11 +454,17 @@ export class GobanNativeBridge extends GobanCanvas {
         this.native_last_update_json = "";
         this.pushNativeGeometry(true);
         this.pushNativeUpdate();
-        if (!this.native_overlay_suspended) {
-            this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
-                () => this.recoverFromActiveTransportFailure("resume"),
-            );
+        if (this.native_overlay_suspended) {
+            /* An overlay is open: the native view stays hidden and the
+             * canvas stays visible as the board until resumeNativeView()
+             * (the coordinator has no snapshot covering us -- its suspend
+             * resolved null while we were bailed). */
+            this.nativeLog("board v1-serviceable again; native re-engage deferred to resume");
+            return;
         }
+        this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(() =>
+            this.recoverFromActiveTransportFailure("resume"),
+        );
         this.setCanvasVisible(false);
         this.nativeLog("board v1-serviceable again; native view re-engaged");
     }

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -85,6 +85,9 @@ export class GobanNativeBridge extends GobanCanvas {
      *  flatten + serialize entirely. Any state-driven request upgrades
      *  the pending sync to a full one. */
     private native_sync_geometry_only = false;
+    /** Which way {@link applyCanvasVisibility} should currently drive the
+     *  web board's layer stack. */
+    private native_canvas_hidden = false;
     private readonly native_window_listener = () => this.scheduleNativeSync(true);
 
     constructor(config: NativeBridgeGobanConfig, preloaded_data?: AdHocFormat | JGOF) {
@@ -336,6 +339,8 @@ export class GobanNativeBridge extends GobanCanvas {
         if (!this.native_transport || this.native_state === "fallback") {
             return;
         }
+        /* Catch up any board layer that attached since the last sync. */
+        this.applyCanvasVisibility();
         const serviceable = this.isV1Serviceable();
 
         switch (this.native_state) {
@@ -667,11 +672,21 @@ export class GobanNativeBridge extends GobanCanvas {
     }
 
     private setCanvasVisible(visible: boolean): void {
-        const visibility = visible ? "" : "hidden";
-        this.board.style.visibility = visibility;
-        if (this.shadow_layer) {
-            this.shadow_layer.style.visibility = visibility;
-        }
+        this.native_canvas_hidden = !visible;
+        this.applyCanvasVisibility();
+    }
+
+    /**
+     * Push the recorded canvas visibility onto the renderer's layer stack.
+     *
+     * Re-applied on every sync rather than only on transitions: the board
+     * is drawn across several lazily-attached layers (shadows, the themed
+     * grid background, the last-move crosshair), any of which can appear
+     * after we hid the ones that existed at the time -- and an unhidden
+     * layer would keep painting a full board underneath the native view.
+     */
+    private applyCanvasVisibility(): void {
+        this.setBoardLayersVisible(!this.native_canvas_hidden);
     }
 }
 

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -202,13 +202,14 @@ export class GobanNativeBridge extends GobanCanvas {
         this.native_overlay_suspended = false;
         if (this.native_state === "active" && this.native_transport) {
             const transport = this.native_transport;
-            this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
-                () => this.recoverFromActiveTransportFailure("resume"),
-            );
-            /* The canvas may have been left visible by a suspension that
-             * predated the attach/re-engage (no snapshot covered the board
-             * then); the native view owns the pixels again now. */
-            this.setCanvasVisible(false);
+            this.enqueueNativeOp(async () => {
+                await transport.resume({ id: this.nativeId() });
+                /* The canvas may have been left visible by a suspension
+                 * that predated the attach/re-engage (no snapshot covered
+                 * the board then); only now does the native view own the
+                 * pixels again. */
+                this.hideCanvasBehindNativeView();
+            }, "resume").catch(() => this.recoverFromActiveTransportFailure("resume"));
         }
         this.scheduleNativeSync();
     }
@@ -237,13 +238,12 @@ export class GobanNativeBridge extends GobanCanvas {
         if (!this.native_transport) {
             return;
         }
-        if (this.native_state === "active" && !this.native_overlay_suspended) {
-            /* setTheme may have re-created the shadow layer; keep it
-             * hidden while the native view owns the pixels. (While an
-             * overlay suspension is in effect the canvas may be serving
-             * as the visible board, so leave it alone.) */
-            this.setCanvasVisible(false);
-        }
+        /* setTheme may have re-created the shadow layer, but there is
+         * nothing to decide here: the scheduleNativeSync() below re-applies
+         * the recorded canvas visibility across the whole layer stack,
+         * including anything just re-created. Re-deriving it here would
+         * only get it wrong -- the canvas is the visible board whenever a
+         * suspend is uncovered or a resume is still in flight. */
         if (this.native_state === "active" || this.native_state === "bailed") {
             const transport = this.native_transport;
             this.enqueueNativeOp(
@@ -531,11 +531,13 @@ export class GobanNativeBridge extends GobanCanvas {
             this.nativeLog("board v1-serviceable again; native re-engage deferred to resume");
             return;
         }
-        this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(() =>
-            this.recoverFromActiveTransportFailure("resume"),
-        );
-        this.setCanvasVisible(false);
-        this.nativeLog("board v1-serviceable again; native view re-engaged");
+        /* The canvas has been the board since bailToCanvas(); it stays up
+         * until the resume lands, below. */
+        this.enqueueNativeOp(async () => {
+            await transport.resume({ id: this.nativeId() });
+            this.hideCanvasBehindNativeView();
+        }, "resume").catch(() => this.recoverFromActiveTransportFailure("resume"));
+        this.nativeLog("board v1-serviceable again; native view re-engaging");
     }
 
     /**
@@ -669,6 +671,28 @@ export class GobanNativeBridge extends GobanCanvas {
             // jsdom and detached elements: fall through to the default
         }
         return "#000000";
+    }
+
+    /**
+     * Hide the web canvas now that a completed transport op has left the
+     * native view owning the pixels.
+     *
+     * Hiding is the one direction that can blank the board, so it may only
+     * ever run once the native view is confirmed visible -- between a
+     * suspend and a *resolved* resume, neither board is on screen.
+     * (Showing the canvas is always safe to do eagerly: the native view
+     * composites above the web content, so an extra web board underneath
+     * it is invisible, never blank.)
+     *
+     * Guarded because the op queue is asynchronous: destroy() or a bail
+     * back to the canvas can land while the resume is still in flight, and
+     * both of those want the canvas left alone.
+     */
+    private hideCanvasBehindNativeView(): void {
+        if (this.destroyed || this.native_state !== "active") {
+            return;
+        }
+        this.setCanvasVisible(false);
     }
 
     private setCanvasVisible(visible: boolean): void {

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -1,0 +1,603 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GobanCanvas, CanvasRendererGobanConfig } from "./CanvasRenderer";
+import { GobanSelectedThemes } from "./Goban";
+import { AdHocFormat } from "../engine/formats/AdHocFormat";
+import { JGOF } from "../engine/formats/JGOF";
+import { JGOFNumericPlayerColor } from "../engine/formats/JGOF";
+import {
+    GobanNativeBridgeTransport,
+    NativeBridgeRect,
+    NativeBridgeTheme,
+    NativeBridgeUpdateOptions,
+} from "./NativeBridgeTransport";
+
+export interface NativeBridgeGobanConfig extends CanvasRendererGobanConfig {
+    /** Injected platform transport (see NativeBridgeTransport.ts). When
+     *  absent the bridge behaves exactly like the canvas renderer. */
+    native_transport?: GobanNativeBridgeTransport;
+}
+
+/**
+ * The lifecycle of the native side of one bridge instance:
+ *
+ * - "pending":   transport present, native view not created yet (waiting
+ *                for the board to be v1-serviceable).
+ * - "attaching": `attach()` in flight.
+ * - "active":    native view visible; the web canvas is kept in sync but
+ *                hidden underneath it.
+ * - "bailed":    the board needs something contract v1 cannot draw (marks,
+ *                analysis, score states, non-square, ...); the native view
+ *                is hidden and the always-current web canvas is shown. The
+ *                bridge re-engages automatically when the board becomes
+ *                serviceable again (e.g. leaving analyze mode).
+ * - "fallback":  permanent web canvas for this instance (no transport,
+ *                attach rejected, or the instance was destroyed).
+ */
+export type NativeBridgeState = "pending" | "attaching" | "active" | "bailed" | "fallback";
+
+/**
+ * Renderer backend that drives a native (out-of-DOM) draw layer through an
+ * injected {@link GobanNativeBridgeTransport}, per the GobanNative plugin
+ * contract v1.
+ *
+ * Design: the bridge *extends the web canvas renderer* rather than
+ * replacing it. The canvas stays fully functional (and fully in sync) at
+ * all times -- it is merely hidden while the native view is active. This
+ * makes the contract-mandated capability fallback trivial and lossless:
+ * anything v1 native cannot draw simply unhides the canvas and hides the
+ * native view, with no re-construction and no state transfer. Input from
+ * the native side (`intentPlace`) is routed through `tapAt()`, the exact
+ * entry point a canvas tap uses, so the engine treats both identically.
+ */
+export class GobanNativeBridge extends GobanCanvas {
+    private native_transport?: GobanNativeBridgeTransport;
+    private native_state: NativeBridgeState = "fallback";
+    /** True while the embedding app has suspended the native view so DOM
+     *  overlays (modals, popovers, drawer) can stack above the board. */
+    private native_overlay_suspended = false;
+    /** Serial queue for transport calls, so attach/update/suspend/...
+     *  never race each other. */
+    private native_op_queue: Promise<void> = Promise.resolve();
+    private native_unsubscribe_intent?: () => void;
+    private native_resize_observer?: ResizeObserver;
+    private native_window_listeners_bound = false;
+    private native_attached_size = 0;
+    private native_last_rect?: NativeBridgeRect;
+    private native_last_update_json = "";
+    private native_sync_scheduled = false;
+    private readonly native_window_listener = () => this.scheduleNativeSync();
+
+    constructor(config: NativeBridgeGobanConfig, preloaded_data?: AdHocFormat | JGOF) {
+        super(config, preloaded_data);
+
+        if (config.native_transport && !this.no_display) {
+            this.native_transport = config.native_transport;
+            this.native_state = "pending";
+
+            this.native_unsubscribe_intent = this.native_transport.onIntentPlace((event) => {
+                if (event.id !== this.nativeId() || this.native_state !== "active") {
+                    return;
+                }
+                /* Exactly the code path a canvas tap takes; the engine
+                 * decides everything. */
+                this.tapAt(event.x, event.y, false);
+            });
+
+            /* Renderer-level changes that don't flow through set()/
+             * setState()/redraw() overrides. */
+            this.on("update", () => this.scheduleNativeSync());
+            this.on("mode", () => this.scheduleNativeSync());
+            this.on("load", () => this.scheduleNativeSync());
+            this.on("cur_move", () => this.scheduleNativeSync());
+
+            if (typeof ResizeObserver !== "undefined") {
+                this.native_resize_observer = new ResizeObserver(() => this.scheduleNativeSync());
+                this.native_resize_observer.observe(this.board);
+                this.native_resize_observer.observe(this.parent);
+            }
+            if (typeof window !== "undefined") {
+                window.addEventListener("resize", this.native_window_listener);
+                window.addEventListener("scroll", this.native_window_listener, { passive: true });
+                this.native_window_listeners_bound = true;
+            }
+
+            this.scheduleNativeSync();
+        }
+    }
+
+    /* ------------ public surface used by the embedding app ------------ */
+
+    /** True when the native view is currently the visible board. */
+    public get nativeBoardActive(): boolean {
+        return this.native_state === "active";
+    }
+
+    /** Terminal-state inspection, primarily for tests and diagnostics. */
+    public get nativeBridgeState(): NativeBridgeState {
+        return this.native_state;
+    }
+
+    /** The native view's content-coordinate rect (CSS px), or null when
+     *  the native view is not attached. */
+    public nativeBoardRect(): NativeBridgeRect | null {
+        if (this.native_state !== "active" && this.native_state !== "bailed") {
+            return null;
+        }
+        return this.native_last_rect ?? null;
+    }
+
+    /**
+     * Overlay coordination: snapshot the native view as a PNG data-URL and
+     * hide it, so site overlays (modals, popovers, the drawer) can stack
+     * above the board. The caller places the snapshot in the DOM and calls
+     * {@link resumeNativeView} when the overlay closes. Returns null when
+     * there is nothing to suspend (native view not active).
+     */
+    public suspendNativeView(): Promise<string | null> {
+        const transport = this.native_transport;
+        if (!transport || this.native_state === "fallback") {
+            return Promise.resolve(null);
+        }
+        const was_suspended = this.native_overlay_suspended;
+        /* Record the suspension in every non-fallback state so a native
+         * view that attaches/re-engages while an overlay is open stays
+         * hidden until resumeNativeView(). */
+        this.native_overlay_suspended = true;
+        if (this.native_state !== "active" || was_suspended) {
+            return Promise.resolve(null);
+        }
+        return new Promise<string | null>((resolve) => {
+            this.enqueueNativeOp(async () => {
+                const { snapshot } = await transport.suspend({ id: this.nativeId() });
+                resolve(snapshot);
+            }, "suspend").catch(() => resolve(null));
+        });
+    }
+
+    /** Show the native view again after {@link suspendNativeView}. */
+    public resumeNativeView(): void {
+        if (!this.native_overlay_suspended) {
+            return;
+        }
+        this.native_overlay_suspended = false;
+        if (this.native_state === "active" && this.native_transport) {
+            const transport = this.native_transport;
+            this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
+                () => undefined,
+            );
+        }
+        this.scheduleNativeSync();
+    }
+
+    /* --------------------- renderer overrides --------------------- */
+
+    public override set(x: number, y: number, player: JGOFNumericPlayerColor): void {
+        super.set(x, y, player);
+        this.scheduleNativeSync();
+    }
+
+    public override setState(): void {
+        super.setState();
+        this.scheduleNativeSync();
+    }
+
+    public override redraw(force_clear?: boolean): void {
+        super.redraw(force_clear);
+        this.scheduleNativeSync();
+    }
+
+    public override setTheme(themes: GobanSelectedThemes, dont_redraw: boolean): void {
+        super.setTheme(themes, dont_redraw);
+        /* setTheme runs during the super() constructor, before our fields
+         * exist; the post-construction scheduleNativeSync covers that. */
+        if (!this.native_transport) {
+            return;
+        }
+        if (this.native_state === "active") {
+            /* setTheme may have re-created the shadow layer; keep it
+             * hidden while the native view owns the pixels. */
+            this.setCanvasVisible(false);
+        }
+        if (this.native_state === "active" || this.native_state === "bailed") {
+            const transport = this.native_transport;
+            this.enqueueNativeOp(
+                () => transport.setTheme({ id: this.nativeId(), theme: this.resolveNativeTheme() }),
+                "setTheme",
+            ).catch(() => undefined);
+        }
+        this.scheduleNativeSync();
+    }
+
+    public override destroy(): void {
+        if (this.native_unsubscribe_intent) {
+            this.native_unsubscribe_intent();
+            delete this.native_unsubscribe_intent;
+        }
+        this.native_resize_observer?.disconnect();
+        delete this.native_resize_observer;
+        if (this.native_window_listeners_bound && typeof window !== "undefined") {
+            window.removeEventListener("resize", this.native_window_listener);
+            window.removeEventListener("scroll", this.native_window_listener);
+            this.native_window_listeners_bound = false;
+        }
+        if (
+            this.native_transport &&
+            (this.native_state === "active" ||
+                this.native_state === "bailed" ||
+                this.native_state === "attaching")
+        ) {
+            const transport = this.native_transport;
+            this.enqueueNativeOp(() => transport.detach({ id: this.nativeId() }), "detach").catch(
+                () => undefined,
+            );
+        }
+        this.native_state = "fallback";
+        delete this.native_transport;
+        super.destroy();
+    }
+
+    /* ------------------------ internals ------------------------ */
+
+    private nativeId(): string {
+        return `goban-${this.goban_id}`;
+    }
+
+    private nativeLog(...args: unknown[]): void {
+        /* "silent, logged in dev" per the contract: debug level keeps
+         * production consoles clean. */
+        console.debug("[GobanNativeBridge]", ...args);
+    }
+
+    private enqueueNativeOp(op: () => Promise<unknown>, label: string): Promise<void> {
+        const next = this.native_op_queue.then(async () => {
+            await op();
+        });
+        /* Keep the queue alive after failures; surface them per-op. */
+        this.native_op_queue = next.catch((err) => {
+            this.nativeLog(`${label} failed`, err);
+        });
+        return next;
+    }
+
+    private scheduleNativeSync(): void {
+        if (!this.native_transport || this.native_sync_scheduled || this.destroyed) {
+            return;
+        }
+        this.native_sync_scheduled = true;
+        Promise.resolve()
+            .then(() => {
+                this.native_sync_scheduled = false;
+                if (!this.destroyed) {
+                    this.syncNative();
+                }
+            })
+            .catch((err) => this.nativeLog("sync failed", err));
+    }
+
+    /** Single driver for the native state machine; coalesced to a
+     *  microtask so bursts of renderer calls produce one transport
+     *  round-trip. */
+    private syncNative(): void {
+        if (!this.native_transport || this.native_state === "fallback") {
+            return;
+        }
+        const serviceable = this.isV1Serviceable();
+
+        switch (this.native_state) {
+            case "attaching":
+                /* attach completion re-schedules a sync */
+                return;
+
+            case "pending":
+                if (serviceable) {
+                    this.attemptNativeAttach();
+                }
+                return;
+
+            case "active":
+                if (!serviceable) {
+                    this.bailToCanvas();
+                } else if (this.engine.width !== this.native_attached_size) {
+                    this.reattachNative();
+                } else {
+                    this.pushNativeGeometry();
+                    this.pushNativeUpdate();
+                }
+                return;
+
+            case "bailed":
+                if (serviceable) {
+                    if (this.engine.width !== this.native_attached_size) {
+                        this.reattachNative();
+                    } else {
+                        this.reengageNative();
+                    }
+                }
+                return;
+        }
+    }
+
+    /**
+     * What contract v1 can draw: a square play-mode board with stones, the
+     * color to move, and the last-move ring. Everything else (analysis and
+     * conditional modes, score/removal states, marks/labels, AI heatmaps
+     * and circles, pen marks, non-square boards) falls back to the web
+     * canvas; non-"play" engine phases (stone removal, finished) need
+     * removal/score drawing, so they fall back too.
+     */
+    private isV1Serviceable(): boolean {
+        const cur_move = this.engine.cur_move;
+        return (
+            this.mode === "play" &&
+            this.engine.phase === "play" &&
+            this.engine.width === this.engine.height &&
+            !this.scoring_mode &&
+            !this.heatmap &&
+            !this.colored_circles &&
+            !(cur_move && cur_move.pen_marks && cur_move.pen_marks.length > 0) &&
+            !(cur_move && cur_move.hasMarks())
+        );
+    }
+
+    private attemptNativeAttach(): void {
+        const transport = this.native_transport;
+        if (!transport) {
+            return;
+        }
+        this.native_state = "attaching";
+        const size = this.engine.width;
+        const rect = this.measureNativeRect();
+        this.enqueueNativeOp(async () => {
+            try {
+                await transport.attach({
+                    id: this.nativeId(),
+                    rect,
+                    size,
+                    board: this.flattenBoard(),
+                    colorToMove: this.engine.player === 2 ? 2 : 1,
+                    lastMove: this.nativeLastMove(),
+                    interactive: this.interactive,
+                    theme: this.resolveNativeTheme(),
+                    showCoordinates:
+                        this.draw_top_labels ||
+                        this.draw_bottom_labels ||
+                        this.draw_left_labels ||
+                        this.draw_right_labels,
+                });
+            } catch (err) {
+                /* Plugin absent/old rim/bad args: permanent canvas
+                 * fallback for this instance (capability probe, never
+                 * version sniffing). */
+                this.native_state = "fallback";
+                this.setCanvasVisible(true);
+                this.nativeLog("attach rejected; falling back to canvas", err);
+                return;
+            }
+            this.native_state = "active";
+            this.native_attached_size = size;
+            this.native_last_rect = rect;
+            this.native_last_update_json = "";
+            this.setCanvasVisible(false);
+            if (this.native_overlay_suspended) {
+                /* An overlay opened while we were attaching. */
+                await transport.suspend({ id: this.nativeId() }).catch(() => undefined);
+            }
+            this.scheduleNativeSync();
+        }, "attach").catch(() => undefined);
+    }
+
+    private reattachNative(): void {
+        const transport = this.native_transport;
+        if (!transport) {
+            return;
+        }
+        /* Board size changed (new engine config): contract v1 has no
+         * resize, so detach and attach fresh. */
+        this.enqueueNativeOp(() => transport.detach({ id: this.nativeId() }), "detach").catch(
+            () => undefined,
+        );
+        this.native_state = "pending";
+        this.setCanvasVisible(true);
+        this.scheduleNativeSync();
+    }
+
+    private bailToCanvas(): void {
+        const transport = this.native_transport;
+        this.native_state = "bailed";
+        this.setCanvasVisible(true);
+        this.nativeLog("board needs features beyond contract v1; showing web canvas");
+        if (transport && !this.native_overlay_suspended) {
+            /* suspend() hides the native view; we have no use for the
+             * snapshot here since the live canvas takes over. */
+            this.enqueueNativeOp(() => transport.suspend({ id: this.nativeId() }), "suspend").catch(
+                () => undefined,
+            );
+        }
+    }
+
+    private reengageNative(): void {
+        const transport = this.native_transport;
+        if (!transport) {
+            return;
+        }
+        this.native_state = "active";
+        this.native_last_update_json = "";
+        this.pushNativeGeometry(true);
+        this.pushNativeUpdate();
+        if (!this.native_overlay_suspended) {
+            this.enqueueNativeOp(() => transport.resume({ id: this.nativeId() }), "resume").catch(
+                () => undefined,
+            );
+        }
+        this.setCanvasVisible(false);
+        this.nativeLog("board v1-serviceable again; native view re-engaged");
+    }
+
+    private pushNativeUpdate(): void {
+        const transport = this.native_transport;
+        if (!transport) {
+            return;
+        }
+        const update: NativeBridgeUpdateOptions = {
+            id: this.nativeId(),
+            board: this.flattenBoard(),
+            colorToMove: this.engine.player === 2 ? 2 : 1,
+            lastMove: this.nativeLastMove(),
+        };
+        const json = JSON.stringify(update);
+        if (json === this.native_last_update_json) {
+            return;
+        }
+        this.native_last_update_json = json;
+        this.enqueueNativeOp(() => transport.update(update), "update").catch(() => undefined);
+    }
+
+    private pushNativeGeometry(force: boolean = false): void {
+        const transport = this.native_transport;
+        if (!transport) {
+            return;
+        }
+        const rect = this.measureNativeRect();
+        const last = this.native_last_rect;
+        if (
+            !force &&
+            last &&
+            last.x === rect.x &&
+            last.y === rect.y &&
+            last.width === rect.width &&
+            last.height === rect.height
+        ) {
+            return;
+        }
+        this.native_last_rect = rect;
+        this.enqueueNativeOp(() => transport.move({ id: this.nativeId(), rect }), "move").catch(
+            () => undefined,
+        );
+    }
+
+    /** The board canvas's rect in CSS px content coordinates (client rect
+     *  plus scroll offsets), per the geometry contract. */
+    private measureNativeRect(): NativeBridgeRect {
+        const r = this.board.getBoundingClientRect();
+        const scroll_x = typeof window !== "undefined" ? window.scrollX : 0;
+        const scroll_y = typeof window !== "undefined" ? window.scrollY : 0;
+        return {
+            x: r.left + scroll_x,
+            y: r.top + scroll_y,
+            width: r.width,
+            height: r.height,
+        };
+    }
+
+    /** Flat row-major 0/1/2 stones per the contract. */
+    private flattenBoard(): number[] {
+        const { width, height, board } = this.engine;
+        const flat: number[] = new Array(width * height);
+        for (let y = 0; y < height; ++y) {
+            for (let x = 0; x < width; ++x) {
+                flat[y * width + x] = board[y][x];
+            }
+        }
+        return flat;
+    }
+
+    private nativeLastMove(): { x: number; y: number } | undefined {
+        if (this.dont_draw_last_move) {
+            return undefined;
+        }
+        const m = this.engine.cur_move;
+        if (m && m.x >= 0 && m.y >= 0) {
+            return { x: m.x, y: m.y };
+        }
+        return undefined;
+    }
+
+    /** Resolve the selected goban theme down to the five colors contract
+     *  v1 understands. Image-based board/stone themes degrade to their
+     *  underlying flat colors; the native side shades procedurally. */
+    private resolveNativeTheme(): NativeBridgeTheme {
+        const board_color = this.theme_board?.getBackgroundCSS()["background-color"] || "#DCB35C";
+        return {
+            boardColor: normalizeColor(board_color),
+            lineColor: normalizeColor(this.theme_board?.getLineColor() || "#000000"),
+            blackStoneColor: normalizeColor(this.theme_black?.getBlackStoneColor() || "#000000"),
+            whiteStoneColor: normalizeColor(this.theme_white?.getWhiteStoneColor() || "#ffffff"),
+            backgroundColor: this.resolveSurroundColor(),
+        };
+    }
+
+    /** The page color behind the board edges: first non-transparent
+     *  background-color walking up from the board container. */
+    private resolveSurroundColor(): string {
+        try {
+            let el: HTMLElement | null = this.parent;
+            while (el) {
+                const bg = getComputedStyle(el).backgroundColor;
+                if (
+                    bg &&
+                    bg !== "transparent" &&
+                    !/rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*0\s*\)/.test(bg)
+                ) {
+                    return normalizeColor(bg);
+                }
+                el = el.parentElement;
+            }
+        } catch {
+            // jsdom and detached elements: fall through to the default
+        }
+        return "#000000";
+    }
+
+    private setCanvasVisible(visible: boolean): void {
+        const visibility = visible ? "" : "hidden";
+        this.board.style.visibility = visibility;
+        if (this.shadow_layer) {
+            this.shadow_layer.style.visibility = visibility;
+        }
+    }
+}
+
+/** Normalize a CSS color to six-digit hex where cheaply possible
+ *  (contract: "six-digit hex preferred"); pass through anything a canvas
+ *  cannot normalize (or when no 2d context is available, e.g. jsdom). */
+export function normalizeColor(color: string): string {
+    if (/^#[0-9a-fA-F]{6}$/.test(color)) {
+        return color;
+    }
+    try {
+        const canvas = document.createElement("canvas");
+        canvas.width = canvas.height = 1;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+            return color;
+        }
+        ctx.fillStyle = color;
+        const normalized = ctx.fillStyle;
+        if (/^#[0-9a-fA-F]{6}$/.test(normalized)) {
+            return normalized;
+        }
+        const m = normalized.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+        if (m) {
+            const hex = (s: string) => parseInt(s, 10).toString(16).padStart(2, "0");
+            return `#${hex(m[1])}${hex(m[2])}${hex(m[3])}`;
+        }
+        return normalized;
+    } catch {
+        return color;
+    }
+}

--- a/src/Goban/NativeBridgeTransport.ts
+++ b/src/Goban/NativeBridgeTransport.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Transport seam for the GobanNativeBridge renderer backend.
+ *
+ * The goban library never talks to a platform bridge (Capacitor or
+ * otherwise) directly: the embedding application injects an object
+ * implementing `GobanNativeBridgeTransport` through the renderer config
+ * (`NativeBridgeGobanConfig.native_transport`). The shape of this interface
+ * mirrors the GobanNative plugin contract v1 (the online-go.com repo's
+ * doc/mobile/GOBAN-NATIVE-CONTRACT.md): one method per plugin method, plus
+ * a subscription for the single gameplay event the native side may emit
+ * (`intentPlace`).
+ *
+ * Geometry note: `rect` is in CSS pixels in *content* coordinates, i.e. the
+ * element's bounding client rect plus the window scroll offsets. The native
+ * side anchors its view at those coordinates inside the web view's scroll
+ * view, so the view stays pixel-locked through scrolling.
+ */
+
+/** Flat board cell value: 0 empty, 1 black, 2 white
+ *  (JGOFNumericPlayerColor). */
+export type NativeBridgeStone = number;
+
+/** CSS-pixel rectangle in content coordinates (element rect + scroll). */
+export interface NativeBridgeRect {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/** The five colors the native draw layer needs. CSS color strings;
+ *  six-digit hex preferred. */
+export interface NativeBridgeTheme {
+    /** Board surface fill. */
+    boardColor: string;
+    /** Grid line / star point color. */
+    lineColor: string;
+    /** Black stones are shaded procedurally from this color. */
+    blackStoneColor: string;
+    /** White stones are shaded procedurally from this color. */
+    whiteStoneColor: string;
+    /** Surround color painted behind the board edges. */
+    backgroundColor: string;
+}
+
+export interface NativeBridgeAttachOptions {
+    id: string;
+    rect: NativeBridgeRect;
+    /** Board size, e.g. 19. v1 boards are square. */
+    size: number;
+    /** Flat row-major stones, length size*size, values 0/1/2. */
+    board: NativeBridgeStone[];
+    colorToMove: 1 | 2;
+    lastMove?: { x: number; y: number };
+    /** Gestures + ghost stone + loupe + intentPlace events. */
+    interactive: boolean;
+    theme: NativeBridgeTheme;
+    /** Native MAY no-op this in v1. */
+    showCoordinates?: boolean;
+}
+
+export interface NativeBridgeUpdateOptions {
+    id: string;
+    board: NativeBridgeStone[];
+    colorToMove?: 1 | 2;
+    lastMove?: { x: number; y: number };
+}
+
+/** Finger released on an intersection of an interactive board. Board
+ *  coordinates. This is an *intent*: all legality/turn logic stays in the
+ *  TS engine, which treats it exactly like a canvas tap. */
+export interface NativeBridgeIntentPlaceEvent {
+    id: string;
+    x: number;
+    y: number;
+}
+
+/**
+ * The injected transport the GobanNativeBridge renderer drives. All
+ * methods return promises and may reject; a rejected `attach` makes the
+ * renderer fall back to its web canvas permanently for that instance.
+ */
+export interface GobanNativeBridgeTransport {
+    /** Create and insert the native view. */
+    attach(opts: NativeBridgeAttachOptions): Promise<void>;
+    /** Re-render state. The native side diffs stones itself. */
+    update(opts: NativeBridgeUpdateOptions): Promise<void>;
+    /** Reposition/resize the native view. */
+    move(opts: { id: string; rect: NativeBridgeRect }): Promise<void>;
+    /** Change theme colors without re-attaching. */
+    setTheme(opts: { id: string; theme: NativeBridgeTheme }): Promise<void>;
+    /** Snapshot the native view as a PNG data-URL, then hide it (so DOM
+     *  overlays can stack above the board). */
+    suspend(opts: { id: string }): Promise<{ snapshot: string }>;
+    /** Show the native view again after a suspend. */
+    resume(opts: { id: string }): Promise<void>;
+    /** Remove the view and all resources. Safe to call on unknown ids. */
+    detach(opts: { id: string }): Promise<void>;
+    /** Subscribe to intentPlace events. Returns an unsubscribe function. */
+    onIntentPlace(cb: (event: NativeBridgeIntentPlaceEvent) => void): () => void;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ export * from "./Goban/callbacks";
 export * from "./Goban/canvas_utils";
 export * from "./Goban/CanvasRenderer";
 export * from "./Goban/SVGRenderer";
+export * from "./Goban/GobanNativeBridge";
+export * from "./Goban/NativeBridgeTransport";
 export * from "./Goban/themes";
 export * from "./Goban/themes/GobanTheme";
 export * from "./Goban/Goban";
@@ -36,9 +38,13 @@ export { placeRenderedImageStone, preRenderImageStone } from "./Goban/themes/ima
 
 import { GobanCanvas, CanvasRendererGobanConfig } from "./Goban/CanvasRenderer";
 import { SVGRenderer, SVGRendererGobanConfig } from "./Goban/SVGRenderer";
+import { GobanNativeBridge, NativeBridgeGobanConfig } from "./Goban/GobanNativeBridge";
 
 export type GobanRenderer = GobanCanvas | SVGRenderer;
-export type GobanRendererConfig = CanvasRendererGobanConfig | SVGRendererGobanConfig;
+export type GobanRendererConfig =
+    | CanvasRendererGobanConfig
+    | SVGRendererGobanConfig
+    | NativeBridgeGobanConfig;
 
 //(window as any)["goban"] = module.exports;
 
@@ -54,6 +60,13 @@ export function createGoban(
     config: GobanRendererConfig,
     preloaded_data?: AdHocFormat | JGOF,
 ): GobanRenderer {
+    /* A native transport in the config opts this instance into the
+     * native-bridge backend (a GobanCanvas subclass that drives an
+     * out-of-DOM draw layer and falls back to the canvas whenever the
+     * board needs more than the bridge contract supports). */
+    if ((config as NativeBridgeGobanConfig).native_transport) {
+        return new GobanNativeBridge(config, preloaded_data);
+    }
     if (renderer === "svg") {
         return new SVGRenderer(config, preloaded_data);
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,14 @@ export function setGobanRenderer(_renderer: "svg" | "canvas") {
 
 import { AdHocFormat, JGOF } from "./engine";
 
+/**
+ * Construct the renderer appropriate for `config`.
+ *
+ * Note: a `native_transport` in the config takes precedence over the
+ * renderer selected with {@link setGobanRenderer} -- the instance will be
+ * a {@link GobanNativeBridge} (a GobanCanvas subclass) regardless of any
+ * explicit "svg"/"canvas" choice.
+ */
 export function createGoban(
     config: GobanRendererConfig,
     preloaded_data?: AdHocFormat | JGOF,

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -843,3 +843,116 @@ describe("no blank board while a resume is in flight", () => {
         goban.destroy();
     });
 });
+
+/* Board state added for the reworked AI review display. None of it is
+ * expressible in contract v1 (which carries only stones, colorToMove and a
+ * last-move ring), so all of it has to reach the web canvas. */
+describe("AI review board state", () => {
+    test("presenting the next move bails to the canvas and clearing re-engages", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        goban.setPresentNextMove(true);
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        goban.setPresentNextMove(false);
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("active");
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("an ai_quality badge bails to the canvas", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        goban.setAIQualityMark(1, 1, "blunder");
+        goban.redraw(true);
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        goban.destroy();
+    });
+
+    test("a subscript2 annotation bails to the canvas", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        goban.setSubscript2Mark(1, 1, "1.2k");
+        goban.redraw(true);
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        goban.destroy();
+    });
+
+    test("colored circles bail, and clearing them re-engages on its own", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        goban.setColoredCircles([{ move: { x: 1, y: 1 }, color: "#ff0000" }]);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("bailed");
+
+        /* setColoredCircles repaints when clearing, which is what schedules
+         * the sync that re-engages us. */
+        goban.setColoredCircles([]);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+        goban.destroy();
+    });
+});
+
+/* Board decorations that predate the AI review work but are equally
+ * outside contract v1: the native side has no way to draw them, so a board
+ * showing them has to be the web canvas. */
+describe("other unrenderable board decorations", () => {
+    test("an outstanding undo request bails, and cancelling it re-engages", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        goban.engine.place(0, 0);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        /* The live game socket sets this and repaints so the "?" appears on
+         * the move the request covers. */
+        goban.engine.undo_requested = goban.engine.cur_move.move_number;
+        goban.redraw(true);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("bailed");
+
+        goban.engine.undo_requested = undefined;
+        goban.redraw(true);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+        goban.destroy();
+    });
+
+    test("move tree move highlighting bails", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        /* Set by puzzle configs, which highlight the moves the tree knows. */
+        (goban as any).highlight_movetree_moves = true;
+        goban.redraw(true);
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        goban.destroy();
+    });
+});

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -45,6 +45,10 @@ interface RecordedCall {
 class RecordingTransport implements GobanNativeBridgeTransport {
     public calls: RecordedCall[] = [];
     public reject_attach = false;
+    /** One-shot rejections (consumed on use): a transient failure of the
+     *  next update/move call. */
+    public reject_next_update = false;
+    public reject_next_move = false;
     private listeners: Array<(event: NativeBridgeIntentPlaceEvent) => void> = [];
 
     attach(opts: NativeBridgeAttachOptions): Promise<void> {
@@ -56,10 +60,18 @@ class RecordingTransport implements GobanNativeBridgeTransport {
     }
     update(opts: NativeBridgeUpdateOptions): Promise<void> {
         this.calls.push({ method: "update", opts });
+        if (this.reject_next_update) {
+            this.reject_next_update = false;
+            return Promise.reject(new Error("update failed"));
+        }
         return Promise.resolve();
     }
     move(opts: { id: string; rect: NativeBridgeRect }): Promise<void> {
         this.calls.push({ method: "move", opts });
+        if (this.reject_next_move) {
+            this.reject_next_move = false;
+            return Promise.reject(new Error("move failed"));
+        }
         return Promise.resolve();
     }
     setTheme(opts: { id: string; theme: NativeBridgeTheme }): Promise<void> {
@@ -361,6 +373,67 @@ describe("overlay suspend/resume", () => {
         const second = await goban.suspendNativeView();
         expect(second).toBeNull();
         expect(transport.callsOf("suspend")).toHaveLength(1);
+        goban.destroy();
+    });
+});
+
+describe("transport failure recovery while active", () => {
+    test("update rejection while active shows the canvas and re-probes with attach", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        transport.reject_next_update = true;
+        goban.enableStonePlacement();
+        transport.emitIntentPlace({ id: `goban-${goban.goban_id}`, x: 0, y: 0 });
+        await flush();
+
+        /* never silently frozen: detach + fresh attach carrying the move */
+        expect(transport.callsOf("detach")).toHaveLength(1);
+        const attaches = transport.callsOf("attach");
+        expect(attaches).toHaveLength(2);
+        expect((attaches[1].opts as NativeBridgeAttachOptions).board).toContain(1);
+        expect(goban.nativeBridgeState).toBe("active");
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("move rejection while active recovers through a re-attach", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        transport.reject_next_move = true;
+        /* bail + re-engage forces a move push, which now rejects */
+        goban.setMode("analyze");
+        await flush();
+        goban.setMode("play");
+        await flush();
+
+        expect(transport.callsOf("attach")).toHaveLength(2);
+        expect(goban.nativeBridgeState).toBe("active");
+        goban.destroy();
+    });
+
+    test("persistently failing transport converges to permanent canvas fallback", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        transport.reject_next_update = true;
+        transport.reject_attach = true;
+        goban.enableStonePlacement();
+        transport.emitIntentPlace({ id: `goban-${goban.goban_id}`, x: 0, y: 0 });
+        await flush();
+
+        /* update failed -> re-probe attach failed -> permanent fallback */
+        expect(goban.nativeBridgeState).toBe("fallback");
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
         goban.destroy();
     });
 });

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -591,6 +591,20 @@ describe("transport failure recovery while active", () => {
 });
 
 describe("sync plumbing", () => {
+    test("window resize triggers a geometry-only sync (no board update)", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        const updates_before = transport.callsOf("update").length;
+
+        window.dispatchEvent(new Event("resize"));
+        await flush();
+
+        expect(transport.callsOf("update")).toHaveLength(updates_before);
+        expect(goban.nativeBridgeState).toBe("active");
+        goban.destroy();
+    });
+
     test("engine cur_move events reach the goban emitter (listener is live)", async () => {
         const transport = new RecordingTransport();
         const goban = new GobanNativeBridge(config(transport));

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -956,3 +956,31 @@ describe("other unrenderable board decorations", () => {
         goban.destroy();
     });
 });
+
+describe("attach payload construction", () => {
+    test("a throw while building the payload falls back instead of stranding the bridge", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        /* The attach op runs off a microtask, so patch before it does. The
+         * engine can be mid-swap when a queued attach finally executes;
+         * a blowing-up board flatten stands in for that. */
+        (goban as any).flattenBoard = () => {
+            throw new Error("engine torn");
+        };
+        await flush();
+
+        expect(transport.callsOf("attach")).toHaveLength(0);
+        /* "attaching" would be terminal: syncNative() reads it as "an
+         * attach is in flight" and returns, so nothing would ever attach
+         * or fall back again. */
+        expect(goban.nativeBridgeState).toBe("fallback");
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        goban.redraw(true);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("fallback");
+        expect(transport.callsOf("attach")).toHaveLength(0);
+        goban.destroy();
+    });
+});

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -25,6 +25,7 @@ import {
     NativeBridgeTheme,
     NativeBridgeUpdateOptions,
 } from "../../src/Goban/NativeBridgeTransport";
+import { callbacks } from "../../src/Goban/callbacks";
 import { GobanSocket } from "engine";
 import WS from "jest-websocket-mock";
 
@@ -633,5 +634,84 @@ describe("destroy", () => {
 
         expect(transport.callsOf("detach")).toHaveLength(1);
         expect(transport.listener_count).toBe(0);
+    });
+});
+
+describe("web board layers", () => {
+    const crosshair = () => ({ enabled: true, color: "#ff0000", thickness: 1 });
+
+    afterEach(() => {
+        delete callbacks.getLastMoveCrosshair;
+    });
+
+    /** Every DOM layer the canvas renderer paints the board on. The board
+     *  is not one canvas: shadows, the themed grid background and the
+     *  last-move crosshair each get their own layer, attached lazily. */
+    function boardLayers(): HTMLElement[] {
+        return Array.from(
+            board_div.querySelectorAll<HTMLElement>(
+                ".StoneLayer, .ShadowLayer, .GridLayer, .GridBackgroundLayer, .CrosshairLayer, .PenLayer",
+            ),
+        );
+    }
+
+    test("hides the whole layer stack while the native view is active", async () => {
+        const transport = new RecordingTransport();
+        callbacks.getLastMoveCrosshair = crosshair;
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        goban.engine.place(0, 0);
+        goban.redraw(true);
+        await flush();
+
+        const layers = boardLayers();
+        /* More than the stone canvas: hiding only that one would leave a
+         * full board painting underneath the native view. */
+        expect(layers.length).toBeGreaterThan(1);
+        for (const layer of layers) {
+            expect(layer.style.visibility).toBe("hidden");
+        }
+        goban.destroy();
+    });
+
+    test("hides a layer that attaches after the native view went active", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(board_div.querySelector(".CrosshairLayer")).toBeNull();
+
+        /* The crosshair layer is attached lazily, on the first draw that
+         * actually shows a crosshair -- long after we hid the layers that
+         * existed at attach time. */
+        callbacks.getLastMoveCrosshair = crosshair;
+        goban.engine.place(0, 0);
+        goban.redraw(true);
+        await flush();
+
+        const crosshair_layer = board_div.querySelector<HTMLElement>(".CrosshairLayer");
+        expect(crosshair_layer).not.toBeNull();
+        expect(crosshair_layer!.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("restores the whole layer stack when bailing to the canvas", async () => {
+        const transport = new RecordingTransport();
+        callbacks.getLastMoveCrosshair = crosshair;
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        goban.engine.place(0, 0);
+        goban.redraw(true);
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+        expect(boardLayers().length).toBeGreaterThan(1);
+
+        goban.setMode("analyze");
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        for (const layer of boardLayers()) {
+            expect(layer.style.visibility).not.toBe("hidden");
+        }
+        goban.destroy();
     });
 });

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -55,6 +55,7 @@ class RecordingTransport implements GobanNativeBridgeTransport {
      *  op queue open to provoke races. */
     public next_attach_gate?: Promise<void>;
     public next_detach_gate?: Promise<void>;
+    public next_resume_gate?: Promise<void>;
     private listeners: Array<(event: NativeBridgeIntentPlaceEvent) => void> = [];
 
     attach(opts: NativeBridgeAttachOptions): Promise<void> {
@@ -92,7 +93,9 @@ class RecordingTransport implements GobanNativeBridgeTransport {
     }
     resume(opts: { id: string }): Promise<void> {
         this.calls.push({ method: "resume", opts });
-        return Promise.resolve();
+        const gate = this.next_resume_gate;
+        this.next_resume_gate = undefined;
+        return gate ?? Promise.resolve();
     }
     detach(opts: { id: string }): Promise<void> {
         this.calls.push({ method: "detach", opts });
@@ -712,6 +715,131 @@ describe("web board layers", () => {
         for (const layer of boardLayers()) {
             expect(layer.style.visibility).not.toBe("hidden");
         }
+        goban.destroy();
+    });
+});
+
+/* The native view is hidden from the moment it is suspended until a resume
+ * actually resolves. Hiding the canvas any earlier than that leaves neither
+ * board on screen for the width of a bridge round-trip. */
+describe("no blank board while a resume is in flight", () => {
+    test("re-engaging keeps the canvas visible until resume resolves", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        goban.setMode("analyze");
+        await flush();
+        expect(goban.nativeBridgeState).toBe("bailed");
+
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        const resume_gate = gate();
+        transport.next_resume_gate = resume_gate.promise;
+        goban.setMode("play");
+        await flush();
+
+        /* resume is in flight: the native view is still suspended, so the
+         * canvas is the only board on screen. */
+        expect(transport.callsOf("resume")).toHaveLength(1);
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        resume_gate.open();
+        await flush();
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("resumeNativeView keeps the canvas visible until resume resolves", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        /* Suspend, then bail and re-engage, so the canvas is left up as the
+         * board with no snapshot covering it (the coordinator's suspend
+         * resolved before we were bailed). */
+        await goban.suspendNativeView();
+        goban.setMode("analyze");
+        await flush();
+        goban.setMode("play");
+        await flush();
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        const resume_gate = gate();
+        transport.next_resume_gate = resume_gate.promise;
+        goban.resumeNativeView();
+        await flush();
+
+        expect(transport.callsOf("resume")).toHaveLength(1);
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        resume_gate.open();
+        await flush();
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("a theme change while a resume is in flight does not hide the canvas", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        goban.setMode("analyze");
+        await flush();
+
+        const resume_gate = gate();
+        transport.next_resume_gate = resume_gate.promise;
+        goban.setMode("play");
+        await flush();
+        expect(transport.callsOf("resume")).toHaveLength(1);
+
+        /* "active" no longer implies "the native view is on screen": a
+         * theme change landing in the resume window must leave the canvas
+         * up as the board. */
+        goban.setTheme(
+            {
+                "board": "Kaya",
+                "black": "Glass",
+                "white": "Glass",
+                "removal-graphic": "x",
+                "removal-scale": 1.0,
+                "stone-scale": 1.0,
+            },
+            false,
+        );
+        await flush();
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        resume_gate.open();
+        await flush();
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("bailing while a resume is in flight leaves the canvas visible", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        goban.setMode("analyze");
+        await flush();
+
+        const resume_gate = gate();
+        transport.next_resume_gate = resume_gate.promise;
+        goban.setMode("play");
+        await flush();
+        expect(transport.callsOf("resume")).toHaveLength(1);
+
+        /* Back out of play before the resume lands: its continuation must
+         * not hide the canvas over a native view we are re-suspending. */
+        goban.setMode("analyze");
+        await flush();
+        expect(goban.nativeBridgeState).toBe("bailed");
+
+        resume_gate.open();
+        await flush();
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
         goban.destroy();
     });
 });

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -391,6 +391,24 @@ describe("overlay suspend/resume", () => {
 });
 
 describe("lifecycle races", () => {
+    test("destroy during an in-flight attach leaves a clean fallback", async () => {
+        const transport = new RecordingTransport();
+        const attach_gate = gate();
+        transport.next_attach_gate = attach_gate.promise;
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("attaching");
+
+        goban.destroy();
+        attach_gate.open();
+        await flush();
+
+        /* the attach continuation must not resurrect any state */
+        expect(goban.nativeBridgeState).toBe("fallback");
+        expect(transport.callsOf("detach")).toHaveLength(1);
+        expect(transport.listener_count).toBe(0);
+    });
+
     test("overlay suspend during attach keeps the canvas visible until resume", async () => {
         const transport = new RecordingTransport();
         const attach_gate = gate();

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -590,6 +590,23 @@ describe("transport failure recovery while active", () => {
     });
 });
 
+describe("sync plumbing", () => {
+    test("engine cur_move events reach the goban emitter (listener is live)", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        /* GobanEngine forwards its emits to the owning goban via
+         * parentEventEmitter; the bridge's goban-level "cur_move"
+         * listener relies on that. */
+        let fired = 0;
+        goban.on("cur_move", () => fired++);
+        goban.engine.place(0, 0);
+        expect(fired).toBe(1);
+        goban.destroy();
+    });
+});
+
 describe("destroy", () => {
     test("detaches the native view and unsubscribes", async () => {
         const transport = new RecordingTransport();

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -155,6 +155,24 @@ function config(
     };
 }
 
+/* The first goban built in a worker pays one-time costs that dwarf anything
+ * any test here does: the theme cache starts cold, and node-canvas enumerates
+ * the system fonts the first time the board draws its coordinate labels.
+ * Locally that is ~50ms against ~6ms for every construction after it; on a CI
+ * runner it is enough on its own to blow the project's 1000ms per-test budget.
+ * Pay it once up front so it lands on a hook rather than on whichever test
+ * happens to run first. */
+beforeAll(async () => {
+    const warmup_div = document.createElement("div");
+    document.body.appendChild(warmup_div);
+    const goban = new GobanNativeBridge(
+        config(new RecordingTransport(), { board_div: warmup_div }),
+    );
+    await flush();
+    goban.destroy();
+    warmup_div.remove();
+}, 30000);
+
 beforeEach(() => {
     board_div = document.createElement("div");
     document.body.appendChild(board_div);

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -49,10 +49,11 @@ class RecordingTransport implements GobanNativeBridgeTransport {
      *  next update/move call. */
     public reject_next_update = false;
     public reject_next_move = false;
-    /** When set, the next attach call resolves only after the gate promise
-     *  does (consumed on use); lets tests hold the bridge's serial op
-     *  queue open to provoke races. */
+    /** When set, the next attach/detach call resolves only after the gate
+     *  promise does (consumed on use); lets tests hold the bridge's serial
+     *  op queue open to provoke races. */
     public next_attach_gate?: Promise<void>;
+    public next_detach_gate?: Promise<void>;
     private listeners: Array<(event: NativeBridgeIntentPlaceEvent) => void> = [];
 
     attach(opts: NativeBridgeAttachOptions): Promise<void> {
@@ -94,7 +95,9 @@ class RecordingTransport implements GobanNativeBridgeTransport {
     }
     detach(opts: { id: string }): Promise<void> {
         this.calls.push({ method: "detach", opts });
-        return Promise.resolve();
+        const gate = this.next_detach_gate;
+        this.next_detach_gate = undefined;
+        return gate ?? Promise.resolve();
     }
     onIntentPlace(cb: (event: NativeBridgeIntentPlaceEvent) => void): () => void {
         this.listeners.push(cb);
@@ -459,6 +462,69 @@ describe("lifecycle races", () => {
         await flush();
         expect(transport.callsOf("resume")).toHaveLength(1);
         expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("board size change detaches and re-attaches with the new size", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport, { width: 19, height: 19 }));
+        await flush();
+        expect((transport.callsOf("attach")[0].opts as NativeBridgeAttachOptions).size).toBe(19);
+
+        goban.load(config(transport, { width: 9, height: 9 }));
+        await flush();
+
+        expect(transport.callsOf("detach")).toHaveLength(1);
+        const attaches = transport.callsOf("attach");
+        expect(attaches).toHaveLength(2);
+        const reattach = attaches[1].opts as NativeBridgeAttachOptions;
+        expect(reattach.size).toBe(9);
+        expect(reattach.board).toHaveLength(81);
+        expect(goban.nativeBridgeState).toBe("active");
+        goban.destroy();
+    });
+
+    test("engine resize while a re-attach is queued sends a payload built at execution", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport, { width: 19, height: 19 }));
+        await flush();
+
+        /* hold the queue open on the reattach's detach so the follow-up
+         * attach op is still queued when the engine changes size again */
+        const detach_gate = gate();
+        transport.next_detach_gate = detach_gate.promise;
+        goban.load(config(transport, { width: 9, height: 9 }));
+        await flush();
+        goban.load(config(transport, { width: 13, height: 13 }));
+        await flush();
+        detach_gate.open();
+        await flush();
+
+        const attaches = transport.callsOf("attach");
+        const last = attaches[attaches.length - 1].opts as NativeBridgeAttachOptions;
+        /* size and board must agree with each other and with the engine
+         * as of op execution, never with values captured at schedule */
+        expect(last.size).toBe(13);
+        expect(last.board).toHaveLength(169);
+        expect(goban.nativeBridgeState).toBe("active");
+        goban.destroy();
+    });
+
+    test("attach carries the state baseline; no redundant first update", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+        expect(transport.callsOf("update")).toHaveLength(0);
+
+        goban.redraw(true);
+        await flush();
+        expect(transport.callsOf("update")).toHaveLength(0);
+
+        goban.enableStonePlacement();
+        transport.emitIntentPlace({ id: `goban-${goban.goban_id}`, x: 0, y: 0 });
+        await flush();
+        expect(transport.callsOf("update")).toHaveLength(1);
         goban.destroy();
     });
 });

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -49,6 +49,10 @@ class RecordingTransport implements GobanNativeBridgeTransport {
      *  next update/move call. */
     public reject_next_update = false;
     public reject_next_move = false;
+    /** When set, the next attach call resolves only after the gate promise
+     *  does (consumed on use); lets tests hold the bridge's serial op
+     *  queue open to provoke races. */
+    public next_attach_gate?: Promise<void>;
     private listeners: Array<(event: NativeBridgeIntentPlaceEvent) => void> = [];
 
     attach(opts: NativeBridgeAttachOptions): Promise<void> {
@@ -56,7 +60,9 @@ class RecordingTransport implements GobanNativeBridgeTransport {
         if (this.reject_attach) {
             return Promise.reject(new Error("unsupported"));
         }
-        return Promise.resolve();
+        const gate = this.next_attach_gate;
+        this.next_attach_gate = undefined;
+        return gate ?? Promise.resolve();
     }
     update(opts: NativeBridgeUpdateOptions): Promise<void> {
         this.calls.push({ method: "update", opts });
@@ -115,6 +121,13 @@ async function flush(): Promise<void> {
     for (let i = 0; i < 5; ++i) {
         await new Promise((resolve) => setTimeout(resolve, 0));
     }
+}
+
+/** A manually-opened gate for the RecordingTransport's `next_*_gate`s. */
+function gate(): { promise: Promise<void>; open: () => void } {
+    let open: () => void = () => undefined;
+    const promise = new Promise<void>((resolve) => (open = resolve));
+    return { promise, open };
 }
 
 let board_div: HTMLDivElement;
@@ -373,6 +386,61 @@ describe("overlay suspend/resume", () => {
         const second = await goban.suspendNativeView();
         expect(second).toBeNull();
         expect(transport.callsOf("suspend")).toHaveLength(1);
+        goban.destroy();
+    });
+});
+
+describe("lifecycle races", () => {
+    test("overlay suspend during attach keeps the canvas visible until resume", async () => {
+        const transport = new RecordingTransport();
+        const attach_gate = gate();
+        transport.next_attach_gate = attach_gate.promise;
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("attaching");
+
+        /* the coordinator suspends pre-active and gets no snapshot ... */
+        await expect(goban.suspendNativeView()).resolves.toBeNull();
+        attach_gate.open();
+        await flush();
+
+        /* ... so the fresh native view is hidden but the canvas stays up */
+        expect(goban.nativeBridgeState).toBe("active");
+        expect(transport.callsOf("suspend")).toHaveLength(1);
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        goban.resumeNativeView();
+        await flush();
+        expect(transport.callsOf("resume")).toHaveLength(1);
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("re-engaging while overlay-suspended keeps the canvas until resume", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        const snapshot = await goban.suspendNativeView();
+        expect(snapshot).toBe("data:image/png;base64,SNAPSHOT");
+        goban.setMode("analyze");
+        await flush();
+        expect(goban.nativeBridgeState).toBe("bailed");
+
+        goban.setMode("play");
+        await flush();
+
+        /* re-engaged, but the overlay is still open: no resume, canvas up */
+        expect(goban.nativeBridgeState).toBe("active");
+        expect(transport.callsOf("resume")).toHaveLength(0);
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        goban.resumeNativeView();
+        await flush();
+        expect(transport.callsOf("resume")).toHaveLength(1);
+        expect(canvas.style.visibility).toBe("hidden");
         goban.destroy();
     });
 });

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C)  Online-Go.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+(global as any).CLIENT = true;
+
+import { GobanNativeBridge, NativeBridgeGobanConfig } from "../../src/Goban/GobanNativeBridge";
+import {
+    GobanNativeBridgeTransport,
+    NativeBridgeAttachOptions,
+    NativeBridgeIntentPlaceEvent,
+    NativeBridgeRect,
+    NativeBridgeTheme,
+    NativeBridgeUpdateOptions,
+} from "../../src/Goban/NativeBridgeTransport";
+import { GobanSocket } from "engine";
+import WS from "jest-websocket-mock";
+
+const test_port = 48890;
+const socket_server = new WS(`ws://localhost:${test_port}`, { jsonProtocol: true });
+const mock_socket = new GobanSocket(`ws://localhost:${test_port}`, {
+    dont_ping: true,
+    quiet: true,
+});
+
+void socket_server;
+
+interface RecordedCall {
+    method: string;
+    opts: any;
+}
+
+class RecordingTransport implements GobanNativeBridgeTransport {
+    public calls: RecordedCall[] = [];
+    public reject_attach = false;
+    private listeners: Array<(event: NativeBridgeIntentPlaceEvent) => void> = [];
+
+    attach(opts: NativeBridgeAttachOptions): Promise<void> {
+        this.calls.push({ method: "attach", opts });
+        if (this.reject_attach) {
+            return Promise.reject(new Error("unsupported"));
+        }
+        return Promise.resolve();
+    }
+    update(opts: NativeBridgeUpdateOptions): Promise<void> {
+        this.calls.push({ method: "update", opts });
+        return Promise.resolve();
+    }
+    move(opts: { id: string; rect: NativeBridgeRect }): Promise<void> {
+        this.calls.push({ method: "move", opts });
+        return Promise.resolve();
+    }
+    setTheme(opts: { id: string; theme: NativeBridgeTheme }): Promise<void> {
+        this.calls.push({ method: "setTheme", opts });
+        return Promise.resolve();
+    }
+    suspend(opts: { id: string }): Promise<{ snapshot: string }> {
+        this.calls.push({ method: "suspend", opts });
+        return Promise.resolve({ snapshot: "data:image/png;base64,SNAPSHOT" });
+    }
+    resume(opts: { id: string }): Promise<void> {
+        this.calls.push({ method: "resume", opts });
+        return Promise.resolve();
+    }
+    detach(opts: { id: string }): Promise<void> {
+        this.calls.push({ method: "detach", opts });
+        return Promise.resolve();
+    }
+    onIntentPlace(cb: (event: NativeBridgeIntentPlaceEvent) => void): () => void {
+        this.listeners.push(cb);
+        return () => {
+            this.listeners = this.listeners.filter((l) => l !== cb);
+        };
+    }
+
+    emitIntentPlace(event: NativeBridgeIntentPlaceEvent): void {
+        for (const cb of this.listeners) {
+            cb(event);
+        }
+    }
+    callsOf(method: string): RecordedCall[] {
+        return this.calls.filter((c) => c.method === method);
+    }
+    get listener_count(): number {
+        return this.listeners.length;
+    }
+}
+
+/** Let the bridge's microtask-coalesced sync and serial op queue drain. */
+async function flush(): Promise<void> {
+    for (let i = 0; i < 5; ++i) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+}
+
+let board_div: HTMLDivElement;
+
+function config(
+    transport: RecordingTransport | undefined,
+    overrides?: Partial<NativeBridgeGobanConfig>,
+): NativeBridgeGobanConfig {
+    return {
+        square_size: 10,
+        board_div: board_div,
+        interactive: true,
+        server_socket: mock_socket,
+        width: 3,
+        height: 3,
+        native_transport: transport,
+        ...(overrides ?? {}),
+    };
+}
+
+beforeEach(() => {
+    board_div = document.createElement("div");
+    document.body.appendChild(board_div);
+});
+
+afterEach(() => {
+    board_div.remove();
+});
+
+describe("attach", () => {
+    test("attaches with flat board, colorToMove, theme and interactive flag", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("active");
+        const attaches = transport.callsOf("attach");
+        expect(attaches).toHaveLength(1);
+        const opts = attaches[0].opts as NativeBridgeAttachOptions;
+        expect(opts.id).toBe(`goban-${goban.goban_id}`);
+        expect(opts.size).toBe(3);
+        expect(opts.board).toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0]);
+        expect(opts.colorToMove).toBe(1);
+        expect(opts.interactive).toBe(true);
+        for (const key of [
+            "boardColor",
+            "lineColor",
+            "blackStoneColor",
+            "whiteStoneColor",
+            "backgroundColor",
+        ] as const) {
+            expect(typeof opts.theme[key]).toBe("string");
+            expect(opts.theme[key].length).toBeGreaterThan(0);
+        }
+        goban.destroy();
+    });
+
+    test("hides the web canvas while the native view is active", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("without a transport the bridge is a plain canvas renderer", async () => {
+        const goban = new GobanNativeBridge(config(undefined));
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("fallback");
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+        goban.destroy();
+    });
+
+    test("attach rejection falls back to the canvas permanently", async () => {
+        const transport = new RecordingTransport();
+        transport.reject_attach = true;
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("fallback");
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        /* and stays fallen back across later state changes */
+        goban.redraw(true);
+        await flush();
+        expect(transport.callsOf("attach")).toHaveLength(1);
+        goban.destroy();
+    });
+
+    test("non-square boards never attach", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport, { width: 4, height: 2 }));
+        await flush();
+
+        expect(transport.callsOf("attach")).toHaveLength(0);
+        expect(goban.nativeBridgeState).toBe("pending");
+        goban.destroy();
+    });
+
+    test("analyze mode at construction never attaches", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport, { mode: "analyze" }));
+        await flush();
+
+        expect(transport.callsOf("attach")).toHaveLength(0);
+        goban.destroy();
+    });
+});
+
+describe("intentPlace", () => {
+    test("routes through the same path as a canvas tap", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        goban.enableStonePlacement();
+        transport.emitIntentPlace({ id: `goban-${goban.goban_id}`, x: 0, y: 0 });
+
+        expect(goban.engine.board).toEqual([
+            [1, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]);
+        goban.destroy();
+    });
+
+    test("ignores events for other board ids", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        goban.enableStonePlacement();
+        transport.emitIntentPlace({ id: "goban-some-other-board", x: 0, y: 0 });
+
+        expect(goban.engine.board).toEqual([
+            [0, 0, 0],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]);
+        goban.destroy();
+    });
+
+    test("placement flows back out as an update with lastMove", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        goban.enableStonePlacement();
+        transport.emitIntentPlace({ id: `goban-${goban.goban_id}`, x: 1, y: 2 });
+        await flush();
+
+        const updates = transport.callsOf("update");
+        expect(updates.length).toBeGreaterThan(0);
+        const last = updates[updates.length - 1].opts as NativeBridgeUpdateOptions;
+        expect(last.board).toEqual([0, 0, 0, 0, 0, 0, 0, 1, 0]);
+        expect(last.lastMove).toEqual({ x: 1, y: 2 });
+        expect(last.colorToMove).toBe(2);
+        goban.destroy();
+    });
+
+    test("identical state does not produce duplicate updates", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        const updates_before = transport.callsOf("update").length;
+        goban.redraw(true);
+        await flush();
+        goban.redraw(true);
+        await flush();
+
+        /* the first sync after attach establishes the baseline; repeated
+         * identical redraws must not keep sending updates */
+        expect(transport.callsOf("update").length).toBeLessThanOrEqual(updates_before + 1);
+        goban.destroy();
+    });
+});
+
+describe("capability fallback and re-engagement", () => {
+    test("entering analyze mode bails to the canvas, returning to play re-engages", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        goban.setMode("analyze");
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        expect(transport.callsOf("suspend")).toHaveLength(1);
+        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
+        expect(canvas.style.visibility).not.toBe("hidden");
+
+        goban.setMode("play");
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("active");
+        expect(transport.callsOf("resume")).toHaveLength(1);
+        expect(canvas.style.visibility).toBe("hidden");
+        goban.destroy();
+    });
+
+    test("marks on the current move bail to the canvas", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(goban.nativeBridgeState).toBe("active");
+
+        goban.getMarks(1, 1).triangle = true;
+        goban.redraw(true);
+        await flush();
+
+        expect(goban.nativeBridgeState).toBe("bailed");
+        goban.destroy();
+    });
+});
+
+describe("overlay suspend/resume", () => {
+    test("suspendNativeView returns the snapshot and resumeNativeView resumes", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        const snapshot = await goban.suspendNativeView();
+        expect(snapshot).toBe("data:image/png;base64,SNAPSHOT");
+        expect(transport.callsOf("suspend")).toHaveLength(1);
+
+        goban.resumeNativeView();
+        await flush();
+        expect(transport.callsOf("resume")).toHaveLength(1);
+        goban.destroy();
+    });
+
+    test("suspendNativeView is null when the native view is not active", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport, { mode: "analyze" }));
+        await flush();
+
+        const snapshot = await goban.suspendNativeView();
+        expect(snapshot).toBeNull();
+        expect(transport.callsOf("suspend")).toHaveLength(0);
+        goban.destroy();
+    });
+
+    test("second suspend without resume is a no-op", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+
+        await goban.suspendNativeView();
+        const second = await goban.suspendNativeView();
+        expect(second).toBeNull();
+        expect(transport.callsOf("suspend")).toHaveLength(1);
+        goban.destroy();
+    });
+});
+
+describe("destroy", () => {
+    test("detaches the native view and unsubscribes", async () => {
+        const transport = new RecordingTransport();
+        const goban = new GobanNativeBridge(config(transport));
+        await flush();
+        expect(transport.listener_count).toBe(1);
+
+        goban.destroy();
+        await flush();
+
+        expect(transport.callsOf("detach")).toHaveLength(1);
+        expect(transport.listener_count).toBe(0);
+    });
+});


### PR DESCRIPTION
Adds `GobanNativeBridge`, a renderer backend for embedding apps that supply a
native (out-of-DOM) board draw layer, per the online-go.com GobanNative plugin
contract v1 (`doc/mobile/GOBAN-NATIVE-CONTRACT.md` in the site repo). Also
exposes an engine-only entry point on the package.

Nothing here changes behaviour for existing consumers: without a
`native_transport` in the config, `GobanNativeBridge` *is* `GobanCanvas`, and
`createGoban()` keeps returning what it always did.

## Design

The bridge **extends the canvas renderer rather than replacing it**. The web
canvas stays fully functional and fully in sync at all times — it is merely
hidden while the native view is visible. That makes the contract-mandated
capability fallback lossless and reversible: anything v1 native cannot draw
(analysis and conditional modes, marks/labels, score and removal states, AI
heatmaps and circles, pen marks, non-square boards, the AI review's presented
move, an outstanding undo request) just unhides the canvas and hides the
native view, with no re-construction and no state transfer, and re-engages
automatically when the board becomes serviceable again. The serviceability
predicate is kept honest against the renderer's own `drawingHash()`, which
enumerates everything that changes a drawn square.

Input from the native side (`intentPlace`) is routed through `tapAt()` — the
exact entry point a canvas tap uses — so the engine treats native and web taps
identically. The native side knows no Go rules; all legality, capture and turn
logic stays in the TS engine.

The library never talks to a platform bridge (Capacitor or otherwise)
directly. `NativeBridgeTransport.ts` defines the injected transport interface
(`attach`/`update`/`move`/`setTheme`/`suspend`/`resume`/`detach` +
`onIntentPlace`); the embedding app supplies the implementation.

## What's in the branch

- **`src/Goban/NativeBridgeTransport.ts`** — the transport seam: interface,
  geometry contract (CSS px in content coordinates), theme payload.
- **`src/Goban/GobanNativeBridge.ts`** — the backend: a
  `pending → attaching → active → bailed → fallback` state machine driven by a
  single microtask-coalesced sync, over a serial op queue so transport calls
  never race. Transport rejections while the native view owns the pixels show
  the canvas and re-probe, so the bridge always converges instead of freezing
  a stale native bitmap over a hidden canvas.
  `suspendNativeView()`/`resumeNativeView()` expose the snapshot-swap overlay
  protocol to the embedding app.
- **`src/Goban/CanvasRenderer.ts`** — `board` and the three
  `theme_board/black/white` fields widen `private → protected` for the
  subclass, plus a new protected `setBoardLayersVisible()` that drives every
  layer the renderer paints the board on.
- **`src/index.ts`** — exports the backend; `createGoban()` returns a
  `GobanNativeBridge` when the config carries a `native_transport` (documented
  as taking precedence over `setGobanRenderer()`).
- **`package.json` / `Makefile`** — a `./engine` subpath export, so
  `import ... from "goban/engine"` resolves to the existing node-targeted
  engine bundle without a DOM shim or the separate `goban-engine` package.
  `make build` now chains `dts-engine` so the generated (gitignored) types
  actually ship.
- **`test/unit_tests/GobanNativeBridge.test.ts`** — 41 tests against a
  recording transport, covering attach/fallback, intent routing, capability
  bail and re-engagement (including the presented move, AI quality badges,
  visit-count annotations, colored circles and undo requests), overlay
  suspend/resume, lifecycle races (destroy-during-attach, engine resize while
  an op is queued, a bail or a theme change landing inside a resume window),
  transport failure recovery, a payload that will not build, and the layer
  stack.

## Note for reviewers

Adding an `exports` map to `package.json` means deep imports of unlisted paths
are no longer resolvable by Node-style resolvers. `.`, `./engine`,
`./package.json` and a `./build/*` passthrough (which keeps
`goban/build/Goban.css` working) are exposed. Verified end to end against a
real build: `goban/engine` resolves at runtime and under
`moduleResolution: nodenext`.

## Verification

`yarn lint`, `yarn prettier:check`, `yarn spellcheck`, `yarn test`
(422 passing, 22 suites) and `make build` all pass on the rebased branch.

Manual testing in mobile and desktop browsers still wanted before merge — in
particular the fallback transitions (entering/leaving analyze mode, marks
appearing) on a real native rim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DA6b8sdLKiQsHGUtHZpo3U
