### PR TITLE
Muted move tree line colours, in a light set and a dark one

### DIFF
--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -926,9 +926,9 @@ export class MoveTree {
     static active_path_number: number = 0;
     static current_line_color: number = 0;
 
-    /* Muted earth tones rather than saturated primaries: these are drawn as
-     * thin branch lines over the move tree's grey, and the hosts that show a
-     * variation's colour beside its name put them next to text. */
+    /* Muted earth tones: these are drawn as thin branch lines over the move
+     * tree's grey, and the hosts that show a variation's colour beside its
+     * name put them next to text. */
     static readonly LINE_COLORS_DARK: ReadonlyArray<string> = [
         "#9E5245", // brick
         "#61804A", // moss

--- a/src/engine/MoveTree.ts
+++ b/src/engine/MoveTree.ts
@@ -926,16 +926,36 @@ export class MoveTree {
     static active_path_number: number = 0;
     static current_line_color: number = 0;
 
-    static line_colors: Array<string> = [
-        "#ff0000",
-        "#00ff00",
-        "#0000ff",
-        "#00ffff",
-        "#ffff00",
-        "#FF9A00",
-        "#9200FF",
-        //"#ff00ff"
+    /* Muted earth tones rather than saturated primaries: these are drawn as
+     * thin branch lines over the move tree's grey, and the hosts that show a
+     * variation's colour beside its name put them next to text. */
+    static readonly LINE_COLORS_DARK: ReadonlyArray<string> = [
+        "#9E5245", // brick
+        "#61804A", // moss
+        "#4A6C90", // denim
+        "#3F7E78", // teal
+        "#B39A4E", // wheat
+        "#B5713C", // clay
+        "#7B5C8A", // plum
     ];
+
+    /* The same seven hues for a host with a light interface, where the darker
+     * set reads heavy beside light text and panels. */
+    static readonly LINE_COLORS_LIGHT: ReadonlyArray<string> = [
+        "#C07A6B", // brick
+        "#86A461", // moss
+        "#6E90B8", // denim
+        "#63A69E", // teal
+        "#C9AE5E", // wheat
+        "#CE8F58", // clay
+        "#9C7BAA", // plum
+    ];
+
+    /* The palette in use, indexed by a node's `line_color`. A host with a
+     * light interface assigns `LINE_COLORS_LIGHT`; the slots hold the same
+     * hue in either set, so a branch keeps its colour family across the
+     * change. Hosts assign this array rather than mutate it. */
+    static line_colors: Array<string> = [...MoveTree.LINE_COLORS_DARK];
 
     static isobranch_colors = {
         strong: "#C100FF",


### PR DESCRIPTION
The move tree draws each branch in a colour from `MoveTree.line_colors`, and
hosts that name a variation show the same colour beside it. The set was
saturated primaries — red, green, blue, cyan, yellow, orange, purple — which
reads loud both as lines over the tree's grey and as a swatch next to text.

Each slot becomes an earth tone of the same hue family, so a branch that was
the red line is still the reddish one and nothing that depends on index order
changes meaning:

| slot | was | now | |
|---|---|---|---|
| 0 | `#ff0000` | `#9E5245` | brick |
| 1 | `#00ff00` | `#61804A` | moss |
| 2 | `#0000ff` | `#4A6C90` | denim |
| 3 | `#00ffff` | `#3F7E78` | teal |
| 4 | `#ffff00` | `#B39A4E` | wheat |
| 5 | `#FF9A00` | `#B5713C` | clay |
| 6 | `#9200FF` | `#7B5C8A` | plum |

`LINE_COLORS_LIGHT` holds the same seven lifted for a host with a light
interface, where the darker set reads heavy against light panels.
`line_colors` stays the array the renderers index and defaults to the dark
set, so a host that does not care is unaffected; one that does assigns the
other set. Online-go.com does that from the site theme, repainting the trees
that are on screen.

Both sets were checked as swatches and as 2px strokes over the move tree's
`#888` grey, on a dark ground and a light one, and then on a real tree with
several branches: still individually distinguishable, no longer shouting. An
earlier pass had mustard and clay too close to tell apart at swatch size,
which is why they now differ in lightness as well as hue.

The commented-out `#ff00ff` that trailed the old list is dropped.

Verified with `prettier --check` and `tsc --noEmit`; no test referenced the
palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ErSSsZ51XqAX9U8ky7fid