### PR TITLE
Show undo request markers only on game moves

### DIFF
--- a/src/engine/GobanEngine.ts
+++ b/src/engine/GobanEngine.ts
@@ -481,29 +481,40 @@ export class GobanEngine extends BoardState {
             (undo_requested_move_count ?? 0) > 0 ? undo_requested_move_count : undefined;
     }
 
-    public getUndoRequestStones(): Array<{ x: number; y: number; move_number: number }> {
+    /**
+     * Returns the game move the pending undo request is for, if that move
+     * is in the line we are currently viewing. Returns null if there is no
+     * undo request, if we are viewing an earlier position, or if we are
+     * viewing an analysis branch that leaves the game at or before that move.
+     */
+    private getUndoRequestedMoveInCurrentLine(): MoveTree | null {
         const requestedMoveNumber = this.undo_requested;
         if (requestedMoveNumber === undefined || !this.cur_move) {
-            return [];
+            return null;
         }
 
-        // If we are viewing an earlier branch, do not attempt to render markers.
         if (this.cur_move.move_number < requestedMoveNumber) {
-            return [];
+            return null;
         }
-
-        const remainingToMark = Math.max(1, this.undo_requested_move_count);
-        const stones: Array<{ x: number; y: number; move_number: number }> = [];
 
         let node: MoveTree | null = this.cur_move;
-        let remaining = remainingToMark;
-
-        // First, navigate to the requested move if we're viewing a later position
         while (node && node.move_number > requestedMoveNumber) {
             node = node.parent;
         }
 
-        // Now mark the requested number of moves going backwards
+        if (!node?.trunk) {
+            return null;
+        }
+
+        return node;
+    }
+
+    public getUndoRequestStones(): Array<{ x: number; y: number; move_number: number }> {
+        const stones: Array<{ x: number; y: number; move_number: number }> = [];
+
+        let node = this.getUndoRequestedMoveInCurrentLine();
+        let remaining = Math.max(1, this.undo_requested_move_count);
+
         while (node && remaining > 0) {
             if (node.x >= 0 && node.y >= 0) {
                 stones.push({ x: node.x, y: node.y, move_number: node.move_number });
@@ -516,23 +527,7 @@ export class GobanEngine extends BoardState {
     }
 
     public isStoneInUndoRequest(x: number, y: number): boolean {
-        const requestedMoveNumber = this.undo_requested;
-        if (requestedMoveNumber === undefined || !this.cur_move) {
-            return false;
-        }
-
-        // If we are viewing an earlier branch, do not attempt to render markers.
-        if (this.cur_move.move_number < requestedMoveNumber) {
-            return false;
-        }
-
-        // Walk backwards from current move to find the requested move
-        let node: MoveTree | null = this.cur_move;
-        while (node && node.move_number > requestedMoveNumber) {
-            node = node.parent;
-        }
-
-        // Now walk backwards from the requested move for N moves
+        let node = this.getUndoRequestedMoveInCurrentLine();
         let remaining = this.undo_requested_move_count;
         while (node && remaining > 0) {
             if (node.x === x && node.y === y) {

--- a/test/unit_tests/GoEngine.test.ts
+++ b/test/unit_tests/GoEngine.test.ts
@@ -753,6 +753,11 @@ describe("state", () => {
     expect(engine.getStoneRemovalString()).toBe("bb");
 });
 
+/** Places a game (trunk) move, the way moves received from the server are placed. */
+function placeGameMove(engine: GobanEngine, x: number, y: number): void {
+    engine.place(x, y, false, false, true, true, true);
+}
+
 describe("multi-move undo", () => {
     describe("undo_requested_by", () => {
         test("defaults to undefined", () => {
@@ -825,8 +830,8 @@ describe("multi-move undo", () => {
     describe("getUndoRequestStones", () => {
         test("returns empty array when no undo requested", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(2, 2);
-            engine.place(3, 3);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
 
             expect(engine.getUndoRequestStones()).toEqual([]);
         });
@@ -840,8 +845,8 @@ describe("multi-move undo", () => {
 
         test("returns single stone for single move undo", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(2, 2);
-            engine.place(3, 3);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
 
             engine.undo_requested = 2;
             engine.undo_requested_move_count = 1;
@@ -852,10 +857,10 @@ describe("multi-move undo", () => {
 
         test("returns multiple stones for multi-move undo", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
-            engine.place(2, 2);
-            engine.place(3, 3);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
 
             engine.undo_requested = 4;
             engine.undo_requested_move_count = 3;
@@ -870,9 +875,9 @@ describe("multi-move undo", () => {
 
         test("handles passes by not including them in output", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(-1, -1);
-            engine.place(2, 2);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, -1, -1);
+            placeGameMove(engine, 2, 2);
 
             engine.undo_requested = 3;
             engine.undo_requested_move_count = 2;
@@ -883,10 +888,10 @@ describe("multi-move undo", () => {
 
         test("returns empty array when viewing earlier branch", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
+            placeGameMove(engine, 0, 0);
             const move1 = engine.cur_move;
-            engine.place(1, 1);
-            engine.place(2, 2);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
 
             engine.undo_requested = 3;
             engine.undo_requested_move_count = 2;
@@ -898,11 +903,11 @@ describe("multi-move undo", () => {
 
         test("navigates from later position to requested move", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
-            engine.place(2, 2);
-            engine.place(3, 3);
-            engine.place(4, 4);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
+            placeGameMove(engine, 4, 4);
 
             engine.undo_requested = 3;
             engine.undo_requested_move_count = 2;
@@ -916,8 +921,8 @@ describe("multi-move undo", () => {
 
         test("handles requesting more moves than available", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
 
             engine.undo_requested = 2;
             engine.undo_requested_move_count = 10;
@@ -933,7 +938,7 @@ describe("multi-move undo", () => {
     describe("isStoneInUndoRequest", () => {
         test("returns false when no undo requested", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(2, 2);
+            placeGameMove(engine, 2, 2);
 
             expect(engine.isStoneInUndoRequest(2, 2)).toBe(false);
         });
@@ -947,8 +952,8 @@ describe("multi-move undo", () => {
 
         test("returns true for stone in single move undo", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(2, 2);
-            engine.place(3, 3);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
 
             engine.undo_requested = 2;
             engine.undo_requested_move_count = 1;
@@ -959,10 +964,10 @@ describe("multi-move undo", () => {
 
         test("returns true for all stones in multi-move undo", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
-            engine.place(2, 2);
-            engine.place(3, 3);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
 
             engine.undo_requested = 4;
             engine.undo_requested_move_count = 3;
@@ -975,10 +980,10 @@ describe("multi-move undo", () => {
 
         test("returns false when viewing earlier branch", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
+            placeGameMove(engine, 0, 0);
             const move1 = engine.cur_move;
-            engine.place(1, 1);
-            engine.place(2, 2);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
 
             engine.undo_requested = 3;
             engine.undo_requested_move_count = 2;
@@ -991,11 +996,11 @@ describe("multi-move undo", () => {
 
         test("correctly identifies stones from later position", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
-            engine.place(2, 2);
-            engine.place(3, 3);
-            engine.place(4, 4);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
+            placeGameMove(engine, 4, 4);
 
             engine.undo_requested = 3;
             engine.undo_requested_move_count = 2;
@@ -1008,8 +1013,8 @@ describe("multi-move undo", () => {
 
         test("handles stones that do not exist in move tree", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
 
             engine.undo_requested = 2;
             engine.undo_requested_move_count = 1;
@@ -1021,10 +1026,10 @@ describe("multi-move undo", () => {
     describe("consistency and edge cases", () => {
         test("getUndoRequestStones and isStoneInUndoRequest are consistent with passes", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
-            engine.place(-1, -1);
-            engine.place(2, 2);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, -1, -1);
+            placeGameMove(engine, 2, 2);
 
             engine.undo_requested = 4;
             engine.undo_requested_move_count = 3;
@@ -1038,10 +1043,10 @@ describe("multi-move undo", () => {
 
         test("handles multiple consecutive passes", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(-1, -1);
-            engine.place(-1, -1);
-            engine.place(1, 1);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, -1, -1);
+            placeGameMove(engine, -1, -1);
+            placeGameMove(engine, 1, 1);
 
             engine.undo_requested = 4;
             engine.undo_requested_move_count = 3;
@@ -1053,31 +1058,86 @@ describe("multi-move undo", () => {
             }
         });
 
-        test("handles move tree branches correctly", () => {
+        test("does not mark an analysis move played in place of the requested move", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
+            placeGameMove(engine, 0, 0);
+            const fork = engine.cur_move;
+            placeGameMove(engine, 1, 1);
+
+            engine.undo_requested = 2;
+            engine.undo_requested_move_count = 1;
+
+            engine.jumpTo(fork);
+            engine.place(3, 3);
+
+            expect(engine.getUndoRequestStones()).toEqual([]);
+            expect(engine.isStoneInUndoRequest(3, 3)).toBe(false);
+            expect(engine.isStoneInUndoRequest(1, 1)).toBe(false);
+        });
+
+        test("does not mark analysis moves that branch before the requested moves", () => {
+            const engine = new GobanEngine({ width: 5, height: 5 });
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
             const fork = engine.cur_move;
 
-            engine.place(2, 2);
-            engine.place(3, 3);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
+
+            engine.undo_requested = 4;
+            engine.undo_requested_move_count = 2;
 
             engine.jumpTo(fork);
             engine.place(4, 4);
             engine.place(0, 1);
 
-            engine.undo_requested = 4;
-            engine.undo_requested_move_count = 2;
-
-            expect(engine.isStoneInUndoRequest(0, 1)).toBe(true);
-            expect(engine.isStoneInUndoRequest(4, 4)).toBe(true);
+            expect(engine.getUndoRequestStones()).toEqual([]);
+            expect(engine.isStoneInUndoRequest(0, 1)).toBe(false);
+            expect(engine.isStoneInUndoRequest(4, 4)).toBe(false);
             expect(engine.isStoneInUndoRequest(3, 3)).toBe(false);
             expect(engine.isStoneInUndoRequest(2, 2)).toBe(false);
         });
 
+        test("marks the requested moves when an analysis branch starts after them", () => {
+            const engine = new GobanEngine({ width: 5, height: 5 });
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
+            const fork = engine.cur_move;
+            placeGameMove(engine, 3, 3);
+
+            engine.undo_requested = 3;
+            engine.undo_requested_move_count = 2;
+
+            engine.jumpTo(fork);
+            engine.place(4, 4);
+
+            expect(engine.getUndoRequestStones()).toEqual([
+                { x: 2, y: 2, move_number: 3 },
+                { x: 1, y: 1, move_number: 2 },
+            ]);
+            expect(engine.isStoneInUndoRequest(4, 4)).toBe(false);
+        });
+
+        test("marks the requested move when analysis replays the game move", () => {
+            const engine = new GobanEngine({ width: 5, height: 5 });
+            placeGameMove(engine, 0, 0);
+            const fork = engine.cur_move;
+            placeGameMove(engine, 1, 1);
+
+            engine.undo_requested = 2;
+            engine.undo_requested_move_count = 1;
+
+            engine.jumpTo(fork);
+            engine.place(1, 1);
+
+            expect(engine.getUndoRequestStones()).toEqual([{ x: 1, y: 1, move_number: 2 }]);
+            expect(engine.isStoneInUndoRequest(1, 1)).toBe(true);
+        });
+
         test("handles undo_requested at move 0", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
+            placeGameMove(engine, 0, 0);
 
             engine.undo_requested = 0;
             engine.undo_requested_move_count = 1;
@@ -1087,10 +1147,10 @@ describe("multi-move undo", () => {
 
         test("handles same position with capture and retake", () => {
             const engine = new GobanEngine({ width: 3, height: 3 });
-            engine.place(0, 0);
-            engine.place(1, 0);
-            engine.place(0, 1);
-            engine.place(1, 1);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 0);
+            placeGameMove(engine, 0, 1);
+            placeGameMove(engine, 1, 1);
 
             engine.undo_requested = 4;
             engine.undo_requested_move_count = 3;
@@ -1106,11 +1166,11 @@ describe("multi-move undo", () => {
 
         test("getUndoRequestStones and isStoneInUndoRequest are always consistent", () => {
             const engine = new GobanEngine({ width: 5, height: 5 });
-            engine.place(0, 0);
-            engine.place(1, 1);
-            engine.place(2, 2);
-            engine.place(3, 3);
-            engine.place(4, 4);
+            placeGameMove(engine, 0, 0);
+            placeGameMove(engine, 1, 1);
+            placeGameMove(engine, 2, 2);
+            placeGameMove(engine, 3, 3);
+            placeGameMove(engine, 4, 4);
 
             for (let moveCount = 1; moveCount <= 5; moveCount++) {
                 engine.undo_requested = 5;

--- a/test/unit_tests/NativeSpec.test.ts
+++ b/test/unit_tests/NativeSpec.test.ts
@@ -171,7 +171,7 @@ describe("buildOverlays", () => {
 
     test("undo request draws the undo glyph and suppresses the last move ring", () => {
         const src = source();
-        src.engine.place(1, 1);
+        src.engine.place(1, 1, false, false, true, true, true);
         src.engine.undo_requested = src.engine.cur_move.move_number;
         const o = overlayAt(buildOverlays(src), 1, 1)!;
         expect(o.texts![0]).toMatchObject({ value: "↶", color: "#ffffff" });


### PR DESCRIPTION
When a player requests an undo, the board draws the undo glyph on the requested moves. The engine found the requested move by walking back from the current position to the requested move number, and it did not make sure that move was a game move.

To see the problem in a correspondence game with a pending undo request: go into analysis, go back one move, and play a different move. Your analysis stone has the same move number as the requested move, so it also gets the undo glyph, drawn over its move number.

`getUndoRequestedMoveInCurrentLine()` now finds the requested move for `isStoneInUndoRequest()` and `getUndoRequestStones()`. It returns nothing when that move is not a trunk move. Server moves are placed as trunk moves; analysis moves are not.

| Position you view | Markers |
|---|---|
| Analysis branch leaves the game at or before the requested move | None |
| Analysis branch starts after the requested move | On the game stones only |
| Analysis replays the game move | On the game stones (the board follows the trunk) |

Tests:

- The undo tests placed non-trunk moves, so they now place game moves the way the server does.
- `handles move tree branches correctly` expected markers on branch stones. I replaced it with one test for each row above. Two of these fail without the fix.
- The undo test in `NativeSpec.test.ts` now places a game move.

Validation:

- `yarn checks`, `yarn type-check`, `yarn test` (26 suites, 440 tests) and `make build` pass.
- online-go.com with this branch passes `yarn type-check`, `yarn lint` and `yarn build`.

Please also manually check desktop and mobile browsers before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EX4C7XCYeKptEVBCVpM6Tv
