### PR TITLE
Add AI review presented-move support

### DIFF
--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -50,6 +50,7 @@ import {
     CaptureDisplay,
     ResolvedBoardBackground,
 } from "./Goban";
+import { AI_QUALITY_BADGES } from "./InteractiveBase";
 
 const __theme_cache: {
     [bw: string]: { [name: string]: { [size: string]: any } };
@@ -278,9 +279,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         delete this.message_div;
         delete this.message_td;
         delete this.message_text;
+        this.removeMoveTreeFromDOM();
         delete this.move_tree_container;
-        delete this.move_tree_inner_container;
-        delete this.move_tree_canvas;
         delete this.title_div;
     }
     private detachShadowLayer(): void {
@@ -1023,7 +1023,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         ) {
             const m = this.engine.getMoveByLocation(x, y, true);
             if (m) {
-                this.engine.jumpTo(m);
+                this.engine.jumpTo(this.clickJumpTarget(m));
                 this.emit("update");
             }
             return;
@@ -1649,6 +1649,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             pos.triangle ||
             pos.chat_triangle ||
             pos.sub_triangle ||
+            pos.ai_quality ||
             pos.cross ||
             pos.square
         ) {
@@ -1658,6 +1659,12 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             have_text_to_draw = true;
         }
         if (pos.subscript && pos.subscript.length > 0) {
+            have_text_to_draw = true;
+        }
+        if (pos.subscript2 && pos.subscript2.length > 0) {
+            have_text_to_draw = true;
+        }
+        if (this.colored_circles?.[j][i]) {
             have_text_to_draw = true;
         }
 
@@ -1871,6 +1878,24 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     color = pos.black ? 1 : 2;
                     translucent = true;
                     stoneAlphaValue = this.variation_stone_opacity;
+                    if (
+                        this.present_next_move &&
+                        this.engine.cur_move.trunk_next &&
+                        this.engine.cur_move.trunk_next.x === i &&
+                        this.engine.cur_move.trunk_next.y === j
+                    ) {
+                        /* the presented next move reads a bit more solidly
+                         * than other mark stones */
+                        stoneAlphaValue = Math.min(1, stoneAlphaValue + 0.15);
+                    }
+                    if (
+                        this.last_hover_square &&
+                        this.last_hover_square.x === i &&
+                        this.last_hover_square.y === j
+                    ) {
+                        /* make the stone stand out while hovered */
+                        stoneAlphaValue = 1.0;
+                    }
                 } else {
                     color = this.engine.player;
                 }
@@ -2277,11 +2302,37 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     yy += this.square_size * 0.3;
                 }
 
+                if (pos.subscript2) {
+                    yy -= this.square_size * 0.15;
+                }
+
                 ctx.textBaseline = "middle";
                 if (transparent) {
                     ctx.globalAlpha = 0.6;
                 }
                 ctx.fillText(subscript, xx, yy);
+                draw_last_move = false;
+                ctx.restore();
+            }
+
+            if (pos.subscript2) {
+                letter_was_drawn = true;
+                ctx.save();
+                ctx.fillStyle = text_color;
+
+                const [, , metrics] = fitText(
+                    ctx,
+                    pos.subscript2,
+                    `bold FONT_SIZEpx ${GOBAN_FONT}`,
+                    this.square_size * 0.28,
+                    this.square_size * 0.7,
+                );
+
+                ctx.textBaseline = "middle";
+                if (transparent) {
+                    ctx.globalAlpha = 0.6;
+                }
+                ctx.fillText(pos.subscript2, cx - metrics.width / 2, cy + this.square_size * 0.35);
                 draw_last_move = false;
                 ctx.restore();
             }
@@ -2330,12 +2381,32 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 ctx.restore();
                 draw_last_move = false;
             }
+            if (pos.ai_quality) {
+                const badge = AI_QUALITY_BADGES[pos.ai_quality];
+                if (badge) {
+                    const oy = this.square_size * 0.3;
+                    const r = this.square_size * 0.2;
+                    ctx.save();
+                    ctx.beginPath();
+                    ctx.fillStyle = badge.color;
+                    ctx.arc(cx, cy + oy, r, 0, 2 * Math.PI, false);
+                    ctx.fill();
+                    ctx.fillStyle = "#FFFFFF";
+                    ctx.font = `bold ${this.square_size * 0.24}px ${GOBAN_FONT}`;
+                    ctx.textAlign = "center";
+                    ctx.textBaseline = "middle";
+                    ctx.fillText(badge.symbol, cx, cy + oy);
+                    ctx.restore();
+                    draw_last_move = false;
+                }
+            }
             if (
-                pos.triangle ||
-                pos.chat_triangle ||
-                pos.sub_triangle ||
-                alt_marking === "triangle" ||
-                hover_mark === "triangle"
+                !pos.ai_quality &&
+                (pos.triangle ||
+                    pos.chat_triangle ||
+                    pos.sub_triangle ||
+                    alt_marking === "triangle" ||
+                    hover_mark === "triangle")
             ) {
                 let scale = 1.0;
                 let oy = 0.0;
@@ -2446,12 +2517,18 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                             ? this.theme_black_text_color
                             : this.theme_white_text_color;
 
+                    /* While the AI review presents the next move, the last
+                     * move circle takes a back seat to the presented stone */
+                    const last_move_opacity = this.present_next_move
+                        ? Math.min(this.last_move_opacity, 0.4)
+                        : this.last_move_opacity;
+
                     if (this.submit_move) {
                         ctx.lineCap = "square";
                         ctx.save();
                         ctx.beginPath();
                         ctx.lineWidth = this.square_size * 0.075;
-                        ctx.globalAlpha = this.last_move_opacity;
+                        ctx.globalAlpha = last_move_opacity;
                         const r = Math.max(1, this.metrics.mid * 0.35) * 0.8;
                         ctx.moveTo(cx - r, cy);
                         ctx.lineTo(cx + r, cy);
@@ -2469,7 +2546,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                             ctx.beginPath();
                             ctx.strokeStyle = color;
                             ctx.lineWidth = this.square_size * 0.075;
-                            ctx.globalAlpha = this.last_move_opacity;
+                            ctx.globalAlpha = last_move_opacity;
                             let r = this.square_size * this.last_move_radius;
                             if (this.submit_move) {
                                 r = this.square_size * 0.3;
@@ -2686,6 +2763,25 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 }
 
                 ret += (translucent ? "T" : "") + color + ",";
+                if (
+                    (pos.black || pos.white) &&
+                    this.last_hover_square &&
+                    this.last_hover_square.x === i &&
+                    this.last_hover_square.y === j
+                ) {
+                    /* hovered mark stones draw less translucently */
+                    ret += "hover,";
+                }
+                if (
+                    (pos.black || pos.white) &&
+                    this.present_next_move &&
+                    this.engine.cur_move.trunk_next &&
+                    this.engine.cur_move.trunk_next.x === i &&
+                    this.engine.cur_move.trunk_next.y === j
+                ) {
+                    /* the presented next move draws less translucently */
+                    ret += "presented,";
+                }
             }
         }
 
@@ -2892,6 +2988,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             if (pos.subscript) {
                 ret += " _ " + pos.subscript + (transparent ? " fade" : "") + ",";
             }
+            if (pos.subscript2) {
+                ret += " _2 " + pos.subscript2 + ",";
+            }
         }
 
         /* draw special symbols */
@@ -2915,6 +3014,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             if (pos.circle) {
                 ret += "circle,";
             }
+            if (pos.ai_quality) {
+                ret += "aiq " + pos.ai_quality + ",";
+            }
             if (pos.triangle || pos.chat_triangle || alt_marking === "triangle") {
                 ret += "triangle,";
             }
@@ -2935,6 +3037,10 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 ret += "last_move,";
+                if (this.present_next_move) {
+                    /* the last move circle draws dimmed while presenting */
+                    ret += "dimmed,";
+                }
                 if (this.getShowUndoRequestIndicator() && this.engine.isStoneInUndoRequest(i, j)) {
                     ret += "?" + ",";
                 }
@@ -3560,12 +3666,28 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
     // Move tree
     //
     public setMoveTreeContainer(container: HTMLElement | null): void {
+        if (this.move_tree_container !== (container ?? undefined)) {
+            this.removeMoveTreeFromDOM();
+        }
         this.move_tree_container = container ?? undefined;
         this.move_tree_redraw();
     }
 
+    /**
+     * Removes this goban's move tree elements from the container so another
+     * goban can take the container over without our stale tree lingering
+     * behind its own.
+     */
+    private removeMoveTreeFromDOM(): void {
+        if (this.move_tree_inner_container) {
+            this.move_tree_inner_container.remove();
+        }
+        delete this.move_tree_inner_container;
+        delete this.move_tree_canvas;
+    }
+
     public move_tree_redraw(no_warp?: boolean): void {
-        if (!this.move_tree_container) {
+        if (this.destroyed || !this.move_tree_container) {
             return;
         }
 
@@ -3631,7 +3753,10 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         */
 
         this.engine.move_tree.recomputeIsobranches();
-        const active_path_end = this.engine.cur_move;
+        const active_path_end =
+            this.present_next_move && this.engine.cur_move.trunk_next
+                ? this.engine.cur_move.trunk_next
+                : this.engine.cur_move;
 
         this.engine.move_tree_layout_dirty = false;
 
@@ -3759,22 +3884,23 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 const node = this.engine.move_tree.getNodeAtLayoutPosition(i, j);
 
                 if (node) {
-                    if (this.engine.cur_move.id !== node.id) {
-                        this.engine.jumpTo(node);
+                    const target = this.clickJumpTarget(node);
+                    if (this.engine.cur_move.id !== target.id) {
+                        this.engine.jumpTo(target);
                         this.setLabelCharacterFromMarks();
                         this.updateTitleAndStonePlacement();
                         this.emit("update");
                         this.syncReviewMove();
                         this.redraw();
                     }
-                    if (this.engine.cur_move.played_by) {
+                    if (node.played_by) {
                         // note that getRelativeEventPosition handles various
                         // nasty looking things to do with Touch etc, so using it here
                         // gets around that kind of thing, even though in theory it
                         // might be nicer to sent the client absolute coords, maybe.
                         const rpos = getRelativeEventPosition(event);
                         this.emit("played-by-click", {
-                            player_id: this.engine.cur_move.played_by,
+                            player_id: node.played_by,
                             x: rpos.x,
                             y: rpos.y,
                         });

--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -24,7 +24,7 @@ import {
     GobanMoveError,
 } from "../engine";
 import { NumberMatrix, encodeMove, makeMatrix, makeEmptyMatrix } from "../engine/util";
-import { MoveTree, MarkInterface } from "../engine/MoveTree";
+import { MoveTree, MarkInterface, AIQualityMark } from "../engine/MoveTree";
 import { ScoreEstimator } from "../engine/ScoreEstimator";
 import { computeAverageMoveTime, niceInterval, matricesAreEqual } from "../engine/util";
 import { _ } from "../engine/translate";
@@ -67,6 +67,24 @@ export interface ColoredCircle {
     border_color?: string;
 }
 
+/**
+ * Badge shown on a stone for each AI review move quality classification:
+ * the symbol drawn in white on a filled circle of the given color. The
+ * colors mirror the `--move-quality-*` CSS variables used by the
+ * online-go.com AI review summary table; renderers use the CSS variable
+ * when available and fall back to these values.
+ */
+export const AI_QUALITY_BADGES: {
+    [quality in AIQualityMark]: { symbol: string; color: string };
+} = {
+    excellent: { symbol: "!!", color: "#2E86AB" },
+    great: { symbol: "!", color: "#3DA35D" },
+    good: { symbol: "+", color: "#6AB04C" },
+    inaccuracy: { symbol: "-", color: "#E8A838" },
+    mistake: { symbol: "?", color: "#E87D3E" },
+    blunder: { symbol: "??", color: "#D64545" },
+};
+
 export interface MoveCommand {
     //game_id?: number | string;
     game_id: number;
@@ -105,6 +123,46 @@ export abstract class GobanInteractive extends GobanBase {
     public showing_scores: boolean = false;
     public stalling_score_estimate?: StallingScoreEstimate;
     public width: number;
+
+    /**
+     * When true, the goban operates in "presented move" space: the current
+     * move's trunk_next is treated as the move being shown to the user. The
+     * move tree highlights it and ends the active path there, clicks that
+     * jump to a played trunk move (move tree nodes, board shift-clicks)
+     * resolve through clickJumpTarget so the clicked move becomes the
+     * presented one, the presented stone draws more solidly, and the last
+     * move circle is dimmed. The AI review sets this while it presents the
+     * next trunk move as a translucent stone on the board.
+     */
+    private _present_next_move: boolean = false;
+
+    public get present_next_move(): boolean {
+        return this._present_next_move;
+    }
+    public setPresentNextMove(enabled: boolean): void {
+        if (this._present_next_move === enabled) {
+            return;
+        }
+        this._present_next_move = enabled;
+        this.move_tree_redraw();
+        /* Board rendering also depends on this flag (presented stone
+         * opacity, dimmed last move circle) */
+        this.redraw(true);
+    }
+
+    /**
+     * Resolves which node a click that jumps to a played move (a move tree
+     * node, a board shift-click) should land on. In presented move space a
+     * click on a trunk node jumps to its parent, so the clicked move becomes
+     * the presented move; variation nodes and the root are jumped to
+     * directly.
+     */
+    public clickJumpTarget(node: MoveTree): MoveTree {
+        if (this._present_next_move && node.trunk && node.parent) {
+            return node.parent;
+        }
+        return node;
+    }
 
     public pause_control?: AdHocPauseControl;
     public paused_since?: number;
@@ -1426,7 +1484,12 @@ export abstract class GobanInteractive extends GobanBase {
     }
     public setColoredCircles(circles?: Array<ColoredCircle>, dont_draw?: boolean): void {
         if (!circles || circles.length === 0) {
+            const had_circles = !!this.colored_circles;
             delete this.colored_circles;
+            /* repaint so previously drawn circles actually disappear */
+            if (had_circles && !dont_draw) {
+                this.redraw(true);
+            }
             return;
         }
 
@@ -1474,6 +1537,36 @@ export abstract class GobanInteractive extends GobanBase {
             this.savePreAIMarks(this.getMarks(x, y));
         }
         this.engine.cur_move.getMarks(x, y).subscript = mark;
+        if (drawSquare) {
+            this.drawSquare(x, y);
+        }
+    }
+    public setSubscript2Mark(
+        x: number,
+        y: number,
+        mark: string,
+        drawSquare: boolean = true,
+        ai_annotation: boolean = true,
+    ): void {
+        if (ai_annotation) {
+            this.savePreAIMarks(this.getMarks(x, y));
+        }
+        this.engine.cur_move.getMarks(x, y).subscript2 = mark;
+        if (drawSquare) {
+            this.drawSquare(x, y);
+        }
+    }
+    public setAIQualityMark(
+        x: number,
+        y: number,
+        quality: AIQualityMark,
+        drawSquare: boolean = true,
+        ai_annotation: boolean = true,
+    ): void {
+        if (ai_annotation) {
+            this.savePreAIMarks(this.getMarks(x, y));
+        }
+        this.engine.cur_move.getMarks(x, y).ai_quality = quality;
         if (drawSquare) {
             this.drawSquare(x, y);
         }

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -46,7 +46,8 @@ import {
     CaptureDisplay,
     ResolvedBoardBackground,
 } from "./Goban";
-import { ColoredCircle } from "./InteractiveBase";
+import { ColoredCircle, AI_QUALITY_BADGES } from "./InteractiveBase";
+import { AIQualityMark } from "../engine/MoveTree";
 
 //import { GobanCanvasConfig, GobanCanvasInterface } from "./GobanCanvas";
 
@@ -350,9 +351,8 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         delete this.message_div;
         delete this.message_td;
         delete this.message_text;
+        this.removeMoveTreeFromDOM();
         delete this.move_tree_container;
-        delete this.move_tree_inner_container;
-        delete this.move_tree_svg;
         delete this.title_div;
     }
     private detachPenLayer(): void {
@@ -909,7 +909,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         ) {
             const m = this.engine.getMoveByLocation(x, y, true);
             if (m) {
-                this.engine.jumpTo(m);
+                this.engine.jumpTo(this.clickJumpTarget(m));
                 this.emit("update");
             }
             return;
@@ -1430,6 +1430,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             pos.triangle ||
             pos.chat_triangle ||
             pos.sub_triangle ||
+            pos.ai_quality ||
             pos.cross ||
             pos.square
         ) {
@@ -1439,6 +1440,12 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             have_text_to_draw = true;
         }
         if (pos.subscript && pos.subscript.length > 0) {
+            have_text_to_draw = true;
+        }
+        if (pos.subscript2 && pos.subscript2.length > 0) {
+            have_text_to_draw = true;
+        }
+        if (this.colored_circles?.[j][i]) {
             have_text_to_draw = true;
         }
 
@@ -1601,6 +1608,24 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                     color = pos.black ? 1 : 2;
                     translucent = true;
                     stoneAlphaValue = this.variation_stone_opacity;
+                    if (
+                        this.present_next_move &&
+                        this.engine.cur_move.trunk_next &&
+                        this.engine.cur_move.trunk_next.x === i &&
+                        this.engine.cur_move.trunk_next.y === j
+                    ) {
+                        /* the presented next move reads a bit more solidly
+                         * than other mark stones */
+                        stoneAlphaValue = Math.min(1, stoneAlphaValue + 0.15);
+                    }
+                    if (
+                        this.last_hover_square &&
+                        this.last_hover_square.x === i &&
+                        this.last_hover_square.y === j
+                    ) {
+                        /* make the stone stand out while hovered */
+                        stoneAlphaValue = 1.0;
+                    }
                 } else {
                     color = this.engine.player;
                 }
@@ -1915,10 +1940,24 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                     this.square_size * 0.4 * this.stone_font_scale,
                     transparent ? 0.6 : 1.0,
                     !!letter,
-                    !!pos.sub_triangle,
+                    !!(pos.sub_triangle || pos.ai_quality),
+                    !!pos.subscript2,
                 );
             } else {
                 cell.clearSubscript();
+            }
+
+            if (pos.subscript2) {
+                letter_was_drawn = true;
+                draw_last_move = false;
+                cell.subscript2(
+                    pos.subscript2,
+                    text_color,
+                    this.square_size * 0.28 * this.stone_font_scale,
+                    transparent ? 0.6 : 1.0,
+                );
+            } else {
+                cell.clearSubscript2();
             }
         }
 
@@ -1957,12 +1996,20 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 cell.clearCircleSymbol();
             }
 
+            if (pos.ai_quality) {
+                draw_last_move = false;
+                cell.aiQualityBadge(pos.ai_quality);
+            } else {
+                cell.clearAIQualityBadge();
+            }
+
             if (
-                pos.triangle ||
-                pos.chat_triangle ||
-                pos.sub_triangle ||
-                alt_marking === "triangle" ||
-                hover_mark === "triangle"
+                !pos.ai_quality &&
+                (pos.triangle ||
+                    pos.chat_triangle ||
+                    pos.sub_triangle ||
+                    alt_marking === "triangle" ||
+                    hover_mark === "triangle")
             ) {
                 draw_last_move = false;
                 cell.triangleSymbol(symbol_color, transparent ? 0.6 : 1.0, !!pos.sub_triangle);
@@ -2019,15 +2066,21 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                             ? this.theme_black_text_color
                             : this.theme_white_text_color;
 
+                    /* While the AI review presents the next move, the last
+                     * move circle takes a back seat to the presented stone */
+                    const last_move_opacity = this.present_next_move
+                        ? Math.min(this.last_move_opacity, 0.4)
+                        : this.last_move_opacity;
+
                     if (this.submit_move) {
                         draw_last_move = false;
-                        cell.lastMove("+", color, this.last_move_opacity);
+                        cell.lastMove("+", color, last_move_opacity);
                     } else {
                         if (should_draw_undo) {
                             draw_last_move = false;
                             cell.lastMove("↶", color, 1.0);
                         } else {
-                            cell.lastMove("o", color, this.last_move_opacity);
+                            cell.lastMove("o", color, last_move_opacity);
                         }
                     }
                 }
@@ -2163,6 +2216,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             pos.triangle ||
             pos.chat_triangle ||
             pos.sub_triangle ||
+            pos.ai_quality ||
             pos.cross ||
             pos.square
         ) {
@@ -2172,6 +2226,12 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             have_text_to_draw = true;
         }
         if (pos.subscript && pos.subscript.length > 0) {
+            have_text_to_draw = true;
+        }
+        if (pos.subscript2 && pos.subscript2.length > 0) {
+            have_text_to_draw = true;
+        }
+        if (this.colored_circles?.[j][i]) {
             have_text_to_draw = true;
         }
 
@@ -2416,6 +2476,24 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                     color = pos.black ? 1 : 2;
                     translucent = true;
                     stoneAlphaValue = this.variation_stone_opacity;
+                    if (
+                        this.present_next_move &&
+                        this.engine.cur_move.trunk_next &&
+                        this.engine.cur_move.trunk_next.x === i &&
+                        this.engine.cur_move.trunk_next.y === j
+                    ) {
+                        /* the presented next move reads a bit more solidly
+                         * than other mark stones */
+                        stoneAlphaValue = Math.min(1, stoneAlphaValue + 0.15);
+                    }
+                    if (
+                        this.last_hover_square &&
+                        this.last_hover_square.x === i &&
+                        this.last_hover_square.y === j
+                    ) {
+                        /* make the stone stand out while hovered */
+                        stoneAlphaValue = 1.0;
+                    }
                 } else {
                     color = this.engine.player;
                 }
@@ -3621,6 +3699,62 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         return ret;
     }
 
+    /**
+     * The exact geometry of the board grid lines: the global coordinate of
+     * the first vertical (ox) and horizontal (oy) line, the stroke width,
+     * and the same line coordinates relative to a cell's origin
+     * (cell_line_x/cell_line_y, identical for every cell). Line n runs at
+     * ox + n * square_size. Shared by drawLines and the faded line overlays
+     * drawn by cells, so overlays cover the grid lines exactly.
+     */
+    public gridLineMetrics(): {
+        ox: number;
+        oy: number;
+        line_width: number;
+        cell_line_x: number;
+        cell_line_y: number;
+    } {
+        const ss = this.square_size;
+        let base_ox = this.draw_left_labels ? ss : 0;
+        let base_oy = this.draw_top_labels ? ss : 0;
+
+        if (this.bounds.left > 0) {
+            base_ox = -ss * this.bounds.left;
+        }
+        if (this.bounds.top > 0) {
+            base_oy = -ss * this.bounds.top;
+        }
+
+        // lines go through center of our stone grid
+        let ox = base_ox + Math.round(ss / 2);
+        let oy = base_oy + Math.round(ss / 2);
+
+        // Tiny square sizes, as in the ones used to display puzzle icons
+        const TINY_SQUARE_SIZE = 10;
+
+        // Compute a line width that is rounded to the nearest 0.5 so we
+        // get crisp lines
+        const line_width =
+            ss > TINY_SQUARE_SIZE
+                ? Math.round(2 * Math.round(Math.max(1, ss * 0.02))) * 0.5
+                : // for very small boards, like puzzle icons, have faint lines
+                  ss * 0.08;
+        ox -= line_width * 0.5;
+        oy -= line_width * 0.5;
+
+        // Round to half pixel offsets odd widths for crisp lines
+        ox = Math.round(ox * 2.0) * 0.5;
+        oy = Math.round(oy * 2.0) * 0.5;
+
+        return {
+            ox,
+            oy,
+            line_width,
+            cell_line_x: ox - base_ox,
+            cell_line_y: oy - base_oy,
+        };
+    }
+
     private drawLines(force_clear?: boolean): void {
         if (force_clear) {
             if (this.lines_layer) {
@@ -3631,36 +3765,10 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
 
         if (!this.lines_layer) {
             const ss = this.square_size;
-            let ox = this.draw_left_labels ? ss : 0;
-            let oy = this.draw_top_labels ? ss : 0;
-
-            if (this.bounds.left > 0) {
-                ox = -ss * this.bounds.left;
-            }
-            if (this.bounds.top > 0) {
-                oy = -ss * this.bounds.top;
-            }
-
-            // lines go through center of our stone grid
-            ox += Math.round(ss / 2);
-            oy += Math.round(ss / 2);
+            const { ox, oy, line_width } = this.gridLineMetrics();
 
             // Tiny square sizes, as in the ones used to display puzzle icons
             const TINY_SQUARE_SIZE = 10;
-
-            // Compute a line width that is rounded to the nearest 0.5 so we
-            // get crisp lines
-            const line_width =
-                ss > TINY_SQUARE_SIZE
-                    ? Math.round(2 * Math.round(Math.max(1, ss * 0.02))) * 0.5
-                    : // for very small boards, like puzzle icons, have faint lines
-                      ss * 0.08;
-            ox -= line_width * 0.5;
-            oy -= line_width * 0.5;
-
-            // Round to half pixel offsets odd widths for crisp lines
-            ox = Math.round(ox * 2.0) * 0.5;
-            oy = Math.round(oy * 2.0) * 0.5;
 
             this.lines_layer = document.createElementNS("http://www.w3.org/2000/svg", "g");
             const lines_path = document.createElementNS("http://www.w3.org/2000/svg", "path");
@@ -4440,12 +4548,29 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
     // Move tree
     //
     public setMoveTreeContainer(container: HTMLElement | null): void {
+        if (this.move_tree_container !== (container ?? undefined)) {
+            this.removeMoveTreeFromDOM();
+        }
         this.move_tree_container = container ?? undefined;
         this.move_tree_redraw();
     }
 
+    /**
+     * Removes this goban's move tree elements from the container so another
+     * goban can take the container over without our stale tree lingering
+     * behind its own.
+     */
+    private removeMoveTreeFromDOM(): void {
+        if (this.move_tree_inner_container) {
+            this.move_tree_inner_container.remove();
+        }
+        delete this.move_tree_inner_container;
+        delete this.move_tree_svg;
+        delete this.move_tree_svg_defs;
+    }
+
     public move_tree_redraw(no_warp?: boolean): void {
-        if (!this.move_tree_container) {
+        if (this.destroyed || !this.move_tree_container) {
             return;
         }
 
@@ -4533,7 +4658,10 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         this.engine.move_tree.recomputeIsobranches();
-        const active_path_end = this.engine.cur_move;
+        const active_path_end =
+            this.present_next_move && this.engine.cur_move.trunk_next
+                ? this.engine.cur_move.trunk_next
+                : this.engine.cur_move;
 
         this.engine.move_tree_layout_dirty = false;
 
@@ -4632,22 +4760,23 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 const node = this.engine.move_tree.getNodeAtLayoutPosition(i, j);
 
                 if (node) {
-                    if (this.engine.cur_move.id !== node.id) {
-                        this.engine.jumpTo(node);
+                    const target = this.clickJumpTarget(node);
+                    if (this.engine.cur_move.id !== target.id) {
+                        this.engine.jumpTo(target);
                         this.setLabelCharacterFromMarks();
                         this.updateTitleAndStonePlacement();
                         this.emit("update");
                         this.syncReviewMove();
                         this.redraw();
                     }
-                    if (this.engine.cur_move.played_by) {
+                    if (node.played_by) {
                         // note that getRelativeEventPosition handles various
                         // nasty looking things to do with Touch etc, so using it here
                         // gets around that kind of thing, even though in theory it
                         // might be nicer to sent the client absolute coords, maybe.
                         const rpos = getRelativeEventPosition(event, this.move_tree_container);
                         this.emit("played-by-click", {
-                            player_id: this.engine.cur_move.played_by,
+                            player_id: node.played_by,
                             x: rpos.x,
                             y: rpos.y,
                         });
@@ -5177,35 +5306,31 @@ class GCell {
 
         const mid = this.renderer.metrics.mid;
         const ss = this.renderer.square_size;
-        const offset = this.renderer.metrics.offset;
         const width = this.renderer.width;
         const height = this.renderer.height;
 
+        /* Use the exact grid line geometry so the faded lines fully cover
+         * the board lines instead of sitting next to them */
+        const { line_width, cell_line_x, cell_line_y } = this.renderer.gridLineMetrics();
+        const mx = cell_line_x;
+        const my = cell_line_y;
+
         let sx = 0;
         let ex = ss;
-        const mx = ss / 2 - offset;
         let sy = 0;
         let ey = ss;
-        const my = ss / 2 - offset;
 
         if (this.i === 0) {
-            sx += mid;
+            sx = mx;
         }
         if (this.i === width - 1) {
-            ex -= mid;
+            ex = mx;
         }
         if (this.j === 0) {
-            sy += mid;
+            sy = my;
         }
         if (this.j === height - 1) {
-            ey -= mid;
-        }
-
-        if (this.i === width - 1 && this.j === height - 1) {
-            if (mx === ex && my === ey) {
-                ex += 1;
-                ey += 1;
-            }
+            ey = my;
         }
 
         const cx = mid;
@@ -5226,13 +5351,14 @@ class GCell {
         const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
         this.last_faded_lines = path;
         path.setAttribute("stroke", this.renderer.theme_faded_line_color);
-        path.setAttribute("stroke-width", this.renderer.square_size < 5 ? "0.2" : "1");
+        path.setAttribute("stroke-width", `${line_width}px`);
+        path.setAttribute("stroke-linecap", "square");
         path.setAttribute("fill", "none");
         path.setAttribute(
             "d",
             `
-                M ${Math.floor(sx)} ${my} L ${Math.floor(ex)} ${my}
-                M ${mx} ${Math.floor(sy)} L ${mx} ${Math.floor(ey)} 
+                M ${sx} ${my} L ${ex} ${my}
+                M ${mx} ${sy} L ${mx} ${ey}
             `,
         );
         g.prepend(path);
@@ -5422,6 +5548,12 @@ class GCell {
             return;
         }
 
+        /* When redrawing an existing stone (e.g. a translucent mark stone
+         * changing opacity on hover), keep its position in the cell group so
+         * it does not get re-appended above cached elements such as
+         * subscripts and quality badges. */
+        const insert_before = this.last_stone?.nextSibling ?? null;
+
         this.clearStone();
 
         const mid = this.renderer.metrics.mid;
@@ -5468,6 +5600,10 @@ class GCell {
 
         if (transparent) {
             elt.setAttribute("opacity", stone_alpha_value.toString());
+        }
+
+        if (insert_before && insert_before.parentNode === this.g) {
+            this.g.insertBefore(elt, insert_before);
         }
 
         this.last_stone = elt;
@@ -5787,6 +5923,7 @@ class GCell {
     private last_subscript_opacity?: number;
     private last_subscript_room_for_letter?: boolean;
     private last_subscript_room_for_sub_triangle?: boolean;
+    private last_subscript_room_for_second_line?: boolean;
 
     public subscript(
         subscript: string,
@@ -5795,6 +5932,7 @@ class GCell {
         opacity: number,
         room_for_letter: boolean,
         room_for_sub_triangle: boolean,
+        room_for_second_line: boolean = false,
     ): void {
         if (
             this.last_subscript &&
@@ -5803,7 +5941,8 @@ class GCell {
             this.last_subscript_font_size === font_size &&
             this.last_subscript_opacity === opacity &&
             this.last_subscript_room_for_letter === room_for_letter &&
-            this.last_subscript_room_for_sub_triangle === room_for_sub_triangle
+            this.last_subscript_room_for_sub_triangle === room_for_sub_triangle &&
+            this.last_subscript_room_for_second_line === room_for_second_line
         ) {
             return;
         }
@@ -5834,6 +5973,10 @@ class GCell {
             yy -= ss * 0.08;
         }
 
+        if (room_for_second_line) {
+            yy -= ss * 0.15;
+        }
+
         text.setAttribute("y", yy.toString());
         text.textContent = subscript;
 
@@ -5849,6 +5992,7 @@ class GCell {
         this.last_subscript_opacity = opacity;
         this.last_subscript_room_for_letter = room_for_letter;
         this.last_subscript_room_for_sub_triangle = room_for_sub_triangle;
+        this.last_subscript_room_for_second_line = room_for_second_line;
     }
 
     public clearSubscript(): void {
@@ -5861,6 +6005,69 @@ class GCell {
             delete this.last_subscript_opacity;
             delete this.last_subscript_room_for_letter;
             delete this.last_subscript_room_for_sub_triangle;
+            delete this.last_subscript_room_for_second_line;
+        }
+    }
+
+    /*
+     * Second, smaller subscript line (e.g. AI visit counts)
+     */
+    private last_subscript2?: SVGTextElement;
+    private last_subscript2_text?: string;
+    private last_subscript2_color?: string;
+    private last_subscript2_font_size?: number;
+    private last_subscript2_opacity?: number;
+
+    public subscript2(
+        text_content: string,
+        color: string,
+        font_size: number,
+        opacity: number,
+    ): void {
+        if (
+            this.last_subscript2 &&
+            this.last_subscript2_text === text_content &&
+            this.last_subscript2_color === color &&
+            this.last_subscript2_font_size === font_size &&
+            this.last_subscript2_opacity === opacity
+        ) {
+            return;
+        }
+
+        this.clearSubscript2();
+
+        const mid = this.renderer.metrics.mid;
+        const ss = this.renderer.square_size;
+
+        const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        text.setAttribute("class", "subscript2");
+        text.setAttribute("fill", color);
+        text.setAttribute("font-size", `${font_size}px`);
+        text.setAttribute("text-anchor", "middle");
+        text.setAttribute("x", mid.toString());
+        text.setAttribute("y", (mid + ss * 0.32 + font_size * 0.3).toString());
+        text.textContent = text_content;
+
+        if (opacity < 1) {
+            text.setAttribute("fill-opacity", opacity.toString());
+        }
+        this.g.appendChild(text);
+
+        this.last_subscript2 = text;
+        this.last_subscript2_text = text_content;
+        this.last_subscript2_color = color;
+        this.last_subscript2_font_size = font_size;
+        this.last_subscript2_opacity = opacity;
+    }
+
+    public clearSubscript2(): void {
+        if (this.last_subscript2) {
+            this.last_subscript2.remove();
+            delete this.last_subscript2;
+            delete this.last_subscript2_text;
+            delete this.last_subscript2_color;
+            delete this.last_subscript2_font_size;
+            delete this.last_subscript2_opacity;
         }
     }
 
@@ -5989,6 +6196,67 @@ class GCell {
             delete this.last_triangle_symbol_color;
             delete this.last_triangle_symbol_opacity;
             delete this.last_triangle_symbol_as_subscript;
+        }
+    }
+
+    /*
+     * AI quality badge
+     */
+    private last_ai_quality_badge?: SVGGElement;
+    private last_ai_quality_badge_quality?: AIQualityMark;
+
+    public aiQualityBadge(quality: AIQualityMark): void {
+        if (this.last_ai_quality_badge && this.last_ai_quality_badge_quality === quality) {
+            return;
+        }
+
+        this.clearAIQualityBadge();
+
+        const badge = AI_QUALITY_BADGES[quality];
+        if (!badge) {
+            return;
+        }
+
+        const mid = this.renderer.metrics.mid;
+        const ss = this.renderer.square_size;
+        const scale = this.renderer.stone_font_scale;
+        const cx = mid;
+        const cy = mid + ss * 0.3;
+        const r = ss * 0.2 * scale;
+        const font_size = ss * 0.24 * scale;
+
+        const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        g.setAttribute("class", `ai-quality-badge ai-quality-${quality}`);
+
+        const circ = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+        circ.setAttribute("fill", `var(--move-quality-${quality}, ${badge.color})`);
+        circ.setAttribute("cx", cx.toFixed(2));
+        circ.setAttribute("cy", cy.toFixed(2));
+        circ.setAttribute("r", r.toFixed(2));
+
+        const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        text.setAttribute("class", "ai-quality-symbol");
+        text.setAttribute("fill", "#FFFFFF");
+        text.setAttribute("font-size", `${font_size}px`);
+        text.setAttribute("font-weight", "bold");
+        text.setAttribute("text-anchor", "middle");
+        text.setAttribute("x", cx.toFixed(2));
+        text.setAttribute("y", (cy + font_size * 0.35).toFixed(2));
+        text.textContent = badge.symbol;
+
+        g.appendChild(circ);
+        g.appendChild(text);
+        this.g.appendChild(g);
+
+        this.last_ai_quality_badge = g;
+        this.last_ai_quality_badge_quality = quality;
+    }
+
+    public clearAIQualityBadge(): void {
+        if (this.last_ai_quality_badge) {
+            this.last_ai_quality_badge.remove();
+            delete this.last_ai_quality_badge;
+            delete this.last_ai_quality_badge_quality;
         }
     }
 

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -32,14 +32,20 @@ import {
 } from "./formats/JGOF";
 import { escapeSGFText, newlines_to_spaces } from "./util";
 
+/** AI review quality classification of a played move, shown as a colored badge on the stone. */
+export type AIQualityMark = "excellent" | "great" | "good" | "inaccuracy" | "mistake" | "blunder";
+
 export interface MarkInterface {
     triangle?: boolean;
     square?: boolean;
     circle?: boolean;
     cross?: boolean;
     blue_move?: boolean;
+    ai_quality?: AIQualityMark;
     letter?: string;
     subscript?: string;
+    /** Smaller second line of text below the subscript (e.g. AI visit counts) */
+    subscript2?: string;
     transient_letter?: string;
     //score?: string | boolean;
     score?: string;

--- a/test/unit_tests/GobanSVG.test.ts
+++ b/test/unit_tests/GobanSVG.test.ts
@@ -661,3 +661,309 @@ describe("last-move crosshair (SVG)", () => {
         goban.destroy();
     });
 });
+
+describe("AI review marks and placement rooting", () => {
+    beforeEach(() => {
+        board_div = document.createElement("div");
+        document.body.appendChild(board_div);
+    });
+
+    afterEach(() => {
+        board_div.remove();
+    });
+
+    function rendererSvg(goban: SVGRenderer): SVGSVGElement {
+        return (goban as unknown as { svg: SVGSVGElement }).svg;
+    }
+
+    test("setAIQualityMark renders a colored badge with the quality symbol", () => {
+        const goban = new SVGRenderer(basic3x3Config({ moves: [[0, 0]], mode: "analyze" }));
+
+        goban.setAIQualityMark(0, 0, "blunder");
+
+        const badge = rendererSvg(goban).querySelector(".ai-quality-badge");
+        expect(badge).not.toBeNull();
+        expect(badge?.getAttribute("class")).toContain("ai-quality-blunder");
+        expect(badge?.querySelector("circle")?.getAttribute("fill")).toBe(
+            "var(--move-quality-blunder, #D64545)",
+        );
+        expect(badge?.querySelector("text")?.textContent).toBe("??");
+        goban.destroy();
+    });
+
+    test("ai_quality badge replaces the sub_triangle triangle", () => {
+        const goban = new SVGRenderer(basic3x3Config({ moves: [[0, 0]], mode: "analyze" }));
+        const svg = rendererSvg(goban);
+
+        goban.setMark(0, 0, "sub_triangle", false);
+        expect(svg.querySelector(".triangle")).not.toBeNull();
+
+        goban.setAIQualityMark(0, 0, "great");
+        expect(svg.querySelector(".triangle")).toBeNull();
+        expect(svg.querySelector(".ai-quality-badge text")?.textContent).toBe("!");
+        goban.destroy();
+    });
+
+    test("clearing marks removes the badge", () => {
+        const goban = new SVGRenderer(basic3x3Config({ moves: [[0, 0]], mode: "analyze" }));
+        const svg = rendererSvg(goban);
+
+        goban.setAIQualityMark(0, 0, "mistake");
+        expect(svg.querySelector(".ai-quality-badge")).not.toBeNull();
+
+        goban.engine.cur_move.clearMarks();
+        goban.redraw(true);
+        expect(svg.querySelector(".ai-quality-badge")).toBeNull();
+        goban.destroy();
+    });
+
+    test("hovering a mark stone draws it fully opaque", () => {
+        const goban = new SVGRenderer(basic3x3Config({ mode: "analyze" }));
+        goban.enableStonePlacement();
+        goban.setMark(1, 1, "black", false);
+
+        const svg = rendererSvg(goban);
+        const stoneOpacities = () =>
+            Array.from(svg.querySelectorAll("[opacity]")).map((e) => e.getAttribute("opacity"));
+
+        expect(stoneOpacities()).toContain("0.6");
+        expect(stoneOpacities()).not.toContain("1");
+
+        goban.parent.dispatchEvent(
+            new MouseEvent("mousemove", {
+                clientX: (1 + 1.5) * TEST_SQUARE_SIZE,
+                clientY: (1 + 1.5) * TEST_SQUARE_SIZE,
+            }),
+        );
+
+        expect(stoneOpacities()).toContain("1");
+        goban.destroy();
+    });
+
+    test("hover keeps the mark stone below its subscript and quality badge", () => {
+        const goban = new SVGRenderer(basic3x3Config({ mode: "analyze" }));
+        goban.enableStonePlacement();
+        goban.setMark(1, 1, "black", false);
+        goban.setSubscriptMark(1, 1, "1.5", true);
+        goban.setAIQualityMark(1, 1, "blunder");
+        const svg = rendererSvg(goban);
+
+        goban.parent.dispatchEvent(
+            new MouseEvent("mousemove", {
+                clientX: (1 + 1.5) * TEST_SQUARE_SIZE,
+                clientY: (1 + 1.5) * TEST_SQUARE_SIZE,
+            }),
+        );
+
+        const stone = svg.querySelector('[opacity="1"]')!;
+        const subscript = svg.querySelector(".subscript")!;
+        const badge = svg.querySelector(".ai-quality-badge")!;
+        expect(stone).not.toBeNull();
+        expect(
+            stone.compareDocumentPosition(subscript) & Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+        expect(
+            stone.compareDocumentPosition(badge) & Node.DOCUMENT_POSITION_FOLLOWING,
+        ).toBeTruthy();
+        goban.destroy();
+    });
+
+    test("the presented next move's stone draws less translucently", () => {
+        const goban = new SVGRenderer(
+            basic3x3Config({
+                moves: [
+                    [0, 0],
+                    [1, 0],
+                ],
+                mode: "analyze",
+            }),
+        );
+        // Sit on move 1; move 2 at (1, 0) is the presented next move
+        goban.showPrevious();
+        goban.setPresentNextMove(true);
+        goban.setMark(1, 0, "white", false);
+
+        const svg = rendererSvg(goban);
+        const opacities = Array.from(svg.querySelectorAll("[opacity]"))
+            .filter((e) => e.getAttribute("class") !== "last-move")
+            .map((e) => e.getAttribute("opacity"));
+        expect(opacities).toContain("0.75");
+        expect(opacities).not.toContain("0.6");
+        goban.destroy();
+    });
+
+    test("the last move circle dims while presenting", () => {
+        const goban = new SVGRenderer(
+            basic3x3Config({
+                moves: [
+                    [0, 0],
+                    [1, 0],
+                ],
+                mode: "analyze",
+            }),
+        );
+        goban.showPrevious();
+        const svg = rendererSvg(goban);
+
+        expect(svg.querySelector(".last-move")).not.toBeNull();
+        expect(svg.querySelector(".last-move")?.getAttribute("opacity")).toBeNull();
+
+        goban.setPresentNextMove(true);
+        expect(svg.querySelector(".last-move")?.getAttribute("opacity")).toBe("0.4");
+
+        goban.setPresentNextMove(false);
+        expect(svg.querySelector(".last-move")?.getAttribute("opacity")).toBeNull();
+        goban.destroy();
+    });
+
+    test("shift clicking a stone in presented move space presents that move", () => {
+        const goban = new SVGRenderer(
+            basic3x3Config({
+                moves: [
+                    [0, 0],
+                    [1, 0],
+                    [2, 0],
+                ],
+                mode: "analyze",
+            }),
+        );
+        const event_layer = goban.parent;
+        goban.setPresentNextMove(true);
+
+        // Shift-click the stone of move 2 at (1, 0): the engine lands on
+        // move 1 so that move 2 is the presented move
+        simulateMouseClick(event_layer, { x: 1, y: 0, shiftKey: true });
+
+        expect(goban.engine.cur_move.move_number).toBe(1);
+        expect(goban.engine.cur_move.trunk_next?.move_number).toBe(2);
+        goban.destroy();
+    });
+
+    test("a goban removes its move tree from the container when detached or destroyed", () => {
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+
+        const goban_a = new SVGRenderer(
+            basic3x3Config({
+                moves: [
+                    [0, 0],
+                    [1, 0],
+                ],
+                mode: "analyze",
+            }),
+        );
+        goban_a.setMoveTreeContainer(container);
+        expect(container.children.length).toBe(1);
+
+        // Detaching (as GobanController.destroy does) removes the tree
+        goban_a.setMoveTreeContainer(null);
+        expect(container.children.length).toBe(0);
+        goban_a.destroy();
+
+        // A new goban taking over the container is the only tree in it,
+        // even when the old goban is destroyed without detaching first
+        const goban_b = new SVGRenderer(basic3x3Config({ moves: [[0, 0]], mode: "analyze" }));
+        goban_b.setMoveTreeContainer(container);
+        expect(container.children.length).toBe(1);
+        goban_b.destroy();
+        expect(container.children.length).toBe(0);
+
+        container.remove();
+    });
+
+    test("clearing colored circles removes them from the board", () => {
+        const goban = new SVGRenderer(basic3x3Config({ mode: "analyze" }));
+        const svg = rendererSvg(goban);
+
+        goban.setColoredCircles([{ move: { x: 1, y: 1 }, color: "rgba(0, 130, 255, 0.7)" }], false);
+        expect(svg.querySelector(".colored-circle")).not.toBeNull();
+
+        goban.setColoredCircles([], false);
+        expect(svg.querySelector(".colored-circle")).toBeNull();
+        goban.destroy();
+    });
+
+    test("subscript2 renders a second line below the subscript", () => {
+        const goban = new SVGRenderer(basic3x3Config({ mode: "analyze" }));
+        goban.setSubscriptMark(1, 1, "-1.0", true);
+        goban.setSubscript2Mark(1, 1, "123", true);
+
+        const svg = rendererSvg(goban);
+        const sub = svg.querySelector(".subscript");
+        const sub2 = svg.querySelector(".subscript2");
+        expect(sub?.textContent).toBe("-1.0");
+        expect(sub2?.textContent).toBe("123");
+        expect(parseFloat(sub2!.getAttribute("y")!)).toBeGreaterThan(
+            parseFloat(sub!.getAttribute("y")!),
+        );
+
+        goban.engine.cur_move.clearMarks();
+        goban.redraw(true);
+        expect(svg.querySelector(".subscript2")).toBeNull();
+        goban.destroy();
+    });
+
+    test("clickJumpTarget resolves clicks in presented move space", () => {
+        const goban = new SVGRenderer(
+            basic3x3Config({
+                moves: [
+                    [0, 0],
+                    [1, 0],
+                    [2, 0],
+                ],
+                mode: "analyze",
+            }),
+        );
+        const move3 = goban.engine.cur_move;
+        const move2 = move3.parent!;
+        const root = goban.engine.move_tree;
+
+        // Without presentation, clicks jump to the clicked node
+        expect(goban.clickJumpTarget(move3).id).toBe(move3.id);
+
+        goban.setPresentNextMove(true);
+
+        // A trunk node click presents that move: jump to its parent
+        expect(goban.clickJumpTarget(move3).id).toBe(move2.id);
+        // The root has no parent and is jumped to directly
+        expect(goban.clickJumpTarget(root).id).toBe(root.id);
+
+        // Variation nodes are jumped to directly
+        goban.engine.jumpTo(move2);
+        goban.engine.place(1, 1);
+        const variation = goban.engine.cur_move;
+        expect(variation.trunk).toBe(false);
+        expect(goban.clickJumpTarget(variation).id).toBe(variation.id);
+        goban.destroy();
+    });
+
+    test("clicking the point of the next trunk move follows it instead of branching", () => {
+        const goban = new SVGRenderer(
+            basic3x3Config({
+                moves: [
+                    [0, 0],
+                    [1, 0],
+                    [2, 0],
+                ],
+                mode: "analyze",
+            }),
+        );
+        const event_layer = goban.parent;
+        goban.enableStonePlacement();
+
+        // Step back to move 2, then click where trunk move 3 was played
+        goban.showPrevious();
+        expect(goban.engine.cur_move.move_number).toBe(2);
+
+        simulateMouseClick(event_layer, { x: 2, y: 0 });
+
+        expect(goban.engine.cur_move.move_number).toBe(3);
+        expect(goban.engine.cur_move.trunk).toBe(true);
+        expect(goban.engine.board).toEqual([
+            [1, 2, 1],
+            [0, 0, 0],
+            [0, 0, 0],
+        ]);
+        goban.destroy();
+    });
+});


### PR DESCRIPTION
Goban-side support for the reworked online-go.com AI review display, where the review presents the next trunk move as a translucent stone on the board (companion frontend PR: online-go/online-go.com — stacked on #3575).

## What's included

- **`present_next_move` flag** — when set, the goban operates in "presented move" space:
  - The move tree highlights `trunk_next` as the active move and ends the active path there.
  - Clicks that jump to a played trunk move (move tree nodes, board shift-clicks) resolve through the new `clickJumpTarget()` so the clicked move becomes the presented one; variation nodes and the root jump directly.
  - The presented stone draws more solidly than other mark stones (+0.15 alpha) and goes fully opaque on hover.
  - The last-move circle dims to at most 0.4 opacity.
- **`ai_quality` mark** — a colored move-quality badge (`!!`, `!`, `+`, `-`, `?`, `??`) drawn where the sub-triangle sits, filled via `var(--move-quality-*)` with baked-in fallbacks.
- **`subscript2` mark** — a smaller second text line below the subscript (used for AI visit counts); the main subscript shifts up to make room.
- **Faded intersection lines** now derive from the exact grid geometry (`gridLineMetrics()`) so they fully cover the board lines instead of sitting beside them, and they draw under colored circles even when no text is present.
- **Fixes**:
  - Clearing colored circles repaints the board (stale circles no longer linger until hover).
  - Gobans remove their move tree DOM from the shared container on detach/destroy, so a replacement goban doesn't show the old tree; `move_tree_redraw` is inert after destroy.
  - Redrawing a stone preserves its DOM position, keeping translucent mark stones below their subscripts/badges on hover.

## Testing

- 381 jest tests pass, including new coverage for the badge, subscript2, presented-move click resolution, shift-click presenting, hover opacity, stone z-order, colored-circle clearing, and move-tree container cleanup.
- lint / prettier / tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEy646ASEDgtUXDGBShc6F