### PR TITLE
Draw the AI review badge as a triangle and drop presented-move support

### DIFF
--- a/src/Goban/CanvasRenderer.ts
+++ b/src/Goban/CanvasRenderer.ts
@@ -50,7 +50,7 @@ import {
     CaptureDisplay,
     ResolvedBoardBackground,
 } from "./Goban";
-import { AI_QUALITY_BADGES } from "./InteractiveBase";
+import { AI_QUALITY_BADGES, AI_QUALITY_BADGE } from "./InteractiveBase";
 
 const __theme_cache: {
     [bw: string]: { [name: string]: { [size: string]: any } };
@@ -1054,7 +1054,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         ) {
             const m = this.engine.getMoveByLocation(x, y, true);
             if (m) {
-                this.engine.jumpTo(this.clickJumpTarget(m));
+                this.engine.jumpTo(m);
                 this.emit("update");
             }
             return;
@@ -1910,16 +1910,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                     translucent = true;
                     stoneAlphaValue = this.variation_stone_opacity;
                     if (
-                        this.present_next_move &&
-                        this.engine.cur_move.trunk_next &&
-                        this.engine.cur_move.trunk_next.x === i &&
-                        this.engine.cur_move.trunk_next.y === j
-                    ) {
-                        /* the presented next move reads a bit more solidly
-                         * than other mark stones */
-                        stoneAlphaValue = Math.min(1, stoneAlphaValue + 0.15);
-                    }
-                    if (
                         this.last_hover_square &&
                         this.last_hover_square.x === i &&
                         this.last_hover_square.y === j
@@ -2415,21 +2405,27 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
             if (pos.ai_quality) {
                 const badge = AI_QUALITY_BADGES[pos.ai_quality];
                 if (badge) {
-                    const oy = this.square_size * 0.3;
-                    const r = this.square_size * 0.2;
+                    const ss = this.square_size;
+                    const by = cy + ss * AI_QUALITY_BADGE.offset_y;
                     ctx.save();
                     ctx.beginPath();
                     ctx.fillStyle =
                         getComputedStyle(document.documentElement)
                             .getPropertyValue(`--move-quality-${pos.ai_quality}`)
                             .trim() || badge.color;
-                    ctx.arc(cx, cy + oy, r, 0, 2 * Math.PI, false);
+                    const r = ss * AI_QUALITY_BADGE.radius;
+                    let theta = -(Math.PI * 2) / 4;
+                    ctx.moveTo(cx + r * Math.cos(theta), by + r * Math.sin(theta));
+                    theta += (Math.PI * 2) / 3;
+                    ctx.lineTo(cx + r * Math.cos(theta), by + r * Math.sin(theta));
+                    theta += (Math.PI * 2) / 3;
+                    ctx.lineTo(cx + r * Math.cos(theta), by + r * Math.sin(theta));
+                    ctx.closePath();
                     ctx.fill();
-                    ctx.fillStyle = "#FFFFFF";
-                    ctx.font = `bold ${this.square_size * 0.24}px ${GOBAN_FONT}`;
-                    ctx.textAlign = "center";
-                    ctx.textBaseline = "middle";
-                    ctx.fillText(badge.symbol, cx, cy + oy);
+                    ctx.lineWidth = ss * AI_QUALITY_BADGE.border_width;
+                    ctx.lineJoin = "round";
+                    ctx.strokeStyle = AI_QUALITY_BADGE.border_color;
+                    ctx.stroke();
                     ctx.restore();
                     draw_last_move = false;
                 }
@@ -2551,11 +2547,7 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                             ? this.theme_black_text_color
                             : this.theme_white_text_color;
 
-                    /* While the AI review presents the next move, the last
-                     * move circle takes a back seat to the presented stone */
-                    const last_move_opacity = this.present_next_move
-                        ? Math.min(this.last_move_opacity, 0.4)
-                        : this.last_move_opacity;
+                    const last_move_opacity = this.last_move_opacity;
 
                     if (this.submit_move) {
                         ctx.lineCap = "square";
@@ -2805,16 +2797,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 ) {
                     /* hovered mark stones draw less translucently */
                     ret += "hover,";
-                }
-                if (
-                    (pos.black || pos.white) &&
-                    this.present_next_move &&
-                    this.engine.cur_move.trunk_next &&
-                    this.engine.cur_move.trunk_next.x === i &&
-                    this.engine.cur_move.trunk_next.y === j
-                ) {
-                    /* the presented next move draws less translucently */
-                    ret += "presented,";
                 }
             }
         }
@@ -3071,10 +3053,6 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 (this.engine.phase === "play" || this.engine.phase === "finished")
             ) {
                 ret += "last_move,";
-                if (this.present_next_move) {
-                    /* the last move circle draws dimmed while presenting */
-                    ret += "dimmed,";
-                }
                 if (this.getShowUndoRequestIndicator() && this.engine.isStoneInUndoRequest(i, j)) {
                     ret += "?" + ",";
                 }
@@ -3787,14 +3765,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         */
 
         this.engine.move_tree.recomputeIsobranches();
-        const active_path_end =
-            this.present_next_move && this.engine.cur_move.trunk_next
-                ? this.engine.cur_move.trunk_next
-                : this.engine.cur_move;
-
         this.engine.move_tree_layout_dirty = false;
 
-        active_path_end.setActivePath(++MoveTree.active_path_number);
+        this.engine.cur_move.setActivePath(++MoveTree.active_path_number);
 
         /*
         if (!this.move_tree_container.data("move-tree-redraw-on-scroll")) {
@@ -3844,15 +3817,15 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         if (!no_warp) {
             /* make sure our active stone is visible, but don't scroll around unnecessarily */
             if (
-                div_scroll_left > active_path_end.layout_cx ||
-                div_scroll_left + div_clientWidth - 20 < active_path_end.layout_cx ||
-                div_scroll_top > active_path_end.layout_cy ||
-                div_scroll_top + div_clientHeight - 20 < active_path_end.layout_cy
+                div_scroll_left > this.engine.cur_move.layout_cx ||
+                div_scroll_left + div_clientWidth - 20 < this.engine.cur_move.layout_cx ||
+                div_scroll_top > this.engine.cur_move.layout_cy ||
+                div_scroll_top + div_clientHeight - 20 < this.engine.cur_move.layout_cy
             ) {
                 this.move_tree_container.scrollLeft =
-                    active_path_end.layout_cx - div_clientWidth / 2;
+                    this.engine.cur_move.layout_cx - div_clientWidth / 2;
                 this.move_tree_container.scrollTop =
-                    active_path_end.layout_cy - div_clientHeight / 2;
+                    this.engine.cur_move.layout_cy - div_clientHeight / 2;
                 div_scroll_top = this.move_tree_container.scrollTop;
                 div_scroll_left = this.move_tree_container.scrollLeft;
             }
@@ -3876,9 +3849,9 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
         }
         ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-        this.move_tree_hilightNode(ctx, active_path_end, "#6BAADA", viewport);
+        this.move_tree_hilightNode(ctx, this.engine.cur_move, "#6BAADA", viewport);
 
-        if (engine.cur_review_move && engine.cur_review_move.id !== active_path_end.id) {
+        if (engine.cur_review_move && engine.cur_review_move.id !== this.engine.cur_move.id) {
             this.move_tree_hilightNode(ctx, engine.cur_review_move, "#6BDA6B", viewport);
         }
 
@@ -3918,9 +3891,8 @@ export class GobanCanvas extends Goban implements GobanCanvasInterface {
                 const node = this.engine.move_tree.getNodeAtLayoutPosition(i, j);
 
                 if (node) {
-                    const target = this.clickJumpTarget(node);
-                    if (this.engine.cur_move.id !== target.id) {
-                        this.engine.jumpTo(target);
+                    if (this.engine.cur_move.id !== node.id) {
+                        this.engine.jumpTo(node);
                         this.setLabelCharacterFromMarks();
                         this.updateTitleAndStonePlacement();
                         this.emit("update");

--- a/src/Goban/GobanNativeBridge.ts
+++ b/src/Goban/GobanNativeBridge.ts
@@ -388,16 +388,6 @@ export class GobanNativeBridge extends GobanCanvas {
      * canvas; non-"play" engine phases (stone removal, finished) need
      * removal/score drawing, so they fall back too.
      *
-     * `present_next_move` is the AI review's presented-move space, where
-     * the board shows a move that has not been played: a translucent stone
-     * at the current move's trunk_next, over a last-move ring dimmed to
-     * make room for it. Contract v1 models neither -- its `board` carries
-     * only played stones and its `lastMove` draws one fixed ring -- so a
-     * presented board is never serviceable. In practice the presented
-     * stone arrives as a mark and `hasMarks()` would catch it, but the flag
-     * is what actually means "not a plain board", and it also dims the ring
-     * on its own.
-     *
      * The conditions below are the renderer's own `drawingHash()` -- the
      * canonical list of everything that changes a drawn square -- minus
      * what v1 carries. The one entry deliberately left out is the
@@ -411,7 +401,6 @@ export class GobanNativeBridge extends GobanCanvas {
             this.mode === "play" &&
             this.engine.phase === "play" &&
             this.engine.width === this.engine.height &&
-            !this.present_next_move &&
             !this.scoring_mode &&
             !this.heatmap &&
             !this.colored_circles &&

--- a/src/Goban/InteractiveBase.ts
+++ b/src/Goban/InteractiveBase.ts
@@ -85,6 +85,21 @@ export const AI_QUALITY_BADGES: {
     blunder: { symbol: "??", color: "#D64545" },
 };
 
+/**
+ * Geometry of the move quality badge, in fractions of the square size. It is
+ * the same small upward triangle as the sub_triangle mark (circumradius 0.15
+ * of the square, drawn low on the stone), filled with the quality color and
+ * outlined dark. The quality is conveyed by the color alone.
+ */
+export const AI_QUALITY_BADGE = {
+    /** Vertical offset of the triangle's center from the stone center */
+    offset_y: 0.3,
+    /** Circumradius of the triangle */
+    radius: 0.15,
+    border_width: 0.0375,
+    border_color: "rgba(0, 0, 0, 0.75)",
+};
+
 export interface MoveCommand {
     //game_id?: number | string;
     game_id: number;
@@ -123,46 +138,6 @@ export abstract class GobanInteractive extends GobanBase {
     public showing_scores: boolean = false;
     public stalling_score_estimate?: StallingScoreEstimate;
     public width: number;
-
-    /**
-     * When true, the goban operates in "presented move" space: the current
-     * move's trunk_next is treated as the move being shown to the user. The
-     * move tree highlights it and ends the active path there, clicks that
-     * jump to a played trunk move (move tree nodes, board shift-clicks)
-     * resolve through clickJumpTarget so the clicked move becomes the
-     * presented one, the presented stone draws more solidly, and the last
-     * move circle is dimmed. The AI review sets this while it presents the
-     * next trunk move as a translucent stone on the board.
-     */
-    private _present_next_move: boolean = false;
-
-    public get present_next_move(): boolean {
-        return this._present_next_move;
-    }
-    public setPresentNextMove(enabled: boolean): void {
-        if (this._present_next_move === enabled) {
-            return;
-        }
-        this._present_next_move = enabled;
-        this.move_tree_redraw();
-        /* Board rendering also depends on this flag (presented stone
-         * opacity, dimmed last move circle) */
-        this.redraw(true);
-    }
-
-    /**
-     * Resolves which node a click that jumps to a played move (a move tree
-     * node, a board shift-click) should land on. In presented move space a
-     * click on a trunk node jumps to its parent, so the clicked move becomes
-     * the presented move; variation nodes and the root are jumped to
-     * directly.
-     */
-    public clickJumpTarget(node: MoveTree): MoveTree {
-        if (this._present_next_move && node.trunk && node.parent) {
-            return node.parent;
-        }
-        return node;
-    }
 
     public pause_control?: AdHocPauseControl;
     public paused_since?: number;

--- a/src/Goban/SVGRenderer.ts
+++ b/src/Goban/SVGRenderer.ts
@@ -46,7 +46,7 @@ import {
     CaptureDisplay,
     ResolvedBoardBackground,
 } from "./Goban";
-import { ColoredCircle, AI_QUALITY_BADGES } from "./InteractiveBase";
+import { ColoredCircle, AI_QUALITY_BADGES, AI_QUALITY_BADGE } from "./InteractiveBase";
 import { AIQualityMark } from "../engine/MoveTree";
 
 //import { GobanCanvasConfig, GobanCanvasInterface } from "./GobanCanvas";
@@ -909,7 +909,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         ) {
             const m = this.engine.getMoveByLocation(x, y, true);
             if (m) {
-                this.engine.jumpTo(this.clickJumpTarget(m));
+                this.engine.jumpTo(m);
                 this.emit("update");
             }
             return;
@@ -1609,16 +1609,6 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                     translucent = true;
                     stoneAlphaValue = this.variation_stone_opacity;
                     if (
-                        this.present_next_move &&
-                        this.engine.cur_move.trunk_next &&
-                        this.engine.cur_move.trunk_next.x === i &&
-                        this.engine.cur_move.trunk_next.y === j
-                    ) {
-                        /* the presented next move reads a bit more solidly
-                         * than other mark stones */
-                        stoneAlphaValue = Math.min(1, stoneAlphaValue + 0.15);
-                    }
-                    if (
                         this.last_hover_square &&
                         this.last_hover_square.x === i &&
                         this.last_hover_square.y === j
@@ -2066,11 +2056,7 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                             ? this.theme_black_text_color
                             : this.theme_white_text_color;
 
-                    /* While the AI review presents the next move, the last
-                     * move circle takes a back seat to the presented stone */
-                    const last_move_opacity = this.present_next_move
-                        ? Math.min(this.last_move_opacity, 0.4)
-                        : this.last_move_opacity;
+                    const last_move_opacity = this.last_move_opacity;
 
                     if (this.submit_move) {
                         draw_last_move = false;
@@ -2476,16 +2462,6 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                     color = pos.black ? 1 : 2;
                     translucent = true;
                     stoneAlphaValue = this.variation_stone_opacity;
-                    if (
-                        this.present_next_move &&
-                        this.engine.cur_move.trunk_next &&
-                        this.engine.cur_move.trunk_next.x === i &&
-                        this.engine.cur_move.trunk_next.y === j
-                    ) {
-                        /* the presented next move reads a bit more solidly
-                         * than other mark stones */
-                        stoneAlphaValue = Math.min(1, stoneAlphaValue + 0.15);
-                    }
                     if (
                         this.last_hover_square &&
                         this.last_hover_square.x === i &&
@@ -4658,14 +4634,9 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         }
 
         this.engine.move_tree.recomputeIsobranches();
-        const active_path_end =
-            this.present_next_move && this.engine.cur_move.trunk_next
-                ? this.engine.cur_move.trunk_next
-                : this.engine.cur_move;
-
         this.engine.move_tree_layout_dirty = false;
 
-        active_path_end.setActivePath(++MoveTree.active_path_number);
+        this.engine.cur_move.setActivePath(++MoveTree.active_path_number);
 
         //const canvas = this.move_tree_canvas;
         const svg = this.move_tree_svg;
@@ -4697,15 +4668,15 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
         if (!no_warp) {
             /* make sure our active stone is visible, but don't scroll around unnecessarily */
             if (
-                div_scroll_left > active_path_end.layout_cx ||
-                div_scroll_left + div_clientWidth - 20 < active_path_end.layout_cx ||
-                div_scroll_top > active_path_end.layout_cy ||
-                div_scroll_top + div_clientHeight - 20 < active_path_end.layout_cy
+                div_scroll_left > this.engine.cur_move.layout_cx ||
+                div_scroll_left + div_clientWidth - 20 < this.engine.cur_move.layout_cx ||
+                div_scroll_top > this.engine.cur_move.layout_cy ||
+                div_scroll_top + div_clientHeight - 20 < this.engine.cur_move.layout_cy
             ) {
                 this.move_tree_container.scrollLeft =
-                    active_path_end.layout_cx - div_clientWidth / 2;
+                    this.engine.cur_move.layout_cx - div_clientWidth / 2;
                 this.move_tree_container.scrollTop =
-                    active_path_end.layout_cy - div_clientHeight / 2;
+                    this.engine.cur_move.layout_cy - div_clientHeight / 2;
                 div_scroll_top = this.move_tree_container.scrollTop;
                 div_scroll_left = this.move_tree_container.scrollLeft;
             }
@@ -4728,9 +4699,9 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
             svg.appendChild(this.move_tree_svg_defs);
         }
 
-        this.move_tree_hilightNode(svg, active_path_end, "#6BAADA", viewport);
+        this.move_tree_hilightNode(svg, this.engine.cur_move, "#6BAADA", viewport);
 
-        if (engine.cur_review_move && engine.cur_review_move.id !== active_path_end.id) {
+        if (engine.cur_review_move && engine.cur_review_move.id !== this.engine.cur_move.id) {
             this.move_tree_hilightNode(svg, engine.cur_review_move, "#6BDA6B", viewport);
         }
 
@@ -4760,9 +4731,8 @@ export class SVGRenderer extends Goban implements GobanSVGInterface {
                 const node = this.engine.move_tree.getNodeAtLayoutPosition(i, j);
 
                 if (node) {
-                    const target = this.clickJumpTarget(node);
-                    if (this.engine.cur_move.id !== target.id) {
-                        this.engine.jumpTo(target);
+                    if (this.engine.cur_move.id !== node.id) {
+                        this.engine.jumpTo(node);
                         this.setLabelCharacterFromMarks();
                         this.updateTitleAndStonePlacement();
                         this.emit("update");
@@ -6219,33 +6189,30 @@ class GCell {
 
         const mid = this.renderer.metrics.mid;
         const ss = this.renderer.square_size;
-        const scale = this.renderer.stone_font_scale;
         const cx = mid;
-        const cy = mid + ss * 0.3;
-        const r = ss * 0.2 * scale;
-        const font_size = ss * 0.24 * scale;
+        const cy = mid + ss * AI_QUALITY_BADGE.offset_y;
 
         const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
         g.setAttribute("class", `ai-quality-badge ai-quality-${quality}`);
 
-        const circ = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-        circ.setAttribute("fill", `var(--move-quality-${quality}, ${badge.color})`);
-        circ.setAttribute("cx", cx.toFixed(2));
-        circ.setAttribute("cy", cy.toFixed(2));
-        circ.setAttribute("r", r.toFixed(2));
+        /* Upward triangle with a dark border */
+        const shape = document.createElementNS("http://www.w3.org/2000/svg", "polygon");
+        shape.setAttribute("fill", `var(--move-quality-${quality}, ${badge.color})`);
+        shape.setAttribute("stroke", AI_QUALITY_BADGE.border_color);
+        shape.setAttribute("stroke-width", (ss * AI_QUALITY_BADGE.border_width).toFixed(2));
+        shape.setAttribute("stroke-linejoin", "round");
+        const r = ss * AI_QUALITY_BADGE.radius;
+        const points: string[] = [];
+        let theta = -(Math.PI * 2) / 4;
+        for (let i = 0; i < 3; i++) {
+            points.push(
+                `${(cx + r * Math.cos(theta)).toFixed(2)},${(cy + r * Math.sin(theta)).toFixed(2)}`,
+            );
+            theta += (Math.PI * 2) / 3;
+        }
+        shape.setAttribute("points", points.join(" "));
 
-        const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
-        text.setAttribute("class", "ai-quality-symbol");
-        text.setAttribute("fill", "#FFFFFF");
-        text.setAttribute("font-size", `${font_size}px`);
-        text.setAttribute("font-weight", "bold");
-        text.setAttribute("text-anchor", "middle");
-        text.setAttribute("x", cx.toFixed(2));
-        text.setAttribute("y", (cy + font_size * 0.35).toFixed(2));
-        text.textContent = badge.symbol;
-
-        g.appendChild(circ);
-        g.appendChild(text);
+        g.appendChild(shape);
         this.g.appendChild(g);
 
         this.last_ai_quality_badge = g;

--- a/test/unit_tests/GobanNativeBridge.test.ts
+++ b/test/unit_tests/GobanNativeBridge.test.ts
@@ -866,27 +866,6 @@ describe("no blank board while a resume is in flight", () => {
  * expressible in contract v1 (which carries only stones, colorToMove and a
  * last-move ring), so all of it has to reach the web canvas. */
 describe("AI review board state", () => {
-    test("presenting the next move bails to the canvas and clearing re-engages", async () => {
-        const transport = new RecordingTransport();
-        const goban = new GobanNativeBridge(config(transport));
-        await flush();
-        expect(goban.nativeBridgeState).toBe("active");
-
-        goban.setPresentNextMove(true);
-        await flush();
-
-        expect(goban.nativeBridgeState).toBe("bailed");
-        const canvas = board_div.querySelector("#board-canvas") as HTMLCanvasElement;
-        expect(canvas.style.visibility).not.toBe("hidden");
-
-        goban.setPresentNextMove(false);
-        await flush();
-
-        expect(goban.nativeBridgeState).toBe("active");
-        expect(canvas.style.visibility).toBe("hidden");
-        goban.destroy();
-    });
-
     test("an ai_quality badge bails to the canvas", async () => {
         const transport = new RecordingTransport();
         const goban = new GobanNativeBridge(config(transport));

--- a/test/unit_tests/GobanSVG.test.ts
+++ b/test/unit_tests/GobanSVG.test.ts
@@ -684,10 +684,11 @@ describe("AI review marks and placement rooting", () => {
         const badge = rendererSvg(goban).querySelector(".ai-quality-badge");
         expect(badge).not.toBeNull();
         expect(badge?.getAttribute("class")).toContain("ai-quality-blunder");
-        expect(badge?.querySelector("circle")?.getAttribute("fill")).toBe(
-            "var(--move-quality-blunder, #D64545)",
-        );
-        expect(badge?.querySelector("text")?.textContent).toBe("??");
+        const shape = badge?.querySelector("polygon");
+        expect(shape?.getAttribute("fill")).toBe("var(--move-quality-blunder, #D64545)");
+        expect(shape?.getAttribute("stroke")).toBe("rgba(0, 0, 0, 0.75)");
+        expect(shape?.getAttribute("points")?.split(" ")).toHaveLength(3);
+        expect(badge?.querySelector("text")).toBeNull();
         goban.destroy();
     });
 
@@ -700,7 +701,9 @@ describe("AI review marks and placement rooting", () => {
 
         goban.setAIQualityMark(0, 0, "great");
         expect(svg.querySelector(".triangle")).toBeNull();
-        expect(svg.querySelector(".ai-quality-badge text")?.textContent).toBe("!");
+        expect(svg.querySelector(".ai-quality-badge")?.getAttribute("class")).toContain(
+            "ai-quality-great",
+        );
         goban.destroy();
     });
 
@@ -768,55 +771,7 @@ describe("AI review marks and placement rooting", () => {
         goban.destroy();
     });
 
-    test("the presented next move's stone draws less translucently", () => {
-        const goban = new SVGRenderer(
-            basic3x3Config({
-                moves: [
-                    [0, 0],
-                    [1, 0],
-                ],
-                mode: "analyze",
-            }),
-        );
-        // Sit on move 1; move 2 at (1, 0) is the presented next move
-        goban.showPrevious();
-        goban.setPresentNextMove(true);
-        goban.setMark(1, 0, "white", false);
-
-        const svg = rendererSvg(goban);
-        const opacities = Array.from(svg.querySelectorAll("[opacity]"))
-            .filter((e) => e.getAttribute("class") !== "last-move")
-            .map((e) => e.getAttribute("opacity"));
-        expect(opacities).toContain("0.75");
-        expect(opacities).not.toContain("0.6");
-        goban.destroy();
-    });
-
-    test("the last move circle dims while presenting", () => {
-        const goban = new SVGRenderer(
-            basic3x3Config({
-                moves: [
-                    [0, 0],
-                    [1, 0],
-                ],
-                mode: "analyze",
-            }),
-        );
-        goban.showPrevious();
-        const svg = rendererSvg(goban);
-
-        expect(svg.querySelector(".last-move")).not.toBeNull();
-        expect(svg.querySelector(".last-move")?.getAttribute("opacity")).toBeNull();
-
-        goban.setPresentNextMove(true);
-        expect(svg.querySelector(".last-move")?.getAttribute("opacity")).toBe("0.4");
-
-        goban.setPresentNextMove(false);
-        expect(svg.querySelector(".last-move")?.getAttribute("opacity")).toBeNull();
-        goban.destroy();
-    });
-
-    test("shift clicking a stone in presented move space presents that move", () => {
+    test("shift clicking a stone jumps to that move even while the next trunk move is marked", () => {
         const goban = new SVGRenderer(
             basic3x3Config({
                 moves: [
@@ -828,14 +783,13 @@ describe("AI review marks and placement rooting", () => {
             }),
         );
         const event_layer = goban.parent;
-        goban.setPresentNextMove(true);
+        goban.showPrevious();
+        goban.showPrevious();
+        goban.setMark(1, 0, "white", true);
 
-        // Shift-click the stone of move 2 at (1, 0): the engine lands on
-        // move 1 so that move 2 is the presented move
         simulateMouseClick(event_layer, { x: 1, y: 0, shiftKey: true });
 
-        expect(goban.engine.cur_move.move_number).toBe(1);
-        expect(goban.engine.cur_move.trunk_next?.move_number).toBe(2);
+        expect(goban.engine.cur_move.move_number).toBe(2);
         goban.destroy();
     });
 
@@ -900,40 +854,6 @@ describe("AI review marks and placement rooting", () => {
         goban.engine.cur_move.clearMarks();
         goban.redraw(true);
         expect(svg.querySelector(".subscript2")).toBeNull();
-        goban.destroy();
-    });
-
-    test("clickJumpTarget resolves clicks in presented move space", () => {
-        const goban = new SVGRenderer(
-            basic3x3Config({
-                moves: [
-                    [0, 0],
-                    [1, 0],
-                    [2, 0],
-                ],
-                mode: "analyze",
-            }),
-        );
-        const move3 = goban.engine.cur_move;
-        const move2 = move3.parent!;
-        const root = goban.engine.move_tree;
-
-        // Without presentation, clicks jump to the clicked node
-        expect(goban.clickJumpTarget(move3).id).toBe(move3.id);
-
-        goban.setPresentNextMove(true);
-
-        // A trunk node click presents that move: jump to its parent
-        expect(goban.clickJumpTarget(move3).id).toBe(move2.id);
-        // The root has no parent and is jumped to directly
-        expect(goban.clickJumpTarget(root).id).toBe(root.id);
-
-        // Variation nodes are jumped to directly
-        goban.engine.jumpTo(move2);
-        goban.engine.place(1, 1);
-        const variation = goban.engine.cur_move;
-        expect(variation.trunk).toBe(false);
-        expect(goban.clickJumpTarget(variation).id).toBe(variation.id);
         goban.destroy();
     });
 


### PR DESCRIPTION
Goban-side companion to the online-go.com AI review cleanup that removes the "presented move" number space (frontend PR to follow).

## What's included

- **Presented-move support removed** — `present_next_move` / `setPresentNextMove`, `clickJumpTarget`, the move tree's shifted active path, the mark stone opacity bump and the dimmed last-move circle are gone. Move tree clicks and board shift-clicks jump to the clicked node again. The native bridge no longer needs a presentation bail: a mark on the board already bails it.
- **`ai_quality` badge is a triangle** — the same small upward triangle as the `sub_triangle` mark (circumradius 0.15 of the square, drawn low on the stone), filled with the quality color and outlined dark. No symbol inside: the `!!`/`??` glyphs were unreadable at that size, and the color carries the classification. Geometry is shared by both renderers through `AI_QUALITY_BADGE`.

## Testing

- 418 jest tests pass; the presented-move tests are removed and the badge tests updated for the bordered polygon.
- lint / prettier / tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QR3d9C9rYoYMteLZdtyX18
